### PR TITLE
docs: add claude instructions

### DIFF
--- a/.claude/skills/orbit-schema-change/SKILL.md
+++ b/.claude/skills/orbit-schema-change/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: orbit-schema-change
+description: Guides schema and custom-field changes in Orbit AI so that migrations, metadata, adapters, API, SDK, CLI, and MCP stay aligned. Invoke this skill whenever adding a new table or entity, adding or promoting a custom field, changing the custom field contract, modifying migration or schema-engine behavior, editing files in packages/core/src/schema/, packages/core/src/schema-engine/, or packages/core/src/entities/, or when a task involves Drizzle table definitions, RLS policy generation, ID prefix registration, or storage adapter schema support. Schema misalignment across packages is Orbit's most common implementation drift — use this skill proactively for any schema-touching change.
+---
+
+# Orbit Schema Change
+
+This skill guides schema changes so that every layer of the Orbit stack stays aligned: Drizzle definitions, ID system, custom field metadata, migration engine, RLS generation, and all four interfaces (API, SDK, CLI, MCP). Schema misalignment across packages is the most likely source of implementation drift.
+
+## When to skip this skill
+
+- Changes to CLI output formatting that don't alter data shapes
+- Documentation-only edits
+- Changes to test fixtures that don't reflect schema contract changes
+- Connector/integration logic that doesn't create or modify tenant-scoped tables (use `orbit-tenant-safety-review` for tenant isolation concerns on connector tables)
+
+## Step 1: Load context
+
+Read the sections relevant to your change:
+
+1. `docs/specs/01-core.md` — the authoritative source for:
+   - Table definitions (section 5: Drizzle Schema Definitions)
+   - ID prefix registry (section 3: ID System)
+   - Custom field system (section 7: Custom Fields)
+   - Schema engine interface (section 10: Schema Engine)
+   - Adapter interface and authority model (section 8: Storage Adapter Interface)
+   - RLS generation rules (section 9: RLS)
+2. `docs/specs/02-api.md` — route structure, envelope format, pagination contracts
+3. `docs/specs/03-sdk.md` — resource methods, transport parity between API and direct mode
+4. `docs/specs/05-mcp.md` — tool inventory and which tools expose schema/entity data
+
+You don't need all four for every change. A new custom field might only need 01-core.md. A new entity needs all four.
+
+## Step 2: Classify the change
+
+Determine which type of schema change you're making:
+
+### Type A: Adding a table / entity
+Touches everything — Drizzle definition, ID prefix, RLS, repositories, services, API routes, SDK resources, CLI commands, MCP tools.
+
+### Type B: Adding or promoting a custom field
+Primarily touches the schema engine and custom field metadata. May touch API/SDK/MCP if the field changes filter, sort, or search contracts.
+
+### Type C: Modifying the custom field contract
+Changes to how custom fields work (validation, promotion rules, JSONB handling). Touches schema engine internals and potentially all interfaces.
+
+### Type D: Changing migration or schema-engine behavior
+Changes to how migrations are generated, applied, rolled back, or how the schema engine validates operations. High-risk because it affects every adapter.
+
+## Step 3: Execute the change checklist
+
+### For Type A (new table/entity) — full checklist:
+
+**Core package (`packages/core/`):**
+
+1. **Drizzle table definition** in `src/schema/tables.ts`
+   - `id: text('id').primaryKey()` — uses type-prefixed ULID
+   - `organizationId: text('organization_id').notNull().references(() => organizations.id)` — unless this is a bootstrap table (only `organizations` is bootstrap in v1)
+   - `...timestamps` — `created_at` and `updated_at`
+   - `customFields: customFieldsColumn` — if the entity is extensible
+   - Appropriate indexes (at minimum: org-scoped unique constraints)
+
+2. **ID prefix** in `src/ids/prefixes.ts`
+   - Add entry to `ID_PREFIXES` const
+   - Prefix must be short, lowercase, descriptive, and not conflict with existing prefixes
+   - Update `OrbitIdKind` type (derived automatically from `keyof typeof ID_PREFIXES`)
+
+3. **Entity type** in `src/types/entities.ts`
+   - Add to `OrbitObjectType` union
+
+4. **Repository** in `src/entities/<entity>/repository.ts`
+   - All queries must filter on `organization_id`
+   - Use `withTenantContext(...)` for all Postgres-family operations
+
+5. **Service** in `src/entities/<entity>/service.ts`
+   - Injects `organization_id` from trusted context, never from caller input
+   - Uses repository methods, not raw queries
+
+6. **Validators** in `src/entities/<entity>/validators.ts`
+   - Zod schemas for create/update inputs
+   - ID validation using `assertOrbitId(value, kind)`
+
+7. **RLS policy** — the RLS generator in `src/schema-engine/rls.ts` must include the new table in its tenant-scoped table list
+
+8. **Relations** in `src/schema/relations.ts` — if the entity has foreign keys to other entities
+
+**API package (`packages/api/`):**
+
+9. **Routes** in `src/routes/` — CRUD endpoints following the envelope format
+10. **OpenAPI schema** registered in `src/openapi/`
+
+**SDK package (`packages/sdk/`):**
+
+11. **Resource class** in `src/resources/<entity>.ts` — record-first methods, must work in both API mode and direct mode
+
+**MCP package (`packages/mcp/`):**
+
+12. **Tool registration** — determine if this entity needs new dedicated tools or is covered by the universal `search_records`/`get_record`/`create_record`/`update_record`/`delete_record` tools via `object_type` parameter. Core tool count is capped at 23 — don't add tools unless the entity has unique operations beyond CRUD.
+
+**CLI package (`packages/cli/`):**
+
+13. **Commands** in `src/commands/<entity>.ts` — supports `--json` flag for agent output
+
+### For Type B (adding/promoting a field):
+
+1. **Field definition** — if adding to a base table, modify `src/schema/tables.ts`. If adding a custom field, use the schema engine's `addField` path.
+2. **Custom field metadata** — new entry in `custom_field_definitions` table with correct `entityType`, `fieldType`, validation rules
+3. **Promotion check** — if promoting (JSONB → real column):
+   - Requires `runWithMigrationAuthority(...)` — this is an elevated operation
+   - SQLite promotion may require table recreation
+   - The promoted column name must not conflict with existing columns
+   - After promotion, reads must still merge promoted and JSONB fields into one logical shape
+4. **Interface impact** — if the field affects filtering, sorting, or search:
+   - API: update query parameter documentation
+   - SDK: update TypeScript types
+   - MCP: update tool input schemas if affected
+
+### For Type C (custom field contract change):
+
+1. **Schema engine** — changes to `src/schema-engine/` files
+2. **Validation** — ensure `custom_fields` JSONB keys still match `custom_field_definitions`
+3. **Promotion rules** — if changing how promotion works, check all adapter paths
+4. **Backwards compatibility** — existing custom field data must not break
+
+### For Type D (migration/schema-engine behavior):
+
+1. **Authority boundary** — migrations run via `runWithMigrationAuthority(...)` only, never from runtime paths
+2. **Rollback** — every migration must store its reverse
+3. **Adapter coverage** — test on SQLite first, then Postgres-family adapters
+4. **Non-destructive default** — DROP and RENAME operations require explicit `--destructive` flag
+5. **Neon branching** — if the Neon adapter is involved, branch-before-migrate must still work
+
+## Step 4: Safety classification
+
+Classify the change:
+
+- **Additive safe**: New column, new table, new custom field (metadata-only). No migration review needed beyond standard checklist.
+- **Additive with migration review**: Field promotion, new index on existing table, adding NOT NULL with default on existing table. Requires testing on all target adapters.
+- **Destructive — blocked without explicit approval**: Column drop, column rename, table drop, type change on existing column. Requires `--destructive` flag in CLI/MCP, and must be blocked in hosted mode.
+
+## Step 5: Produce the implementation checklist
+
+Output a checklist specific to the change, structured as:
+
+```
+## Schema Change: [description]
+
+### Classification
+[Additive safe | Additive with migration review | Destructive]
+
+### ID Prefix
+- Prefix: `<prefix>` — [correct/needs-registration/N/A]
+
+### Tenant Scoping
+- [tenant-scoped | bootstrap-scoped] — [evidence]
+
+### Impacted Packages and Files
+- [ ] packages/core/src/schema/tables.ts — [what changes]
+- [ ] packages/core/src/ids/prefixes.ts — [what changes]
+- [ ] packages/core/src/entities/<entity>/... — [what changes]
+- [ ] packages/api/src/routes/... — [what changes]
+- [ ] packages/sdk/src/resources/... — [what changes]
+- [ ] packages/mcp/src/tools/... — [what changes or "covered by universal tools"]
+- [ ] packages/cli/src/commands/... — [what changes]
+
+### Interface Contracts
+- Pagination/filter/search: [unaffected | updated — describe]
+- API envelope: [unaffected | updated — describe]
+- SDK types: [unaffected | updated — describe]
+- MCP tools: [unaffected | updated — describe]
+- CLI --json output: [unaffected | updated — describe]
+```
+
+## Step 6: Validation
+
+Confirm all of these before marking the change as complete:
+
+1. **ID prefix is correct**: the prefix exists in `ID_PREFIXES`, is unique, and matches the entity's semantic name
+2. **Tenant vs bootstrap classification is explicit**: the code and schema clearly show whether this is org-scoped or bootstrap-scoped, with no ambiguity
+3. **Pagination, filter, and search contracts are either unaffected or explicitly updated**: if a new entity is searchable, it must be added to the search service; if new fields are filterable, the API query params and SDK types must reflect this
+4. **All affected interfaces are listed**: if the change touches API behavior, SDK, CLI, and MCP impact must all be assessed (even if "no change needed")
+
+If any check fails, flag it in the checklist before proceeding with implementation.

--- a/.claude/skills/orbit-tenant-safety-review/SKILL.md
+++ b/.claude/skills/orbit-tenant-safety-review/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: orbit-tenant-safety-review
+description: Reviews code changes for multi-tenant isolation safety in Orbit AI. Invoke this skill whenever a task touches organization_id, storage adapters, repositories, auth middleware, tenant context, RLS policies, admin/bootstrap boundaries, or adds a new tenant-scoped table or plugin extension. Also use when reviewing PRs or commits that modify files in packages/core/src/adapters/, packages/core/src/entities/, packages/core/src/services/, packages/api/src/middleware/, or any file containing withTenantContext, organization_id filtering, or RLS policy generation. Cross-tenant data exposure is Orbit's #1 threat — when in doubt about whether this skill applies, use it.
+---
+
+# Orbit Tenant Safety Review
+
+This skill reviews code changes for tenant isolation safety. Cross-tenant data exposure is Orbit AI's most critical failure mode — it would be existential for a CRM infrastructure product. Every new adapter, service, route, repository, and plugin table must be reviewed through this lens.
+
+## When to skip this skill
+
+- Generic performance optimization with no tenant data path changes
+- Frontend/UI-only changes
+- Documentation-only changes that don't alter security contracts
+- Changes entirely within `packages/cli/src/commands/` that only format output (no data fetching logic)
+
+## Step 1: Load context
+
+Read these files to ground your review in Orbit's actual contracts:
+
+1. `docs/security/security-architecture.md` — sections 4 (Tenant Isolation Model) and 5 (Postgres Role Model) define the rules
+2. `docs/specs/01-core.md` — sections on `withTenantContext`, RLS generation, adapter interface, and the runtime vs migration authority split
+3. `docs/specs/02-api.md` — sections on auth middleware, tenant context middleware, and route classification (bootstrap vs tenant CRUD)
+4. `docs/security/orbit-ai-threat-model.md` — T1 (Cross-Tenant Read/Write) and T2 (Privileged Credential Misuse) are the primary threats this review guards against
+
+You don't need to read all of these end-to-end every time. Read the relevant sections based on what the changed code touches.
+
+## Step 2: Identify what changed
+
+Look at the changed files (staged, unstaged, or the diff under review). Classify each changed file:
+
+- **Tenant data path**: touches entity services, repositories, adapters, or any code that reads/writes tenant-scoped tables
+- **Auth/context path**: touches auth middleware, tenant context injection, API key resolution, or request context propagation
+- **Schema/migration path**: touches schema engine, RLS generation, migration authority, or table definitions
+- **Bootstrap/admin path**: touches organization creation, API key issuance, platform admin routes, or hosted operational controls
+- **Connector/integration path**: touches provider credentials, sync state, or integration tables that hold tenant data
+
+If none of these categories apply, this skill doesn't need to produce a full review — just confirm the change doesn't touch tenant boundaries and stop.
+
+## Step 3: Review against the isolation rules
+
+For each changed file that touches a tenant boundary, check these rules. These come directly from the security architecture and threat model:
+
+### Rule 1: Organization context is never caller-controlled
+
+The service layer must inject `organization_id` from trusted runtime context — never from request body, query params, or path params for public operations. The trusted sources are:
+
+- **API mode**: auth middleware resolves API key → `orgId` and injects it into request context
+- **Direct mode**: the embedding app provides trusted `context: { userId, orgId }` at SDK initialization
+- **MCP mode**: org context comes from the server's configured context, not from tool arguments
+
+If the code accepts `organization_id` from user input and uses it for data scoping, that's a critical finding.
+
+### Rule 2: Runtime paths use runtime credentials only
+
+Request-serving code (API routes, SDK operations, MCP tools, webhook delivery workers) must never use:
+
+- `service_role` credentials (Supabase) — this is a **release blocker**
+- `migration_role` credentials — these are only for `runWithMigrationAuthority(...)`
+- Any credential that bypasses RLS
+
+The runtime vs migration authority split is a core architectural decision. If you see code that needs elevated credentials on a request path, that's a design problem, not something to work around.
+
+### Rule 3: Postgres-family adapters use `withTenantContext(...)`
+
+All tenant-scoped database operations on Postgres-family adapters must execute inside `withTenantContext(...)`, which sets `app.current_org_id` as a transaction-local setting via `set_config(..., true)`.
+
+This is mandatory because pooled Postgres connections can leak session state between requests if tenant context isn't transaction-bound. If you see tenant-scoped queries running outside a transaction with tenant context set, that's a high-severity finding.
+
+### Rule 4: New tenant tables have both layers of defense
+
+Every new tenant-scoped table needs:
+
+1. **App-level filtering**: the repository/service explicitly filters on `organization_id` in every query
+2. **RLS policy**: for Postgres-family adapters, auto-generated RLS policies enforce `organization_id = current_setting('app.current_org_id')::uuid` on SELECT, INSERT, UPDATE, and DELETE
+
+RLS is necessary but not sufficient — the app layer must also filter, because:
+- Direct mode needs to be auditable and understandable without relying on database magic
+- SQLite has no RLS at all (it's dev/local only, not a production isolation boundary)
+- App-layer checks catch mistakes earlier and produce better error messages
+
+### Rule 5: Bootstrap routes never enter tenant context
+
+Routes that handle organization creation, API key issuance, platform admin operations, or hosted control-plane actions must not call `withTenantContext(...)`. These are structurally separate from tenant CRUD routes.
+
+If bootstrap logic accidentally enters tenant context, it could either fail (no org context set) or worse, operate on the wrong tenant's data.
+
+### Rule 6: Plugin/integration tables are not exempt
+
+If a connector or plugin creates tables that hold tenant data (sync cursors, provider tokens, integration state), those tables must follow the same rules as core entity tables: `organization_id` column, app-level filtering, and RLS policies on Postgres-family adapters.
+
+### Rule 7: Secrets don't cross read boundaries
+
+Tenant-scoped reads must never return:
+- API key plaintext (only prefix is retrievable after creation)
+- Webhook signing secrets (returned once on creation, never again)
+- Connector access/refresh tokens (server-owned, never in API/CLI/MCP output)
+- Raw provider error strings that might contain tokens
+
+Check that serializers/DTOs use redaction markers (`credentials_redacted`, `cursor_redacted`, `error_redacted`) for secret-bearing objects.
+
+## Step 4: Produce the review note
+
+Write a concise review note with these sections:
+
+### Boundary touched
+Which trust boundary from the security architecture does this change cross? (Tenant Runtime, Platform/Bootstrap, Database, Connector/Provider, or Public Interface)
+
+### Org context source
+Where does `organization_id` come from in the changed code? Is it from a trusted source?
+
+### Access mode safety
+Does the change remain safe across both API mode (HTTP requests with API key auth) and direct mode (SDK with trusted context)? If MCP is involved, is it safe there too?
+
+### Secret exposure check
+Can any secrets or admin-only state leak through the changed paths?
+
+### Findings (if any)
+
+If problems are found, list them as a flat list ordered by severity:
+
+```
+- [CRITICAL] <description> — <file>:<line>
+- [HIGH] <description> — <file>:<line>
+- [MEDIUM] <description> — <file>:<line>
+```
+
+Severity definitions:
+- **CRITICAL**: Direct cross-tenant data exposure or service_role on a request path
+- **HIGH**: Missing RLS policy, missing withTenantContext, or migration credentials accessible from runtime
+- **MEDIUM**: Missing app-level org filter (RLS may catch it, but defense-in-depth is violated), or missing redaction on a secret-bearing field
+
+### Validation
+
+Explicitly state pass or fail for each of these three checks:
+
+1. **No caller-controlled org context**: Pass/Fail — [brief evidence]
+2. **Runtime credentials only**: Pass/Fail — [brief evidence]
+3. **Defense-in-depth on new tables**: Pass/Fail or N/A — [brief evidence]
+
+If any check fails, the review outcome is **FAIL** and the findings must be resolved before the change is safe to merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+## Project
+
+Orbit AI — CRM infrastructure for AI agents and developers. TypeScript monorepo (Turborepo + pnpm). Pre-alpha: planning docs complete, implementation starting with `@orbit-ai/core`.
+
+## Commands
+
+```bash
+pnpm install              # Install all workspace dependencies
+pnpm run build            # Build all packages (turbo)
+pnpm run dev              # Watch mode, all packages
+pnpm run test             # Run all tests (vitest)
+pnpm run lint             # Lint all packages
+pnpm run typecheck        # TypeScript type checking
+```
+
+## Monorepo Structure
+
+```
+packages/core/    # @orbit-ai/core — schema engine, entities, adapters (Drizzle ORM)
+packages/sdk/     # @orbit-ai/sdk — TypeScript client SDK
+packages/api/     # @orbit-ai/api — Hono REST API server
+packages/mcp/     # @orbit-ai/mcp — MCP server (stdio + HTTP transport)
+packages/cli/     # orbit CLI tool (Commander.js + Ink)
+apps/docs/        # Documentation site
+examples/         # Reference apps (nextjs-crm, agent-workflow)
+docs/             # Strategy, specs, security, implementation plans
+```
+
+## Tech Stack
+
+- **Language**: TypeScript (strict)
+- **ORM**: Drizzle ORM (programmatic migration API via `drizzle-kit/api`)
+- **API**: Hono (14KB, runs on Node/Bun/Deno/Edge)
+- **CLI**: Commander.js + Ink
+- **MCP**: @modelcontextprotocol/sdk
+- **Validation**: Zod
+- **Tests**: Vitest
+- **Storage adapters**: Supabase, Neon, SQLite (MVP wave)
+
+## Key Architecture Rules
+
+- Every table MUST include `organization_id uuid NOT NULL` + RLS policy
+- All schema definitions use Drizzle ORM syntax — never raw SQL strings
+- Never import across packages using relative paths — use `@orbit-ai/*` package names
+- Migrations are transaction-wrapped and must have reverse migrations stored in `packages/core/src/migrations/`
+- Test migrations on SQLite adapter before Postgres adapters
+- Agent-safe by default: ADD is allowed, DROP/RENAME requires `--destructive` flag
+- MCP tools follow `orbit.<entity>.<operation>` naming (e.g. `orbit.contacts.create`)
+- CLI always supports `--json` flag for structured agent output
+
+## Adding an Entity
+
+1. Drizzle schema in `packages/core/src/schema/<entity>.ts`
+2. Types in `packages/core/src/types.ts`
+3. CRUD in `packages/core/src/entities/<entity>.ts`
+4. REST routes in `packages/api/src/routes/<entity>.ts`
+5. MCP tools in `packages/mcp/src/tools/<entity>.ts`
+6. CLI commands in `packages/cli/src/commands/<entity>.ts`
+
+## Adding a Storage Adapter
+
+1. Create `packages/core/src/adapters/<name>/index.ts`
+2. Implement `StorageAdapter` interface from `packages/core/src/adapters/interface.ts`
+3. Export from `packages/core/src/adapters/index.ts`
+
+## Base Entities (12)
+
+contacts, companies, deals, pipeline_stages, activities, products, payments, contracts, channels, sequences, tags, notes
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DATABASE_URL` | Yes (self-hosted) | Postgres connection string |
+| `ORBIT_API_KEY` | Yes (hosted) | API key for hosted Orbit AI |
+| `ORBIT_ADAPTER` | No | Storage adapter override (`supabase`, `neon`, `sqlite`) |
+| `ORBIT_ORG_ID` | No | Default organization ID |
+
+## Gotchas
+
+- This is NOT `smb-sale-crm-app` (the Next.js CRM app). This is the extracted infrastructure project.
+- No packages are published to npm yet. Development starts with `packages/core`.
+- Key planning docs: `docs/IMPLEMENTATION-PLAN.md` (execution baseline), `docs/META-PLAN.md` (master plan), `docs/specs/01-core.md` through `06-integrations.md`.
+- Neon adapter auto-creates a database branch before migration for safe preview.


### PR DESCRIPTION
## Summary
- add `CLAUDE.md` with project context, commands, architecture rules, and contribution guidance for Claude-style agents

## Testing
- not run (docs-only)