### PR TITLE
fix(core): resolve slice 1 review findings

### DIFF
--- a/docs/KB.md
+++ b/docs/KB.md
@@ -36,7 +36,7 @@ Completed:
 Current focus:
 
 - maintain the repo knowledge base as the live hub
-- move from completed core slice 1 into Milestone 3 planning and repository primitives
+- move from completed slice-1 remediation into slice 2 operational schema and repository primitives
 - keep execution docs and skills aligned with implementation progress
 
 Not started yet:
@@ -81,6 +81,8 @@ Use these files first:
 - Execution support:
   - [IMPLEMENTATION-PLAN.md](/Users/sharonsciammas/orbit-ai/docs/IMPLEMENTATION-PLAN.md)
   - [core-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-implementation-plan.md)
+  - [core-slice-1-remediation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-slice-1-remediation-plan.md)
+  - [core-slice-2-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-slice-2-plan.md)
   - [orbit-skills-plan.md](/Users/sharonsciammas/orbit-ai/docs/skills/orbit-skills-plan.md)
 
 ## What Is Next
@@ -94,8 +96,8 @@ Immediate next actions:
 2. Start slice 1 from [core-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-implementation-plan.md) using the defined workstreams:
    - completed on branch `core-slice-1-execution`
 3. Next:
-   - review and accept slice 1 as complete
-   - start Milestone 3 validation/query primitives
+   - accept the slice-1 remediation branch and review outcome
+   - execute [core-slice-2-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-slice-2-plan.md)
    - keep tenant-safety review in the loop for repository work
 
 ## Open Items
@@ -120,6 +122,10 @@ These are still open, but they do not block the KB:
 - 2026-03-31: Created the first two execution skills under `.claude/skills/` and tightened them after review to cover CLI contract drift and secret-redaction validation explicitly.
 - 2026-03-31: Reconciled [AGENTS.MD](/Users/sharonsciammas/orbit-ai/AGENTS.MD) with the frozen product and execution baseline, and added `orbit-core-slice-review` so completed core slices have an explicit validation gate.
 - 2026-03-31: Executed `@orbit-ai/core` slice 1 on branch `core-slice-1-execution`, including package bootstrap, prefixed ULID IDs, shared types, bootstrap schema, adapter authority boundary, and the slice-1 validation proof harness.
+- 2026-03-31: Created [core-slice-2-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-slice-2-plan.md) to bridge slice 1 into operational schema, validation, query primitives, and tenant-safe repository foundations.
+- 2026-03-31: Accepted [core-slice-1-review.md](/Users/sharonsciammas/orbit-ai/docs/review/core-slice-1-review.md) as the gating review artifact and created [core-slice-1-remediation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-slice-1-remediation-plan.md) to fix the blocking issues before slice 2 starts.
+- 2026-03-31: Executed the slice-1 remediation patch set on branch `core-slice-1-remediation`, reran core validation, and cleared the must-fix auth, tenant-context, and schema-helper issues that were blocking slice 2.
+- 2026-03-31: Recorded the remediation review outcome in [core-slice-1-remediation-review.md](/Users/sharonsciammas/orbit-ai/docs/review/core-slice-1-remediation-review.md); slice 1 remediation is now ready for acceptance and slice 2 is unblocked.
 
 ## Working Rule
 

--- a/docs/execution/core-slice-1-remediation-plan.md
+++ b/docs/execution/core-slice-1-remediation-plan.md
@@ -1,0 +1,342 @@
+# Orbit AI Core Slice 1 Remediation Plan
+
+Date: 2026-03-31
+Status: Executed locally and ready for review acceptance
+Package: `@orbit-ai/core`
+Depends on:
+- [core-slice-1-review.md](/Users/sharonsciammas/orbit-ai/docs/review/core-slice-1-review.md)
+- [core-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-implementation-plan.md)
+- [core-slice-2-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-slice-2-plan.md)
+- [01-core.md](/Users/sharonsciammas/orbit-ai/docs/specs/01-core.md)
+- [orbit-ai-threat-model.md](/Users/sharonsciammas/orbit-ai/docs/security/orbit-ai-threat-model.md)
+
+## 1. Purpose
+
+This document turns the slice-1 review findings into an executable remediation plan.
+
+The goal is not to reopen slice 1 broadly. The goal is to fix the blocking issues the review identified, record the review-gate outcome cleanly, and then start slice 2 from a sound baseline.
+
+## 2. Assessment Of The Review
+
+The review is directionally correct and should be treated as the gating artifact for slice 1.
+
+Its strongest conclusions are:
+
+1. the auth naming mismatch is a real cross-cutting defect and must be fixed first
+2. tenant-context validation and transaction-local behavior must be tightened before repository work begins
+3. the remaining code-quality issues are small, concrete, and cheap to fix now
+
+One sequencing clarification is required:
+
+- SQLite is correctly listed as missing from the original slice-1 target, but it should not block the remediation patch set that unlocks slice 2. It should be planned as a prerequisite before Wave 1 services or Milestone 5, not as a hotfix inside the first remediation pass.
+
+One scope clarification is also required:
+
+- RLS generation remains a Milestone 9 deliverable. It should stay on the tracked follow-up list and not distort the near-term remediation branch.
+
+## 3. Remediation Outcome We Need
+
+Slice 1 should be considered remediated when:
+
+1. all eight "before Milestone 3" findings from the review are fixed
+2. the two minor ID tests are added while the related files are already open
+3. the specialized review gates are rerun and pass:
+   - `orbit-tenant-safety-review`
+   - `orbit-core-slice-review`
+4. `core-slice-2-plan.md` is treated as unblocked and execution-ready
+
+## 4. Fix Phases
+
+### Phase A. Immediate Blockers Before Slice 2
+
+These are the fixes that should land in the first remediation branch.
+
+#### A1. Auth Naming And Export Consistency
+
+Files:
+
+- `packages/core/src/adapters/interface.ts`
+- `packages/core/src/adapters/interface.test.ts`
+- `packages/core/src/schema/tables.ts`
+- `packages/core/src/index.ts`
+
+Changes:
+
+- rename `ApiKeyAuthLookup.permissions` to `scopes`
+- keep naming aligned with:
+  - `OrbitAuthContext.scopes`
+  - `apiKeys.scopes`
+- export `ID_PREFIXES` and `OrbitIdKind` from `src/index.ts`
+
+Why first:
+
+- it removes the highest-risk auth contract mismatch
+- it prevents downstream adapter work from encoding the wrong field name
+
+#### A2. Tenant Context Safety Fixes
+
+Files:
+
+- `packages/core/src/adapters/postgres/tenant-context.ts`
+- `packages/core/src/adapters/postgres/tenant-context.test.ts`
+- `packages/core/src/ids/parse-id.ts`
+- `packages/core/src/ids/parse-id.test.ts`
+
+Changes:
+
+- validate `context.orgId` with `assertOrbitId(context.orgId, 'organization')`
+- remove the redundant `finally` clear path
+- add a lowercase ULID rejection test
+
+Why first:
+
+- this is the most important T1 isolation fix in the review
+- the current implementation can accept malformed org identifiers and can mask callback failures
+
+#### A3. Schema Helper And Relation Corrections
+
+Files:
+
+- `packages/core/src/schema/helpers.ts`
+- `packages/core/src/schema/tables.ts`
+- `packages/core/src/schema/relations.ts`
+- `packages/core/src/schema/bootstrap-schema.test.ts`
+
+Changes:
+
+- add `.$onUpdateFn(() => new Date())` to `updatedAt`
+- remove the `pgTable` re-export
+- remove dead imports from `tables.ts`
+- disambiguate the two `organizationMemberships -> users` relations with `relationName`
+
+Why now:
+
+- these are low-cost structural fixes that affect all later schema and repository work
+
+#### A4. Test And Contract Hardening
+
+Files:
+
+- `packages/core/src/ids/generate-id.test.ts`
+- `packages/core/src/ids/parse-id.test.ts`
+- `packages/core/src/adapters/interface.test.ts`
+
+Changes:
+
+- add a uniqueness assertion for generated IDs
+- update the auth lookup test fixture to `scopes`
+- keep the existing contract tests aligned with the renamed auth shape
+
+### Phase B. Near-Term Hardening During Slice 2
+
+These are important but should be handled as explicit slice-2-adjacent work, not mixed into the first blocker patch set unless they come naturally.
+
+#### B1. Migration Authority Type Separation
+
+Files:
+
+- `packages/core/src/adapters/interface.ts`
+- any adapter tests affected by the type change
+
+Changes:
+
+- introduce a branded `MigrationDatabase` type
+- make `runWithMigrationAuthority()` yield `MigrationDatabase`, not `OrbitDatabase`
+
+Reason:
+
+- this is a real T2 boundary hardening improvement
+- it fits naturally beside repository and adapter-boundary work in slice 2
+
+#### B2. Restrict Raw Database Access
+
+Files:
+
+- `packages/core/src/adapters/interface.ts`
+- any call sites that rely on the public property
+
+Changes:
+
+- remove `database` as a casual public escape hatch, or rename it to an explicitly internal/raw handle with warning comments
+
+Reason:
+
+- it closes an easy tenant-context bypass path before service implementations multiply
+
+#### B3. Transaction-Boundary Proof
+
+Files:
+
+- Postgres-family adapter tests or integration harness for slice 2
+
+Changes:
+
+- add a real-database or adapter-backed test proving tenant GUC state is not visible outside the transaction boundary
+
+Reason:
+
+- the current interface assumes correct transaction behavior but does not prove it on a real connection path
+
+#### B4. Prefix Invariant Test
+
+Files:
+
+- `packages/core/src/ids/prefixes.ts`
+- new test file for prefix invariants
+
+Changes:
+
+- assert all prefixes are unique
+- assert no prefix is another prefix plus a shared delimiter accident
+- document that `assertOrbitId` validates format, not authorization
+
+### Phase C. Later Milestone Follow-Ups
+
+These should stay tracked, but they are not slice-1-remediation blockers.
+
+#### C1. SQLite Adapter
+
+Target:
+
+- before Milestone 5 or Wave 1 services
+
+Reason:
+
+- it was part of the original early-adapter intent, but it should not block the blocker-fix branch
+
+#### C2. Error Detail Redaction Contract
+
+Target:
+
+- when API and richer error surfaces begin
+
+Reason:
+
+- the risk becomes concrete once API, CLI JSON, and MCP error paths expand
+
+#### C3. RLS Generation
+
+Target:
+
+- Milestone 9
+
+Reason:
+
+- this remains a planned capability, not a slice-1 defect
+
+## 5. Workstream Plan
+
+Keep the remediation branch small and deterministic.
+
+### Workstream A. Auth And Tenant Boundary
+
+Owns:
+
+- `packages/core/src/adapters/interface.ts`
+- `packages/core/src/adapters/interface.test.ts`
+- `packages/core/src/adapters/postgres/tenant-context.ts`
+- `packages/core/src/adapters/postgres/tenant-context.test.ts`
+
+Responsibilities:
+
+- `permissions` to `scopes` rename
+- `orgId` validation
+- `finally` block removal
+- tenant-context test updates
+
+### Workstream B. Schema And Relations
+
+Owns:
+
+- `packages/core/src/schema/helpers.ts`
+- `packages/core/src/schema/tables.ts`
+- `packages/core/src/schema/relations.ts`
+- `packages/core/src/schema/bootstrap-schema.test.ts`
+
+Responsibilities:
+
+- `updatedAt` auto-update fix
+- `pgTable` re-export removal
+- dead import cleanup
+- relation disambiguation
+
+### Workstream C. Exports And ID Tests
+
+Owns:
+
+- `packages/core/src/index.ts`
+- `packages/core/src/ids/generate-id.test.ts`
+- `packages/core/src/ids/parse-id.test.ts`
+
+Responsibilities:
+
+- export `ID_PREFIXES`
+- add uniqueness and lowercase-rejection tests
+
+## 6. Branch And Commit Strategy
+
+Recommended branch:
+
+- `core-slice-1-remediation`
+
+Recommended commit sequence:
+
+1. `fix(core): align api key auth scope contract`
+2. `fix(core): harden tenant context validation`
+3. `fix(core): correct schema helpers and relations`
+4. `test(core): add id contract coverage`
+5. `docs: record slice 1 remediation status`
+
+If the branch is small enough, commits 2 and 3 may be combined. Do not hide the auth contract fix inside a mixed commit.
+
+## 7. Required Skills And Review Gates
+
+Mandatory reviews for this remediation branch:
+
+- `orbit-tenant-safety-review`
+  - required after Workstream A and before merge
+- `orbit-schema-change`
+  - required after Workstream B because schema helpers and relations are changing
+- `orbit-core-slice-review`
+  - required on the integrated remediation diff before slice 2 execution starts
+
+## 8. Validation Gates
+
+The remediation branch is not complete until all of these pass:
+
+- `pnpm --filter @orbit-ai/core test`
+- `pnpm --filter @orbit-ai/core typecheck`
+- `pnpm --filter @orbit-ai/core build`
+- `git diff --check`
+
+And specifically:
+
+- auth lookup tests use `scopes` consistently
+- malformed `org_` IDs are rejected before transaction start
+- thrown callback errors are not masked by cleanup logic
+- membership relations compile and traverse without ambiguity
+- `updatedAt` behavior is covered by at least one focused test or schema assertion
+- ID export and invariant tests pass
+
+## 9. Exit Criteria
+
+This remediation plan is complete when:
+
+1. the eight must-fix review findings are resolved
+2. the two opportunistic ID tests are added
+3. the remediation branch passes all validation gates
+4. the review gate outcome changes from:
+   - slice 1: conditional pass
+   - tenant safety: fail
+   to:
+   - slice 1: pass
+   - tenant safety: pass
+5. slice 2 can begin without carrying known auth or tenant-boundary defects forward
+
+## 10. Immediate Next Actions
+
+1. Accept this remediation plan.
+2. Create branch `core-slice-1-remediation`.
+3. Execute Workstreams A-C.
+4. Run the three required reviews.
+5. Update the KB and slice-2 status after the remediation branch is accepted.

--- a/docs/execution/core-slice-2-plan.md
+++ b/docs/execution/core-slice-2-plan.md
@@ -1,0 +1,280 @@
+# Orbit AI Core Slice 2 Plan
+
+Date: 2026-03-31
+Status: Ready for execution
+Package: `@orbit-ai/core`
+Depends on:
+- [core-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-implementation-plan.md)
+- [core-slice-1-remediation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-slice-1-remediation-plan.md)
+- [01-core.md](/Users/sharonsciammas/orbit-ai/docs/specs/01-core.md)
+- [orbit-ai-threat-model.md](/Users/sharonsciammas/orbit-ai/docs/security/orbit-ai-threat-model.md)
+- [KB.md](/Users/sharonsciammas/orbit-ai/docs/KB.md)
+
+## 1. Purpose
+
+This document defines the second executable core slice after the completed bootstrap and authority-boundary work in slice 1.
+
+Slice 2 is intentionally narrow. Its job is to land the minimum remaining schema and repository foundation needed before broad entity services begin.
+
+Execution precondition:
+
+- the must-fix items from [core-slice-1-review.md](/Users/sharonsciammas/orbit-ai/docs/review/core-slice-1-review.md) are resolved through [core-slice-1-remediation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-slice-1-remediation-plan.md)
+
+## 2. Slice Objective
+
+Complete the minimum bridge between slice 1 and service work:
+
+1. add the first operational tenant tables needed to prove repository behavior
+2. implement generated Zod validation for the implemented tables
+3. add cursor and list-query primitives
+4. add base repository primitives with deterministic tenant filtering
+
+This slice should stop before service breadth, audit writing, idempotency handling, or schema-engine mutation work.
+
+## 3. In Scope
+
+- first operational domain tables:
+  - `companies`
+  - `contacts`
+  - `pipelines`
+  - `stages`
+  - `deals`
+- `packages/core/src/schema/zod.ts`
+- query and cursor helpers
+- base repository primitives
+- deterministic tenant filtering rules for Postgres-family and SQLite paths
+- tests that prove repository-level tenant behavior is stable before service work starts
+
+## 4. Out Of Scope
+
+- entity service implementations
+- admin/system services beyond what already exists
+- audit write behavior
+- idempotency behavior
+- schema-engine apply, rollback, or promotion logic
+- webhook, import, or integration entities
+- API, SDK, CLI, or MCP implementation work
+
+## 5. Deliverables
+
+Slice 2 should produce these concrete outputs:
+
+- `packages/core/src/schema/tables.ts`
+  - adds `companies`, `contacts`, `pipelines`, `stages`, `deals`
+- `packages/core/src/schema/relations.ts`
+  - adds relations for the same first operational graph
+- `packages/core/src/schema/zod.ts`
+  - replaces the placeholder export with generated select, insert, and update schemas for implemented tables
+- `packages/core/src/query/cursor.ts`
+  - cursor encode, decode, and validation helpers
+- `packages/core/src/query/list-query.ts`
+  - normalized limit, sort, filter, and cursor parsing helpers
+- `packages/core/src/repositories/base-repository.ts`
+  - tenant-safe base list and record lookup primitives
+- `packages/core/src/repositories/tenant-scope.ts`
+  - shared tenant filter helpers and bootstrap-table exceptions
+- tests for:
+  - Zod generation and custom validation extensions
+  - cursor stability and invalid-cursor rejection
+  - deterministic sort normalization
+  - tenant-safe repository predicates
+  - SQLite application-level tenant filtering expectations
+
+If file names need to shift slightly during implementation, keep the module boundaries the same and update exports in one pass.
+
+## 6. Why This Slice Exists
+
+Slice 1 proved:
+
+- package shape
+- shared IDs and types
+- bootstrap schema
+- runtime-vs-migration authority boundary
+- Postgres-family tenant context
+
+It did not yet prove:
+
+- the first operational tenant table graph
+- generated validation for implemented tables
+- reusable cursor and list-query behavior
+- repository primitives that always inject tenant scope
+
+Those are the minimum dependencies for safe service implementation in the next slice.
+
+## 7. Workstream Ownership
+
+Use disjoint write scopes so the slice can execute safely with sub-agents.
+
+### Workstream A. Operational Schema Bridge
+
+Owns:
+
+- `packages/core/src/schema/tables.ts`
+- `packages/core/src/schema/relations.ts`
+- schema tests that cover only the five new operational tables
+
+Responsibilities:
+
+- add `companies`, `contacts`, `pipelines`, `stages`, and `deals`
+- keep `organization_id` on every tenant-scoped table
+- preserve prefixed-ULID text IDs
+- encode the minimum relation graph needed for repository proofs:
+  - contacts to companies
+  - deals to companies
+  - deals to contacts
+  - deals to pipelines
+  - deals to stages
+  - stages to pipelines
+
+Constraints:
+
+- do not add service-layer code
+- do not add nonessential entities in the same patch
+- if a table requires a secret-bearing field, stop and split it into a later slice
+
+### Workstream B. Validation Layer
+
+Owns:
+
+- `packages/core/src/schema/zod.ts`
+- validation-focused tests under `packages/core/src/schema/`
+
+Responsibilities:
+
+- replace the milestone-3 placeholder export
+- generate select, insert, and update schemas with `drizzle-zod`
+- add the documented runtime extensions that are already required by the spec for implemented tables
+- keep validation limited to tables that actually exist after Workstream A lands
+
+Constraints:
+
+- do not invent service-specific DTO shapes
+- do not widen into schema-engine mutation behavior
+
+### Workstream C. Query And Cursor Primitives
+
+Owns:
+
+- `packages/core/src/query/cursor.ts`
+- `packages/core/src/query/list-query.ts`
+- tests under `packages/core/src/query/`
+
+Responsibilities:
+
+- implement cursor encode and decode helpers
+- normalize default limits and enforce upper bounds
+- normalize sort rules so pagination is deterministic
+- validate and normalize list and search query inputs for repository consumption
+
+Constraints:
+
+- keep external transport mapping out of this slice
+- reuse existing shared types rather than introducing competing query shapes
+
+### Workstream D. Repository Primitives And Tenant Scope
+
+Owns:
+
+- `packages/core/src/repositories/base-repository.ts`
+- `packages/core/src/repositories/tenant-scope.ts`
+- repository tests under `packages/core/src/repositories/`
+- any export wiring in `packages/core/src/index.ts` needed for the new modules
+
+Responsibilities:
+
+- implement reusable tenant-scope helpers
+- distinguish bootstrap-table behavior from tenant-table behavior
+- make repository list and get behavior deterministic on tenant filters and sort order
+- define the minimum repository contract the later entity services will build on
+- prove SQLite still applies explicit tenant filters at the repository layer
+
+Constraints:
+
+- do not implement entity-specific CRUD repositories yet
+- do not bypass tenant filters because Postgres-family RLS will exist later
+
+## 8. Coordination Rules
+
+1. Workstream A lands first because Workstreams B and D depend on the new tables.
+2. Workstream C can start in parallel with A.
+3. Workstream B starts after A is merged or rebased locally.
+4. Workstream D starts after A and C are stable.
+5. Integrated slice review happens only after all four workstreams are merged.
+
+## 9. Required Skills
+
+These skills are mandatory for slice 2:
+
+- `orbit-schema-change`
+  - required for Workstream A and any `schema/zod.ts` change that depends on new tables
+- `orbit-tenant-safety-review`
+  - required for Workstream D and for any schema change that introduces or changes tenant-scoped table behavior
+- `orbit-core-slice-review`
+  - required after the integrated slice is complete and before service work begins
+
+Do not add more skills to the critical path for this slice.
+
+## 10. Validation Gates
+
+Slice 2 is not done until all of these pass.
+
+### 10.1 Unit And Build Gates
+
+- `pnpm --filter @orbit-ai/core test`
+- `pnpm --filter @orbit-ai/core typecheck`
+- `pnpm --filter @orbit-ai/core build`
+- `git diff --check`
+
+### 10.2 Schema And Validation Gates
+
+- table tests prove all five operational tables compile with the expected tenant columns and indexes
+- relation tests prove the minimum contact, company, deal, pipeline, and stage graph
+- generated Zod schemas exist for every implemented table in this slice
+- validation extensions cover the documented invariants that apply to implemented tables, especially:
+  - valid Orbit IDs
+  - stage won/lost mutual exclusion
+  - basic deal-stage consistency rules, if modeled in this slice
+
+### 10.3 Query And Pagination Gates
+
+- cursor encode and decode round-trip tests pass
+- invalid cursor inputs are rejected cleanly
+- default sort normalization is deterministic
+- tie-break behavior is documented and tested
+- list-query normalization does not allow unbounded or unstable repository calls
+
+### 10.4 Tenant-Safety Gates
+
+- repository primitives always require tenant scope for tenant tables
+- bootstrap-table exceptions are explicit and tested
+- SQLite tests prove application-level tenant filtering remains mandatory
+- no repository helper assumes privileged database authority
+
+## 11. Threat Focus
+
+Slice 2 primarily addresses:
+
+- T1 cross-tenant leakage through repository or predicate mistakes
+- T3 secret exposure risk from premature broad schema expansion
+
+The slice should reduce risk by proving the repository layer before service code starts.
+
+## 12. Done Condition
+
+Slice 2 is complete when all of the following are true:
+
+1. the five operational tables and their minimum relations are in place
+2. `schema/zod.ts` is no longer a placeholder
+3. cursor and list-query helpers are reusable and tested
+4. repository primitives prove deterministic tenant filtering
+5. `orbit-schema-change` review reports no unresolved findings
+6. `orbit-tenant-safety-review` reports no unresolved findings
+7. `orbit-core-slice-review` reports that the integrated diff matches this plan and the core spec
+
+## 13. Immediate Next Actions
+
+1. Accept this slice-2 plan.
+2. Create branch `core-slice-2-execution`.
+3. Assign Workstreams A-D with the file ownership listed above.
+4. Land Workstream A first.
+5. Stop after the integrated slice-2 review before starting entity services.

--- a/docs/review/core-slice-1-remediation-review.md
+++ b/docs/review/core-slice-1-remediation-review.md
@@ -1,0 +1,104 @@
+# Core Slice 1 Remediation Review
+
+Date: 2026-03-31
+Branch: `core-slice-1-remediation`
+Scope:
+- `packages/core/src/`
+- [core-slice-1-remediation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-slice-1-remediation-plan.md)
+
+## 1. Review Summary
+
+The slice-1 remediation patch set resolves the must-fix findings from [core-slice-1-review.md](/Users/sharonsciammas/orbit-ai/docs/review/core-slice-1-review.md) that were blocking Milestone 3 and slice 2.
+
+Resolved in this branch:
+
+- `ApiKeyAuthLookup.permissions` renamed to `scopes`
+- `withTenantContext(...)` now validates `orgId` with `assertOrbitId(...)`
+- redundant tenant-context cleanup removed
+- `updatedAt` now has automatic update behavior
+- `pgTable` is no longer re-exported from schema helpers
+- `organizationMemberships -> users` relations are disambiguated
+- `ID_PREFIXES` is exported from the core package root
+- ID uniqueness and lowercase-ULID rejection tests are present
+
+## 2. Validation Evidence
+
+Passed:
+
+- `pnpm --filter @orbit-ai/core test`
+- `pnpm --filter @orbit-ai/core typecheck`
+- `pnpm --filter @orbit-ai/core build`
+- `git diff --check`
+
+Test totals at review time:
+
+- 8 test files passed
+- 24 tests passed
+
+## 3. Code Review Outcome
+
+Outcome: `PASS`
+
+Findings:
+
+- none
+
+Notes:
+
+- the branch fixes the slice-1 contract and safety defects without pulling in slice-2 repository or service work
+- the auth naming, export surface, relation, and timestamp helper changes are narrow and consistent with the core spec
+
+## 4. Tenant-Safety Review Outcome
+
+Boundary touched:
+
+- Tenant Runtime
+- Database
+
+Org context source:
+
+- `organization_id` still comes from trusted runtime context
+- `withTenantContext(...)` now rejects malformed `orgId` values before entering the transaction
+
+Access mode safety:
+
+- API mode remains safe on the current contract because auth lookup and tenant context now use aligned `scopes` and validated `orgId`
+- direct mode remains safe on the current contract because the trusted `context.orgId` path is validated before tenant context is established
+
+Secret exposure check:
+
+- no new secret-bearing reads were introduced
+- the remediation branch does not widen DTOs, envelopes, or serializer surfaces
+
+Validation:
+
+1. **No caller-controlled org context**: Pass — `withTenantContext(...)` validates `context.orgId` before opening a transaction
+2. **Runtime credentials only**: Pass — no runtime path was changed to use elevated or migration credentials
+3. **Defense-in-depth on new tables**: N/A — this remediation branch does not add tenant tables
+4. **Secrets stay redacted across read surfaces**: Pass — no new read surface was added and the auth DTO remains minimal
+
+Outcome: `PASS`
+
+## 5. Core Slice Review Outcome
+
+Validation:
+
+1. **Slice scope is respected**: Pass — the branch only addresses slice-1 remediation items
+2. **Workstream ownership stayed clean**: Pass — auth, tenant-context, schema helper, relation, export, and ID-test changes stayed within the planned remediation file sets
+3. **Required build/test evidence exists**: Pass — build, typecheck, tests, and diff hygiene all passed
+4. **Shared contracts still match the core spec**: Pass — `scopes`, `ID_PREFIXES`, helper exports, and tenant-context behavior are aligned with the reconciled core spec
+5. **Required specialized reviews ran where needed**: Pass — this document records both the tenant-safety and integrated slice outcomes
+6. **Postgres-family proof exists when required**: Pass — the existing slice-1 proof test remains green after the tenant-context change
+
+Outcome: `READY FOR NEXT MILESTONE`
+
+## 6. Remaining Follow-Ups
+
+Tracked but not blocking slice 2:
+
+- branded `MigrationDatabase` type
+- restricted raw database access on `StorageAdapter`
+- stronger transaction-boundary proof on a real adapter-backed connection path
+- prefix invariant test
+- SQLite adapter before Wave 1 services
+- RLS generation in Milestone 9

--- a/packages/core/src/adapters/interface.test.ts
+++ b/packages/core/src/adapters/interface.test.ts
@@ -13,7 +13,7 @@ describe('adapter authority model', () => {
     const lookup: ApiKeyAuthLookup = {
       id: 'key_01ABCDEF0123456789ABCDEF01',
       organizationId: 'org_01ABCDEF0123456789ABCDEF01',
-      permissions: ['contacts:read'],
+      scopes: ['contacts:read'],
       revokedAt: null,
       expiresAt: null,
     }
@@ -22,8 +22,8 @@ describe('adapter authority model', () => {
       'expiresAt',
       'id',
       'organizationId',
-      'permissions',
       'revokedAt',
+      'scopes',
     ])
   })
 
@@ -36,7 +36,7 @@ describe('adapter authority model', () => {
         return {
           id: 'key_01ABCDEF0123456789ABCDEF01',
           organizationId: 'org_01ABCDEF0123456789ABCDEF01',
-          permissions: ['contacts:read'],
+          scopes: ['contacts:read'],
           revokedAt: null,
           expiresAt: null,
         }
@@ -46,7 +46,7 @@ describe('adapter authority model', () => {
     await expect(adapter.lookupApiKeyForAuth(expectedHash)).resolves.toEqual({
       id: 'key_01ABCDEF0123456789ABCDEF01',
       organizationId: 'org_01ABCDEF0123456789ABCDEF01',
-      permissions: ['contacts:read'],
+      scopes: ['contacts:read'],
       revokedAt: null,
       expiresAt: null,
     })

--- a/packages/core/src/adapters/interface.ts
+++ b/packages/core/src/adapters/interface.ts
@@ -32,7 +32,7 @@ export interface IUserResolver {
 export interface ApiKeyAuthLookup {
   id: string
   organizationId: string
-  permissions: string[]
+  scopes: string[]
   revokedAt: Date | null
   expiresAt: Date | null
 }

--- a/packages/core/src/adapters/postgres/slice-1-proof.test.ts
+++ b/packages/core/src/adapters/postgres/slice-1-proof.test.ts
@@ -2,7 +2,7 @@ import { getTableConfig } from 'drizzle-orm/pg-core'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { OrbitDatabase } from '../interface.js'
-import { buildClearTenantContextStatement, buildSetTenantContextStatement, withTenantContext } from './tenant-context.js'
+import { buildSetTenantContextStatement, withTenantContext } from './tenant-context.js'
 import { apiKeys, organizationMemberships, organizations, users } from '../../schema/tables.js'
 
 describe('slice 1 postgres-family proof', () => {
@@ -35,6 +35,6 @@ describe('slice 1 postgres-family proof', () => {
 
     expect(result).toBe('orbit.users')
     expect(execute).toHaveBeenNthCalledWith(1, buildSetTenantContextStatement('org_01ABCDEF0123456789ABCDEF01'))
-    expect(execute).toHaveBeenNthCalledWith(2, buildClearTenantContextStatement())
+    expect(execute).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/adapters/postgres/tenant-context.test.ts
+++ b/packages/core/src/adapters/postgres/tenant-context.test.ts
@@ -1,14 +1,21 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { OrbitDatabase } from '../interface.js'
-import {
-  buildClearTenantContextStatement,
-  buildSetTenantContextStatement,
-  withTenantContext,
-} from './tenant-context.js'
+import { buildSetTenantContextStatement, withTenantContext } from './tenant-context.js'
 
 describe('withTenantContext', () => {
-  it('sets and clears transaction-local org context around the callback', async () => {
+  it('validates org ids before opening the transaction', async () => {
+    const db = {
+      transaction: vi.fn(),
+    } as unknown as OrbitDatabase
+
+    await expect(withTenantContext(db, { orgId: '' }, async () => 'ok')).rejects.toThrow(
+      'Expected organization ID with prefix "org_"',
+    )
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('sets transaction-local org context around the callback', async () => {
     const execute = vi.fn(async () => undefined)
     const tx = { execute } as unknown as OrbitDatabase
     const db = {
@@ -23,10 +30,10 @@ describe('withTenantContext', () => {
     expect(result).toBe('ok')
     expect(db.transaction).toHaveBeenCalledTimes(1)
     expect(execute).toHaveBeenNthCalledWith(1, buildSetTenantContextStatement('org_01ABCDEF0123456789ABCDEF01'))
-    expect(execute).toHaveBeenNthCalledWith(2, buildClearTenantContextStatement())
+    expect(execute).toHaveBeenCalledTimes(1)
   })
 
-  it('clears the org context even when the callback throws', async () => {
+  it('does not mask callback errors with redundant cleanup', async () => {
     const execute = vi.fn(async () => undefined)
     const tx = { execute } as unknown as OrbitDatabase
     const db = {
@@ -40,6 +47,6 @@ describe('withTenantContext', () => {
     ).rejects.toThrow('boom')
 
     expect(execute).toHaveBeenNthCalledWith(1, buildSetTenantContextStatement('org_01ABCDEF0123456789ABCDEF01'))
-    expect(execute).toHaveBeenNthCalledWith(2, buildClearTenantContextStatement())
+    expect(execute).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/adapters/postgres/tenant-context.ts
+++ b/packages/core/src/adapters/postgres/tenant-context.ts
@@ -1,13 +1,10 @@
 import { sql } from 'drizzle-orm'
 
 import type { OrbitAuthContext, OrbitDatabase } from '../interface.js'
+import { assertOrbitId } from '../../ids/parse-id.js'
 
 export function buildSetTenantContextStatement(orgId: string) {
   return sql`select set_config('app.current_org_id', ${orgId}, true)`
-}
-
-export function buildClearTenantContextStatement() {
-  return sql`select set_config('app.current_org_id', '', true)`
 }
 
 export async function withTenantContext<T>(
@@ -15,12 +12,10 @@ export async function withTenantContext<T>(
   context: OrbitAuthContext,
   fn: (tx: OrbitDatabase) => Promise<T>,
 ): Promise<T> {
+  assertOrbitId(context.orgId, 'organization')
+
   return db.transaction(async (tx) => {
-    try {
-      await tx.execute(buildSetTenantContextStatement(context.orgId))
-      return await fn(tx)
-    } finally {
-      await tx.execute(buildClearTenantContextStatement())
-    }
+    await tx.execute(buildSetTenantContextStatement(context.orgId))
+    return await fn(tx)
   })
 }

--- a/packages/core/src/ids/generate-id.test.ts
+++ b/packages/core/src/ids/generate-id.test.ts
@@ -8,4 +8,8 @@ describe('generateId', () => {
     expect(id.startsWith('contact_')).toBe(true)
     expect(id).toHaveLength('contact_'.length + 26)
   })
+
+  it('creates unique ids across successive calls', () => {
+    expect(generateId('contact')).not.toBe(generateId('contact'))
+  })
 })

--- a/packages/core/src/ids/parse-id.test.ts
+++ b/packages/core/src/ids/parse-id.test.ts
@@ -20,4 +20,10 @@ describe('assertOrbitId', () => {
       'Invalid ULID body for contact ID',
     )
   })
+
+  it('rejects lowercase ulid bodies', () => {
+    expect(() => assertOrbitId('contact_01aryz6s41yyyyyyyyyyyyyyyy', 'contact')).toThrow(
+      'Invalid ULID body for contact ID',
+    )
+  })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './adapters/interface.js'
 export * from './ids/generate-id.js'
 export * from './ids/parse-id.js'
+export * from './ids/prefixes.js'
 export * from './schema/tables.js'
 export * from './schema/zod.js'
 export * from './schema-engine/engine.js'

--- a/packages/core/src/schema/helpers.test.ts
+++ b/packages/core/src/schema/helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { getTableColumns } from 'drizzle-orm'
 import { apiKeys, organizationMemberships, organizations, users } from './tables.js'
+import * as helpers from './helpers.js'
 
 describe('bootstrap schema slice 1', () => {
   it('keeps organizations bootstrap-scoped', () => {
@@ -41,5 +42,15 @@ describe('bootstrap schema slice 1', () => {
       'createdAt',
       'updatedAt',
     ])
+  })
+
+  it('keeps updatedAt configured for automatic update timestamps', () => {
+    const columns = getTableColumns(users)
+
+    expect(columns.updatedAt.onUpdateFn).toBeTypeOf('function')
+  })
+
+  it('does not expose pgTable through schema helpers', () => {
+    expect('pgTable' in helpers).toBe(false)
   })
 })

--- a/packages/core/src/schema/helpers.ts
+++ b/packages/core/src/schema/helpers.ts
@@ -6,7 +6,6 @@ import {
   jsonb,
   numeric,
   pgSchema,
-  pgTable,
   primaryKey,
   text,
   timestamp,
@@ -17,7 +16,7 @@ export const orbit = pgSchema('orbit')
 
 export const timestamps = {
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().$onUpdateFn(() => new Date()).notNull(),
 }
 
 export const customFieldsColumn = jsonb('custom_fields').$type<Record<string, unknown>>().notNull().default({})
@@ -26,4 +25,4 @@ export const money = (name: string) => numeric(name, { precision: 18, scale: 2 }
 
 export const metadata = () => jsonb('metadata').$type<Record<string, unknown>>().notNull().default({})
 
-export { boolean, foreignKey, index, integer, jsonb, numeric, pgTable, primaryKey, text, timestamp, uniqueIndex }
+export { boolean, foreignKey, index, integer, jsonb, numeric, primaryKey, text, timestamp, uniqueIndex }

--- a/packages/core/src/schema/relations.ts
+++ b/packages/core/src/schema/relations.ts
@@ -12,7 +12,12 @@ export const usersRelations = relations(users, ({ one, many }) => ({
     fields: [users.organizationId],
     references: [organizations.id],
   }),
-  memberships: many(organizationMemberships),
+  memberships: many(organizationMemberships, {
+    relationName: 'membershipUser',
+  }),
+  membershipInvites: many(organizationMemberships, {
+    relationName: 'membershipInvitedBy',
+  }),
   apiKeysCreated: many(apiKeys),
 }))
 
@@ -22,10 +27,12 @@ export const organizationMembershipsRelations = relations(organizationMembership
     references: [organizations.id],
   }),
   user: one(users, {
+    relationName: 'membershipUser',
     fields: [organizationMemberships.userId],
     references: [users.id],
   }),
   invitedBy: one(users, {
+    relationName: 'membershipInvitedBy',
     fields: [organizationMemberships.invitedByUserId],
     references: [users.id],
   }),

--- a/packages/core/src/schema/tables.ts
+++ b/packages/core/src/schema/tables.ts
@@ -1,4 +1,4 @@
-import { boolean, customFieldsColumn, index, integer, jsonb, metadata, orbit, text, timestamp, timestamps, uniqueIndex } from './helpers.js'
+import { boolean, index, jsonb, metadata, orbit, text, timestamp, timestamps, uniqueIndex } from './helpers.js'
 
 export const organizations = orbit.table(
   'organizations',


### PR DESCRIPTION
## Summary
Resolves all 8 must-fix items from the [core slice 1 review](docs/review/core-slice-1-review.md):

- **Security (critical):** Add `assertOrbitId` validation in `withTenantContext` — prevents empty/malformed orgId from being injected into `set_config`
- **Security (critical):** Remove redundant `finally` block in `withTenantContext` — transaction-local GUC auto-clears, `finally` masked errors on rollback
- **Auth contract:** Rename `permissions` → `scopes` in `ApiKeyAuthLookup` — aligns DTO with `apiKeys.scopes` table column and `OrbitAuthContext.scopes`
- **Schema correctness:** Add `$onUpdateFn` to `updatedAt`, remove `pgTable` re-export footgun, add `relationName` disambiguation, clean dead imports
- **Public API:** Export `ID_PREFIXES`/`OrbitIdKind` from `index.ts`

Both code review and security review agents verified all fixes with no new issues introduced.

## Test plan
- [x] `withTenantContext` rejects empty orgId before opening transaction
- [x] `withTenantContext` propagates errors cleanly with no masked cleanup errors
- [x] `execute` called exactly once (no redundant cleanup call)
- [x] `updatedAt` has `onUpdateFn` function
- [x] `pgTable` not re-exported from helpers
- [x] Lowercase ULID rejected by `assertOrbitId`
- [x] Successive `generateId` calls return unique values

🤖 Generated with [Claude Code](https://claude.com/claude-code)