### PR TITLE
feat(core): TransactionScope plumbing on StorageAdapter (PR 2 of 5)

### DIFF
--- a/packages/core/src/adapters/interface.ts
+++ b/packages/core/src/adapters/interface.ts
@@ -75,6 +75,32 @@ export interface SchemaSnapshot {
   tables: string[]
 }
 
+/**
+ * A capability object that lets service code run a callback inside a real
+ * database transaction while preserving tenant context.
+ *
+ * Implementors must:
+ *   1. Open a real transaction boundary (BEGIN/COMMIT or equivalent)
+ *   2. Set the auth context (RLS variables on Postgres) before invoking `fn`
+ *   3. Roll back on any thrown error
+ *
+ * Service code should obtain a `TransactionScope` from
+ * `adapter.beginTransaction()` and use it for any read-then-write or
+ * multi-step operation that must be atomic. Do NOT call `adapter.transaction`
+ * directly from service code — that path bypasses tenant-context propagation.
+ */
+export interface TransactionScope {
+  /**
+   * Execute `fn` inside a single transaction. The `txDb` parameter is a
+   * transaction-scoped `OrbitDatabase`; repositories that accept it (via a
+   * `withDatabase(txDb)` rebinding) will run their queries inside the same
+   * transaction. The `ctx` parameter carries the auth context — Postgres-family
+   * adapters use it to issue `set_config('app.current_org_id', …)` for the
+   * duration of the transaction.
+   */
+  run<T>(ctx: OrbitAuthContext, fn: (txDb: OrbitDatabase) => Promise<T>): Promise<T>
+}
+
 export interface StorageAdapter {
   readonly name: AdapterName
   readonly dialect: AdapterDialect
@@ -95,6 +121,12 @@ export interface StorageAdapter {
   runWithMigrationAuthority<T>(fn: (db: MigrationDatabase) => Promise<T>): Promise<T>
   lookupApiKeyForAuth(keyHash: string): Promise<ApiKeyAuthLookup | null>
   transaction<T>(fn: (tx: OrbitDatabase) => Promise<T>): Promise<T>
+  /**
+   * Return a `TransactionScope` that service code can use to run atomic
+   * operations with preserved tenant context. Prefer this over calling
+   * `transaction()` directly — the bare method does not carry auth context.
+   */
+  beginTransaction(): TransactionScope
   execute(statement: SQL): Promise<unknown>
   query<T extends Record<string, unknown>>(statement: SQL): Promise<T[]>
   withTenantContext<T>(context: OrbitAuthContext, fn: (db: OrbitDatabase) => Promise<T>): Promise<T>

--- a/packages/core/src/adapters/noop-transaction-scope.ts
+++ b/packages/core/src/adapters/noop-transaction-scope.ts
@@ -1,0 +1,23 @@
+import type { OrbitAuthContext, OrbitDatabase, TransactionScope } from './interface.js'
+
+/**
+ * A `TransactionScope` that does NOT open a real transaction. Intended for
+ * unit tests that pair the scope with in-memory repositories — those repos
+ * have no notion of a database, so the `txDb` parameter is meaningless.
+ *
+ * Tests that need to assert real transactional behavior (commit/rollback,
+ * race conditions, savepoint nesting) MUST use a real adapter's
+ * `beginTransaction()` instead. This helper is for service-logic unit tests
+ * only.
+ */
+export function createNoopTransactionScope(): TransactionScope {
+  return {
+    async run<T>(_ctx: OrbitAuthContext, fn: (txDb: OrbitDatabase) => Promise<T>): Promise<T> {
+      // The in-memory repos never read from txDb, so passing an empty object
+      // is safe. Any production repo that received this would crash on the
+      // first method call — which is the desired behavior if a misconfigured
+      // service somehow received the noop scope at runtime.
+      return fn({} as OrbitDatabase)
+    },
+  }
+}

--- a/packages/core/src/adapters/postgres/adapter.ts
+++ b/packages/core/src/adapters/postgres/adapter.ts
@@ -9,9 +9,11 @@ import {
   type OrbitDatabase,
   type SchemaSnapshot,
   type StorageAdapter,
+  type TransactionScope,
   type IUserResolver,
 } from '../interface.js'
-import { withTenantContext } from './tenant-context.js'
+import { buildSetTenantContextStatement, withTenantContext } from './tenant-context.js'
+import { assertOrbitId } from '../../ids/parse-id.js'
 import { fromPostgresDate, fromPostgresJson } from '../../repositories/postgres/shared.js'
 
 const defaultUserResolver: IUserResolver = {
@@ -101,6 +103,22 @@ export class PostgresStorageAdapter implements StorageAdapter {
 
   async transaction<T>(fn: (tx: OrbitDatabase) => Promise<T>): Promise<T> {
     return this.unsafeRawDatabase.transaction(fn)
+  }
+
+  beginTransaction(): TransactionScope {
+    const adapter = this
+    return {
+      async run<T>(ctx: OrbitAuthContext, fn: (txDb: OrbitDatabase) => Promise<T>): Promise<T> {
+        assertOrbitId(ctx.orgId, 'organization')
+        return adapter.unsafeRawDatabase.transaction(async (txDb) => {
+          // Set the tenant RLS context for the duration of this transaction
+          // (transaction-local — third arg `true` to set_config). All
+          // statements run on `txDb` see the same `app.current_org_id`.
+          await txDb.execute(buildSetTenantContextStatement(ctx.orgId))
+          return fn(txDb)
+        })
+      },
+    }
   }
 
   async execute(statement: Parameters<OrbitDatabase['execute']>[0]): Promise<unknown> {

--- a/packages/core/src/adapters/sqlite/adapter.ts
+++ b/packages/core/src/adapters/sqlite/adapter.ts
@@ -8,6 +8,7 @@ import {
   type OrbitDatabase,
   type SchemaSnapshot,
   type StorageAdapter,
+  type TransactionScope,
   type IUserResolver,
 } from '../interface.js'
 
@@ -86,6 +87,19 @@ export class SqliteStorageAdapter implements StorageAdapter {
 
   async transaction<T>(fn: (tx: OrbitDatabase) => Promise<T>): Promise<T> {
     return this.unsafeRawDatabase.transaction(fn)
+  }
+
+  beginTransaction(): TransactionScope {
+    const adapter = this
+    return {
+      async run<T>(ctx: OrbitAuthContext, fn: (txDb: OrbitDatabase) => Promise<T>): Promise<T> {
+        // SQLite has no RLS / set_config — the orgId is enforced at the
+        // repository layer by appending organization_id to every query.
+        // We still validate the orgId shape so a misformed ctx fails fast.
+        assertOrbitId(ctx.orgId, 'organization')
+        return adapter.unsafeRawDatabase.transaction(fn)
+      },
+    }
   }
 
   async execute(statement: Parameters<OrbitDatabase['execute']>[0]): Promise<unknown> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './adapters/interface.js'
+export * from './adapters/noop-transaction-scope.js'
 export * from './adapters/postgres/adapter.js'
 export * from './adapters/postgres/database.js'
 export * from './adapters/postgres/schema.js'

--- a/packages/core/src/services/index.test.ts
+++ b/packages/core/src/services/index.test.ts
@@ -104,6 +104,13 @@ function createTestAdapter(): StorageAdapter {
     async transaction(fn) {
       return runtimeDb.transaction(fn)
     },
+    beginTransaction() {
+      return {
+        async run(_ctx, fn) {
+          return runtimeDb.transaction(fn)
+        },
+      }
+    },
     async execute(statement) {
       return runtimeDb.execute(statement)
     },


### PR DESCRIPTION
## Summary

**PR 2 of 5** in the `api-sdk-execution` stacked split. This is the "hinge" PR — infrastructure-only, small, unblocks PR 3 and PR 4.

Single commit: `feat(core): introduce TransactionScope plumbing on StorageAdapter (T0a)` — adds a TransactionScope interface member to StorageAdapter with a noop default implementation. No service uses it yet; consumers land in PR 3 (T4/T5/T6/T7 transaction wrapping + Phase 2 gate fixes).

## Test plan

- [x] `pnpm -r typecheck` clean
- [x] `pnpm -r lint` clean
- [x] `pnpm -r test` passing

> **Note**: Replaces closed PR #19 (auto-closed when PR #22 squash-merged and deleted `pr-1-phase-0-1-fixes`). Branch rebased onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)