### PR TITLE
docs: tighten execution skills

### DIFF
--- a/.claude/skills/orbit-schema-change/SKILL.md
+++ b/.claude/skills/orbit-schema-change/SKILL.md
@@ -27,9 +27,10 @@ Read the sections relevant to your change:
    - RLS generation rules (section 9: RLS)
 2. `docs/specs/02-api.md` — route structure, envelope format, pagination contracts
 3. `docs/specs/03-sdk.md` — resource methods, transport parity between API and direct mode
-4. `docs/specs/05-mcp.md` — tool inventory and which tools expose schema/entity data
+4. `docs/specs/04-cli.md` — command surface and the `--json`/`.response()`/`firstPage()` contract
+5. `docs/specs/05-mcp.md` — tool inventory and which tools expose schema/entity data
 
-You don't need all four for every change. A new custom field might only need 01-core.md. A new entity needs all four.
+You don't need all five for every change. A new custom field might only need 01-core.md. A new entity needs all interface specs.
 
 ## Step 2: Classify the change
 
@@ -114,6 +115,7 @@ Changes to how migrations are generated, applied, rolled back, or how the schema
    - API: update query parameter documentation
    - SDK: update TypeScript types
    - MCP: update tool input schemas if affected
+   - CLI: confirm `--json` still flows through SDK `response()`/`firstPage()` helpers without reconstructing envelopes
 
 ### For Type C (custom field contract change):
 
@@ -121,6 +123,7 @@ Changes to how migrations are generated, applied, rolled back, or how the schema
 2. **Validation** — ensure `custom_fields` JSONB keys still match `custom_field_definitions`
 3. **Promotion rules** — if changing how promotion works, check all adapter paths
 4. **Backwards compatibility** — existing custom field data must not break
+5. **Sanitized reads** — if custom field metadata or values can expose secret-bearing records, review read serializers and redaction markers
 
 ### For Type D (migration/schema-engine behavior):
 
@@ -129,6 +132,7 @@ Changes to how migrations are generated, applied, rolled back, or how the schema
 3. **Adapter coverage** — test on SQLite first, then Postgres-family adapters
 4. **Non-destructive default** — DROP and RENAME operations require explicit `--destructive` flag
 5. **Neon branching** — if the Neon adapter is involved, branch-before-migrate must still work
+6. **Read-surface impact** — if migration behavior changes exposed shapes or secret-bearing objects, update API/SDK/CLI/MCP redaction expectations explicitly
 
 ## Step 4: Safety classification
 
@@ -169,6 +173,7 @@ Output a checklist specific to the change, structured as:
 - SDK types: [unaffected | updated — describe]
 - MCP tools: [unaffected | updated — describe]
 - CLI --json output: [unaffected | updated — describe]
+- Redaction/serializers: [unaffected | updated — describe]
 ```
 
 ## Step 6: Validation
@@ -179,5 +184,6 @@ Confirm all of these before marking the change as complete:
 2. **Tenant vs bootstrap classification is explicit**: the code and schema clearly show whether this is org-scoped or bootstrap-scoped, with no ambiguity
 3. **Pagination, filter, and search contracts are either unaffected or explicitly updated**: if a new entity is searchable, it must be added to the search service; if new fields are filterable, the API query params and SDK types must reflect this
 4. **All affected interfaces are listed**: if the change touches API behavior, SDK, CLI, and MCP impact must all be assessed (even if "no change needed")
+5. **Secret-bearing read surfaces are assessed**: if the schema change touches API keys, webhooks, webhook deliveries, integration credentials, provider errors, or similar fields, API/SDK/CLI/MCP serializer and redaction impact must be listed explicitly
 
 If any check fails, flag it in the checklist before proceeding with implementation.

--- a/.claude/skills/orbit-tenant-safety-review/SKILL.md
+++ b/.claude/skills/orbit-tenant-safety-review/SKILL.md
@@ -12,7 +12,10 @@ This skill reviews code changes for tenant isolation safety. Cross-tenant data e
 - Generic performance optimization with no tenant data path changes
 - Frontend/UI-only changes
 - Documentation-only changes that don't alter security contracts
-- Changes entirely within `packages/cli/src/commands/` that only format output (no data fetching logic)
+- Changes entirely within CLI presentation code only when all of the following are true:
+  - no data fetching logic changes
+  - no serializer or DTO shape changes
+  - no `--json` output changes for secret-bearing or admin-only objects
 
 ## Step 1: Load context
 
@@ -113,7 +116,7 @@ Where does `organization_id` come from in the changed code? Is it from a trusted
 Does the change remain safe across both API mode (HTTP requests with API key auth) and direct mode (SDK with trusted context)? If MCP is involved, is it safe there too?
 
 ### Secret exposure check
-Can any secrets or admin-only state leak through the changed paths?
+Can any secrets or admin-only state leak through the changed paths? This includes API output, SDK direct-mode envelopes, CLI `--json`, MCP tool results, logs, audit snapshots, and connector/webhook DTOs.
 
 ### Findings (if any)
 
@@ -132,10 +135,11 @@ Severity definitions:
 
 ### Validation
 
-Explicitly state pass or fail for each of these three checks:
+Explicitly state pass or fail for each of these four checks:
 
 1. **No caller-controlled org context**: Pass/Fail — [brief evidence]
 2. **Runtime credentials only**: Pass/Fail — [brief evidence]
 3. **Defense-in-depth on new tables**: Pass/Fail or N/A — [brief evidence]
+4. **Secrets stay redacted across read surfaces**: Pass/Fail or N/A — [brief evidence]
 
 If any check fails, the review outcome is **FAIL** and the findings must be resolved before the change is safe to merge.

--- a/docs/KB.md
+++ b/docs/KB.md
@@ -35,13 +35,12 @@ Completed:
 Current focus:
 
 - maintain the repo knowledge base as the live hub
-- create the first two execution skills needed for core
-- begin `@orbit-ai/core` slice 1 after the skills exist
+- begin `@orbit-ai/core` slice 1 with the first two execution skills in place
+- keep execution docs and skills aligned as implementation starts
 
 Not started yet:
 
 - package implementation
-- skill creation
 
 ## Frozen Decisions
 
@@ -87,7 +86,7 @@ Use these files first:
 
 Immediate next actions:
 
-1. Create only the minimum pre-core skills:
+1. Minimum pre-core skills are in place:
    - `orbit-tenant-safety-review`
    - `orbit-schema-change`
 2. Start slice 1 from [core-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-implementation-plan.md):
@@ -116,6 +115,7 @@ These are still open, but they do not block the KB:
 - 2026-03-31: Defined the first skills backlog in [orbit-skills-plan.md](/Users/sharonsciammas/orbit-ai/docs/skills/orbit-skills-plan.md).
 - 2026-03-31: Upgraded [IMPLEMENTATION-PLAN.md](/Users/sharonsciammas/orbit-ai/docs/IMPLEMENTATION-PLAN.md) into the execution-grade baseline.
 - 2026-03-31: Created and reviewed [core-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-implementation-plan.md); the final sub-agent review returned no findings.
+- 2026-03-31: Created the first two execution skills under `.claude/skills/` and tightened them after review to cover CLI contract drift and secret-redaction validation explicitly.
 
 ## Working Rule
 


### PR DESCRIPTION
## Summary
- Tighten orbit-tenant-safety-review: refine CLI skip conditions, expand secret exposure check to cover all read surfaces, add 4th validation check for secret redaction
- Tighten orbit-schema-change: add CLI spec to context loading, add CLI `--json` contract checks, add sanitized reads and read-surface impact checks, add redaction/serializer line to output checklist

Follow-up to #1 with refinements from manual review.

## Test plan
- [ ] Review skill changes match security architecture contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)