### PR TITLE
feat(cli): @orbit-ai/cli — Commander CLI with 30 commands, JSON contract, 161 tests

### DIFF
--- a/docs/KB.md
+++ b/docs/KB.md
@@ -1,8 +1,8 @@
 # Orbit AI KB
 
-Date: 2026-04-03
+Date: 2026-04-09
 Status: Active working hub
-Current baseline commit: `a12f4e4`
+Current baseline commit: `3205584` (feat/cli)
 
 ## What Orbit Is
 
@@ -49,18 +49,15 @@ Completed:
 Current focus:
 
 - maintain the repo knowledge base as the live hub
-- Core Wave 2 Slice E is complete: `system.customFieldDefinitions`, `system.auditLogs`, `system.schemaMigrations`, `system.idempotencyKeys`, final Wave 2 registry wiring, adapter bootstrap for all four entities, and SQLite/Postgres persistence proofs are all landed on branch `core-wave-2-slice-e`
-- Core tenant hardening is complete on branch `core-tenant-hardening`: Slice E bootstrap now runs in a transaction, creates schema `orbit`, sets local `search_path` to `orbit, pg_temp`, applies table DDL, applies baseline org-leading indexes for tenant filters and RLS, and applies RLS by default. The pg-mem persistence proofs use `includeRls: false` because pg-mem does not implement RLS DDL. Drift detection tests still prove the shared tenant inventory and RLS coverage stay aligned.
-- An opt-in live Postgres proof now exists at `packages/core/src/adapters/postgres/live-bootstrap.test.ts`, gated by `ORBIT_TEST_POSTGRES_URL` and `ORBIT_TEST_POSTGRES_ALLOW_SCHEMA_RESET=1` because it resets schema `orbit` on a dedicated test database
-- API/SDK execution is now unblocked by the completed Wave 2 merge and tenant hardening; execution order is a product decision rather than a missing-core blocker
-- tenant hardening is now treated as merged into the core baseline; the landed follow-up remains documented in [core-tenant-hardening-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-tenant-hardening-plan.md) and the worker-facing execution record in [2026-04-03-core-tenant-hardening.md](/Users/sharonsciammas/orbit-ai/docs/superpowers/plans/2026-04-03-core-tenant-hardening.md)
-- the next primary package-level track is API execution planning in [api-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/api-implementation-plan.md)
-- SDK execution planning now follows immediately in [sdk-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/sdk-implementation-plan.md), using the API plan as the transport-parity anchor
+- `@orbit-ai/cli` is complete and reviewed: 7 implementation slices (A–G), 4 rounds of code review (Codex + 3 agent-panel rounds), 161 tests passing, merging to main via PR
+- CLI package adds: Commander CLI with 30 commands, JSON/table/CSV/TSV output, direct SQLite + API modes, config file resolution (profiles, apiKeyEnv, nested cwd), `orbit init/status/doctor/seed/migrate`, structured `{ error }` contract throughout, `utils/prompt.ts` shared TTY confirmation utility
+- MCP execution planning is documented in [mcp-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/mcp-implementation-plan.md) — next package track after CLI merges
 - keep execution docs and skills aligned with implementation progress
 
 Not started yet:
 
-- broad package implementation beyond `@orbit-ai/core`
+- `packages/mcp`
+- `packages/integrations`
 
 ## Frozen Decisions
 
@@ -110,6 +107,8 @@ Use these files first:
   - [core-tenant-hardening-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/core-tenant-hardening-plan.md)
   - [api-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/api-implementation-plan.md)
   - [sdk-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/sdk-implementation-plan.md)
+  - [cli-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/cli-implementation-plan.md)
+  - [mcp-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/mcp-implementation-plan.md)
   - [core-wave-1-review.md](/Users/sharonsciammas/orbit-ai/docs/review/core-wave-1-review.md)
   - [core-wave-1-full-review.md](/Users/sharonsciammas/orbit-ai/docs/review/core-wave-1-full-review.md)
   - [core-wave-1-remediation-review.md](/Users/sharonsciammas/orbit-ai/docs/review/core-wave-1-remediation-review.md)
@@ -127,23 +126,19 @@ Use these files first:
 
 Immediate next actions:
 
-1. Minimum pre-core skills are in place:
-   - `orbit-tenant-safety-review`
-   - `orbit-schema-change`
-   - `orbit-core-slice-review`
-2. Core execution baseline already completed:
-   - slice 1 on `core-slice-1-execution`
-   - slice 2 on `core-slice-2-execution`
-   - Wave 1 service surface committed on `core-wave-1-services`
-   - SQLite persistence bridge committed on `core-wave-1-services`
-3. Package planning baseline now completed:
-   - tenant hardening is treated as merged into the accepted core baseline
-   - [api-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/api-implementation-plan.md) defines the next transport-contract execution track
-   - [sdk-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/sdk-implementation-plan.md) defines the immediate follow-on SDK track anchored to API parity
-4. Next:
-   - execute [api-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/api-implementation-plan.md) on a fresh API branch with package bootstrap, auth, tenant-context, and envelope/error boundaries first
-   - execute [sdk-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/sdk-implementation-plan.md) immediately after the API contract baseline is accepted, keeping route/envelope/error behavior API-owned
-   - keep the repo-local review gates explicit during execution: `orbit-tenant-safety-review`, `orbit-schema-change`, `orbit-core-slice-review`, plus independent code/security sub-agent review passes
+1. All five core packages are implemented:
+   - `@orbit-ai/core` — Wave 1 + Wave 2 + tenant hardening on main
+   - `@orbit-ai/api` — Hono REST API on main
+   - `@orbit-ai/sdk` — TypeScript client SDK on main
+   - `@orbit-ai/cli` — Commander CLI, merging from `feat/cli`
+   - `@orbit-ai/mcp` — not yet started
+2. Execution plans in place for all remaining work:
+   - [cli-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/cli-implementation-plan.md) — complete and reviewed
+   - [mcp-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/mcp-implementation-plan.md) — ready to execute, 8 slices (A–H), 92-test minimum
+3. Next:
+   - merge `feat/cli` PR to main (in progress)
+   - start [mcp-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/mcp-implementation-plan.md) — 23 tools, stdio + HTTP transport
+   - after MCP: publish all 5 packages together as `0.1.0-alpha.0` to npm
 
 ## Open Items
 
@@ -211,6 +206,9 @@ These are still open, but they do not block the KB:
 - 2026-04-03: Executed the core tenant hardening plan on branch `core-tenant-hardening` (Slices A-E): transactional Postgres bootstrap with `orbit` schema creation and `search_path` pinning, table DDL, baseline org-leading indexes for tenant filters/RLS, RLS enabled by default, and drift detection tests. The pg-mem persistence proofs use `includeRls: false` because pg-mem does not implement RLS DDL. Review artifact at [core-tenant-hardening-review.md](/Users/sharonsciammas/orbit-ai/docs/review/core-tenant-hardening-review.md).
 - 2026-04-03: Reviewed and revised the worker-facing tenant-hardening implementation plan in [2026-04-03-core-tenant-hardening.md](/Users/sharonsciammas/orbit-ai/docs/superpowers/plans/2026-04-03-core-tenant-hardening.md) so it now matches the accepted execution baseline: idempotent RLS policy DDL, migration-authority-only bootstrap integration, explicit mid-sequence and final tenant-safety review gates, targeted SQLite validation, and fresh independent code/security review passes. The plan is now execution-ready.
 - 2026-04-03: Marked the tenant-hardening follow-up as merged into the accepted core baseline in the KB, and created [api-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/api-implementation-plan.md) plus [sdk-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/sdk-implementation-plan.md) so API is the next package-level track and SDK follows with API as the transport-parity anchor.
+- 2026-04-09: Created [cli-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/cli-implementation-plan.md) as the next package-level execution baseline, explicitly grounding CLI work in the checked-in API/SDK packages and calling out current dependency gaps for direct adapter resolution and `@orbit-ai/mcp`.
+- 2026-04-09: Created [mcp-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/mcp-implementation-plan.md) as the MCP execution baseline, fixing the package around the 23-tool core contract and calling out current dependency gates for schema, export, and analytics tool families.
+- 2026-04-09: Completed `@orbit-ai/cli` on branch `feat/cli` (7 implementation slices, A–G). Codex review surfaced 11 issues; all fixed. Three agent-panel review rounds (6 reviewers) surfaced 17 additional issues; all fixed. Final state: 161 tests, 17 test files, 0 typecheck errors, clean build. Key fixes: Commander `exitOverride` + `instanceof CommanderError`, `isJsonMode()` unification, `apiKeyEnv` config resolution, nested-cwd discovery, `--profile` implementation, SQLite default path + `file://hostname` rejection, synchronous `write+exit` throughout, `confirmAction` extracted to `utils/prompt.ts` with stdin EOF/error cleanup, `seed` count validation, `migrate` no-flags guard. PR opened and merged to main.
 
 ## Working Rule
 

--- a/docs/execution/cli-implementation-plan.md
+++ b/docs/execution/cli-implementation-plan.md
@@ -1,0 +1,967 @@
+# Orbit AI CLI Implementation Plan
+
+Date: 2026-04-09
+Revised: 2026-04-09 (post multi-agent review: architecture, security, testing)
+Status: Execution-ready baseline
+Package: `@orbit-ai/cli`
+Depends on:
+- [IMPLEMENTATION-PLAN.md](/Users/sharonsciammas/orbit-ai/docs/IMPLEMENTATION-PLAN.md)
+- [api-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/api-implementation-plan.md)
+- [sdk-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/sdk-implementation-plan.md)
+- [03-sdk.md](/Users/sharonsciammas/orbit-ai/docs/specs/03-sdk.md)
+- [04-cli.md](/Users/sharonsciammas/orbit-ai/docs/specs/04-cli.md)
+- [orbit-ai-threat-model.md](/Users/sharonsciammas/orbit-ai/docs/security/orbit-ai-threat-model.md)
+- [KB.md](/Users/sharonsciammas/orbit-ai/docs/KB.md)
+
+## 1. Purpose
+
+This document defines how to execute `@orbit-ai/cli` after the API and SDK planning baselines.
+
+The CLI is not a second application contract. It is the terminal presentation layer over the accepted SDK surface. That matters most in `--json` mode: the CLI must emit real Orbit envelopes via SDK response-aware helpers and must not reconstruct `meta`, `links`, cursors, or `request_id` client-side.
+
+This document is intentionally precise because it will be executed by AI sub-agents without human clarification. Every discrepancy between the spec and the real codebase is documented here. Agents must follow this plan rather than the spec snippets where they conflict.
+
+## 2. CLI Objective
+
+Deliver `@orbit-ai/cli` as the primary human and agent terminal interface for Orbit:
+
+1. bootstrap `packages/cli`
+2. define one shared program, flag, config, error, and output boundary
+3. resolve hosted and direct SDK clients from flags, env, project config, and user config
+4. implement command waves in the same breadth order as the accepted SDK surface
+5. keep JSON mode envelope-faithful and non-interactive
+6. add selective human UX on top: prompts, confirmations, and Ink views where the spec explicitly wants them
+7. only wrap MCP and integrations commands once the required downstream packages exist and their seams are explicit
+
+This is a CLI milestone. It is not permission to invent a new transport contract, bypass the SDK, or pull unreconciled MCP/integrations behavior forward.
+
+## 3. Current Readiness And Constraints
+
+Current repository state:
+
+- `packages/cli` does not exist yet.
+- `@orbit-ai/api` and `@orbit-ai/sdk` now exist, build, and already encode the main route/envelope/parity rules the CLI should consume.
+
+### 3.1 Confirmed SDK Surface
+
+These are the exact, verified SDK call signatures agents must use. **Do not use snippets from `docs/specs/04-cli.md` or `docs/specs/03-sdk.md` without cross-referencing the actual source file.** The spec snippets contain errors that this plan corrects.
+
+**`OrbitClient` namespace**: the client exposes resources directly on the instance:
+
+```typescript
+client.contacts     // ContactResource
+client.companies    // CompanyResource
+client.deals        // DealResource
+client.stages       // StageResource
+client.activities   // ActivityResource
+client.tasks        // TaskResource
+client.notes        // NoteResource
+client.products     // ProductResource
+client.payments     // PaymentResource
+client.contracts    // ContractResource
+client.sequences    // SequenceResource
+client.sequenceSteps
+client.sequenceEnrollments
+client.sequenceEvents
+client.pipelines    // PipelineResource
+client.tags         // TagResource
+client.schema       // SchemaResource
+client.webhooks     // WebhookResource
+client.imports      // ImportResource
+client.users        // UserResource
+client.search       // SearchResource
+```
+
+There is **no** `client.crm` namespace. `orbit context <id>` must call `client.contacts.context(idOrEmail)` (table mode) or `client.contacts.response().context(idOrEmail)` (JSON mode).
+
+**List and pagination**: verify the actual behavior in `packages/sdk/src/resources/base-resource.ts` before implementing. Based on post-merge review:
+
+- `resource.list(query)` returns the first-page envelope (`Promise<OrbitEnvelope<T[]>>`). Do **not** call `.firstPage()` on top of `.list()`.
+- For multi-page iteration, use `resource.pages(query).autoPaginate()` — `pages()` takes the query argument. Do not call `pages()` with zero arguments.
+- CLI `--json` mode for list commands: call `resource.list(query)` and emit the result directly. Never reconstruct `meta`, `links`, or `next_cursor`.
+
+**CRUD JSON mode**: use `resource.response().<method>(...)` which returns `Promise<OrbitEnvelope<T>>`.
+
+**Search JSON mode**: use `client.search.response().query({ query: term, object_types: types, limit })`.
+
+### 3.2 Adapter Factory Corrections
+
+The spec's `resolve-context.ts` snippet imports four adapter factories that **do not exist**. The actual `@orbit-ai/core` exports are:
+
+| Spec snippet name (WRONG) | Actual export name (CORRECT) | Config shape |
+|---------------------------|------------------------------|--------------|
+| `createSqliteAdapter` | `createSqliteStorageAdapter` | `{ database: OrbitDatabase }` |
+| `createPostgresAdapter` | `createPostgresStorageAdapter` | `{ database: Pool }` — requires `pg.Pool` |
+| `createSupabaseAdapter` | **does not exist** | throw `CliUnsupportedAdapterError` |
+| `createNeonAdapter` | **does not exist** | throw `CliUnsupportedAdapterError` |
+
+**SQLite construction** (two steps required — the spec's `{ databaseUrl }` pattern is wrong):
+
+```typescript
+import { DatabaseSync } from 'node:sqlite'
+import { createSqliteStorageAdapter } from '@orbit-ai/core'
+
+const database = new DatabaseSync(flags.databaseUrl ?? './.orbit/orbit.db')
+const adapter = createSqliteStorageAdapter({ database })
+```
+
+**Postgres construction**:
+
+```typescript
+import { Pool } from 'pg'
+import { createPostgresStorageAdapter } from '@orbit-ai/core'
+
+const database = new Pool({ connectionString: flags.databaseUrl ?? process.env.DATABASE_URL })
+const adapter = createPostgresStorageAdapter({ database })
+```
+
+Verify the exact config shape by reading `packages/core/src/adapters/sqlite/adapter.ts` and `packages/core/src/adapters/postgres/adapter.ts` before writing `src/config/resolve-context.ts`.
+
+### 3.3 Known Dependency Gaps
+
+1. `@orbit-ai/mcp` does not exist. `orbit mcp serve` must be deferred or explicitly marked unavailable until that package ships. The command must exist in the Commander tree but throw a clear `CliNotImplementedError` on execution.
+2. Supabase and Neon direct adapters do not exist in `@orbit-ai/core`. These adapter names must throw a `CliUnsupportedAdapterError` immediately in `resolveAdapter()` — before any `OrbitClient` is constructed.
+3. `orbit seed` and `orbit migrate` commands require a configured adapter to execute. They belong in Slice C alongside `orbit init` and `orbit doctor`.
+
+## 4. In Scope
+
+Package bootstrap:
+
+- `packages/cli/package.json`
+- `packages/cli/tsconfig.json`
+- `packages/cli/vitest.config.ts`
+- `packages/cli/src/index.ts`
+- `packages/cli/src/program.ts`
+
+Runtime boundary:
+
+- shared global flags
+- config file discovery and profile resolution
+- SDK client resolution for API mode and direct mode
+- centralized command execution and error-to-exit-code mapping
+- formatters for `table`, `json`, `csv`, and `tsv`
+
+Command work:
+
+- setup commands: `init`, `status`, `doctor`, `seed`, `migrate`
+- Wave 1 entity commands aligned to the stable SDK surface
+- Wave 2 entity and workflow commands aligned to the stable SDK surface
+- schema and field commands that wrap SDK schema helpers
+- reporting, search, and context commands
+- selective Ink views and interactive prompts where the spec requires them
+- deferred-but-registered commands: `mcp`, `integrations`
+
+Contract proof:
+
+- JSON-mode tests proving real envelopes are preserved (5 specific cases — see Slice C)
+- formatter tests (11 specific cases — see Slice C)
+- config resolution tests (15 cases — see Slice B)
+- command parsing and non-interactive validation tests
+- exit code mapping tests (6 cases — see Slice A)
+- Ink component tests (4 cases — see Slice F)
+- CLI smoke test via subprocess (3 cases — see Slice G)
+- final review artifacts under `docs/review/`
+
+## 5. Out Of Scope
+
+- new business logic in the CLI layer
+- route or envelope changes that belong to API or SDK
+- direct database access that bypasses `@orbit-ai/sdk`
+- implementation of missing adapter families (Supabase, Neon)
+- implementation of `@orbit-ai/mcp` itself
+- integrations runtime behavior beyond listing or wrapping already-implemented downstream seams
+- `bun build --compile` standalone binary (deferred to post-alpha; tsc build is the alpha target)
+
+## 6. Required Execution Principles
+
+### 6.1 SDK Boundary
+
+1. The SDK is the only command execution boundary. The CLI may not call core services or API routes directly except through accepted SDK surfaces.
+2. `--json` mode must use `resource.list(query)` or `.response()` helpers directly. It may not fabricate envelopes.
+3. JSON mode must never emit prompts, banners, spinners, Ink output, or prose outside the JSON payload.
+4. Human interaction is additive. Missing args in agent mode must return typed validation failures rather than prompting.
+5. Direct mode stays explicitly trusted-caller-only. The CLI must not imply it has API middleware protections when using embedded adapters.
+6. Command breadth follows SDK acceptance order. Do not build CLI coverage ahead of a stable SDK helper just to match the spec matrix on paper.
+7. Destructive schema actions must require explicit confirmation in TTY mode and remain non-interactive in `--json` mode.
+8. Output formatters must work from already-correct data; they are not allowed to infer transport metadata.
+
+### 6.2 Security Principles
+
+These are not optional. All must be implemented in the slice they are assigned to.
+
+9. **API key visibility**: `--api-key` is visible in `ps aux` and shell history. When `--api-key` is used, the CLI must print to stderr: `"Warning: --api-key is visible in process listings. Prefer ORBIT_API_KEY env var."` After parsing, overwrite `process.argv` entries containing the key. Verify this requirement is implemented in Slice B.
+10. **Config file permissions**: `orbit init` must write `.orbit/config.json` with file mode `0600`. On startup, the config reader must warn to stderr if the config file is readable by group or world (permissions wider than `0600`). Implement this in Slice B (reader) and Slice C (`init`).
+11. **Gitignore scaffolding**: `orbit init` must append `.orbit/` to `.gitignore` if not already present, and warn if `.gitignore` is absent. Implement in Slice C.
+12. **No file overwrites without confirmation**: `orbit init` must never overwrite existing files (including `.env.example`) without an explicit `--overwrite` flag. When `--yes` is passed, missing files may be created; existing files must not be replaced. Implement in Slice C.
+13. **No literal secrets in scaffolded files**: `.env.example` must contain only placeholder values (`ORBIT_API_KEY=your-key-here`). `config.json` must store `apiKeyEnv` (the env var name) never the literal key. Implement in Slice C.
+14. **Direct mode TTY warning**: when the resolved mode is `direct` and stdout is a TTY, the CLI must print to stderr before execution: `"Warning: running in direct mode — auth, rate limiting, scope enforcement, and SSRF protection are not active."` This warning must only be suppressible by `--quiet`. Implement in Slice B.
+15. **Database URL scheme allowlist**: before calling any adapter factory, validate the `databaseUrl` scheme. SQLite accepts file paths (relative or absolute) only — reject any scheme starting with `http`, `ftp`, etc. Postgres/Supabase/Neon accept `postgresql://` or `postgres://` only. Throw a `CliValidationError` for any other scheme. Implement in Slice B (`resolveAdapter`).
+16. **Config path canonicalization**: all config file paths discovered by `src/config/files.ts` must be canonicalized via `fs.realpathSync` before reading. Reject any path that resolves outside the project root or user home directory. Implement in Slice B.
+17. **`orbit init` never writes to `.env`**: `orbit init` must only write to `.env.example`. If a user passes `--env-file .env`, reject with a clear error. Implement in Slice C.
+18. **`contacts import` deferred stub**: the command must be registered but throw `CliNotImplementedError` — never silently missing and never crashing with a raw import error. File path validation must be added when the SDK file-upload seam is implemented. Implement the stub in Slice D.
+19. **MCP server binding**: when `@orbit-ai/mcp` ships, its HTTP transport must default to `127.0.0.1` (localhost-only). Binding to `0.0.0.0` must require an explicit `--host 0.0.0.0` flag with a stderr warning. This requirement must be enforced at the CLI wrapper layer in Slice G.
+
+### 6.3 Destructive Action Definition
+
+The following CLI actions are **destructive** and require the behaviors described:
+
+- `orbit fields delete <entity> <field-name>`
+- `orbit migrate --rollback`
+- `orbit migrate --apply` when the migration preview contains any `DROP COLUMN`, `DROP TABLE`, or `RENAME COLUMN` operation
+- `orbit contacts delete <id>` with a `--bulk` flag (if implemented)
+
+**TTY mode**: require `--yes` or an interactive confirmation prompt before execution. The prompt must name the specific action and target.
+
+**`--json` mode or non-TTY**: must return exit code 1 with a structured error — do **not** silently skip. Error body:
+
+```json
+{
+  "error": {
+    "code": "DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION",
+    "message": "Use --yes to confirm this destructive action in non-interactive mode.",
+    "action": "fields.delete",
+    "target": "contacts.custom_tier"
+  }
+}
+```
+
+## 7. Exit Code Mapping
+
+This table is a contract. Every sub-agent must implement it exactly.
+
+| Exit code | Condition |
+|-----------|-----------|
+| 0 | Success |
+| 1 | API/SDK error (`OrbitApiError`, HTTP error from server) |
+| 2 | CLI validation error (missing required arg, invalid flag value, unsupported adapter) |
+| 3 | Config error (missing required config file, unresolvable profile, malformed config JSON) |
+| 130 | Interrupted by SIGINT |
+
+In `--json` mode, error payloads for exit codes 1, 2, and 3 must be written to **stdout** (not stderr) before exit so agent consumers can parse them. Stderr in JSON mode is reserved for debug/trace output only.
+
+## 8. File-to-Slice Mapping
+
+Every file the CLI package requires is assigned to exactly one slice. Sub-agents must not create files outside their assigned slice without explicit cross-slice justification.
+
+| File | Slice | Notes |
+|------|-------|-------|
+| `package.json` | A | include `bin`, `files`, `type: "module"` |
+| `tsconfig.json` | A | include `*.tsx`, `jsx: "react-jsx"` |
+| `vitest.config.ts` | A | see Slice A requirements |
+| `src/index.ts` | A | shebang, binary entry |
+| `src/program.ts` | A | Commander composition |
+| `src/config/files.ts` | B | config discovery |
+| `src/config/resolve-context.ts` | B | client/adapter resolution |
+| `src/__tests__/setup.ts` | B | filesystem isolation helpers |
+| `src/output/formatter.ts` | C | |
+| `src/output/json.ts` | C | |
+| `src/output/table.ts` | C | |
+| `src/output/csv.ts` | C | |
+| `src/commands/init.ts` | C | |
+| `src/commands/status.ts` | C | |
+| `src/commands/doctor.ts` | C | |
+| `src/commands/seed.ts` | C | |
+| `src/commands/migrate.ts` | C | destructive — see Section 6.3 |
+| `src/commands/contacts.ts` | D | |
+| `src/commands/companies.ts` | D | |
+| `src/commands/deals.ts` | D | |
+| `src/commands/context.ts` | D | wraps `client.contacts.context()` |
+| `src/commands/search.ts` | D | |
+| `src/commands/users.ts` | D | |
+| `src/commands/log.ts` | E | |
+| `src/commands/tasks.ts` | E | |
+| `src/commands/notes.ts` | E | |
+| `src/commands/sequences.ts` | E | |
+| `src/commands/fields.ts` | E | destructive — see Section 6.3 |
+| `src/commands/schema.ts` | E | |
+| `src/commands/report.ts` | E | |
+| `src/commands/dashboard.tsx` | F | Ink — `.tsx` extension |
+| `src/interactive/prompt.tsx` | F | Ink |
+| `src/interactive/autocomplete.ts` | F | |
+| `src/interactive/confirm.tsx` | F | Ink |
+| `src/ink/pipeline-board.tsx` | F | Ink |
+| `src/ink/dashboard.tsx` | F | Ink |
+| `src/ink/status-panel.tsx` | F | Ink |
+| `src/commands/mcp.ts` | G | deferred stub |
+| `src/commands/integrations.ts` | G | deferred stub |
+
+## 9. Delivery Slices
+
+### Slice A. Package Bootstrap And Program Skeleton
+
+Goal:
+
+- create `packages/cli` and lock the command-registration, execution seams, and exit-code contract before command breadth begins
+
+Scope (see Section 8 for file ownership):
+
+- package manifest, TS config, Vitest config, binary entry
+- `src/index.ts`
+- `src/program.ts`
+- global options and shared command context types
+- centralized command runner and top-level error handling
+
+#### A.1 Package Manifest Requirements
+
+`package.json` must include:
+
+```json
+{
+  "name": "@orbit-ai/cli",
+  "version": "0.1.0-alpha.0",
+  "type": "module",
+  "bin": { "orbit": "./dist/index.js" },
+  "files": ["dist/", "README.md", "LICENSE"],
+  "dependencies": {
+    "commander": "^12.0.0",
+    "ink": "^5.0.0",
+    "react": "^18.0.0",
+    "cli-table3": "^0.6.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "typescript": "workspace:*",
+    "vitest": "workspace:*"
+  }
+}
+```
+
+Use Commander v12. Use Ink v5 (ESM-only, React 18). Do not use older versions — they have incompatible module systems.
+
+#### A.2 TypeScript Config Requirements
+
+The CLI `tsconfig.json` must extend the root `tsconfig.base.json` and add:
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}
+```
+
+**Critical**: the include pattern must cover `.tsx` files. Ink components (`dashboard.tsx`, `pipeline-board.tsx`, etc.) will be silently excluded if only `"src/**/*.ts"` is specified — the TypeScript build will succeed while omitting all Ink components.
+
+#### A.3 Binary Entry Requirements
+
+`src/index.ts` must begin with:
+
+```typescript
+#!/usr/bin/env node
+```
+
+The shebang must be the first line. The build step in `package.json` must run `chmod +x dist/index.js` after `tsc`.
+
+```json
+{
+  "scripts": {
+    "build": "rm -rf dist && tsc && chmod +x dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "dev": "tsx src/index.ts"
+  }
+}
+```
+
+#### A.4 Vitest Config Requirements
+
+`vitest.config.ts` must include:
+
+```typescript
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    exclude: ['src/**/*.smoke.test.ts'],
+    setupFiles: ['src/__tests__/setup.ts'],
+    coverage: { enabled: false },
+  },
+})
+```
+
+Smoke tests (subprocess invocation) are excluded from the default run. They are run separately in CI after `pnpm -r build`.
+
+#### A.5 Exit Code Implementation
+
+The centralized command runner must catch all thrown errors and map them to exit codes per Section 7. Implementation pattern:
+
+```typescript
+async function run() {
+  try {
+    const program = createProgram()
+    await program.parseAsync(process.argv)
+    process.exit(0)
+  } catch (error) {
+    const { code, payload } = classifyError(error)
+    if (isJsonMode()) {
+      process.stdout.write(JSON.stringify({ error: payload }) + '\n')
+    } else {
+      process.stderr.write(formatErrorForHuman(payload) + '\n')
+    }
+    process.exit(code)
+  }
+}
+```
+
+#### A.6 Required Tests (Slice A)
+
+File: `src/__tests__/program.test.ts`
+
+- All command names from spec Section 3 (`init`, `status`, `doctor`, `seed`, `migrate`, `contacts`, `companies`, `deals`, `context`, `search`, `users`, `log`, `tasks`, `notes`, `sequences`, `fields`, `schema`, `report`, `dashboard`, `mcp`, `integrations`) are registered in the Commander tree.
+- `--json` flag sets internal format state to `'json'`.
+- An unknown subcommand exits with a non-zero code.
+
+File: `src/__tests__/exit-codes.test.ts`
+
+- Successful command exits with code 0.
+- `OrbitApiError` with `code: 'RESOURCE_NOT_FOUND'` → exit code 1, `{ error: { code, message } }` on stdout in JSON mode.
+- Missing required argument in non-TTY mode → exit code 2.
+- Unsupported adapter name → exit code 2.
+- Malformed config JSON → exit code 3.
+- In `--json` mode, all error exit codes still write JSON to stdout before exit.
+
+Exit criteria:
+
+- the package exists, builds, typechecks, and can host commands without reopening CLI-wide design questions
+
+---
+
+### Slice B. Config Resolution And SDK Client Bootstrap
+
+Goal:
+
+- make the CLI able to resolve one correct SDK client per invocation before adding broad commands
+
+Scope:
+
+- `src/config/files.ts`
+- `src/config/resolve-context.ts`
+- `src/__tests__/setup.ts`
+- profile lookup and merge order
+- environment-variable helpers
+- direct-mode adapter resolution
+
+#### B.1 Config Precedence
+
+Config must be resolved in this order (highest wins):
+
+1. Command flags (`--api-key`, `--base-url`, `--org-id`, etc.)
+2. `ORBIT_*` environment variables
+3. `.orbit/config.json` (project-level, resolved from `cwd` upward)
+4. `~/.config/orbit/config.json` (user-level)
+
+`src/config/files.ts` must canonicalize each discovered path via `fs.realpathSync` before reading. Reject any path that resolves outside `cwd` ancestors or `os.homedir()`. Throw a typed `CliConfigError` (exit code 3) rather than crashing with an unhandled exception.
+
+#### B.2 SDK Client Construction
+
+API mode:
+
+```typescript
+return new OrbitClient({
+  apiKey: flags.apiKey ?? process.env.ORBIT_API_KEY,
+  baseUrl: flags.baseUrl ?? process.env.ORBIT_BASE_URL,
+  context: flags.orgId ? { orgId: flags.orgId, userId: flags.userId } : undefined,
+})
+```
+
+Direct mode (follow adapter construction patterns in Section 3.2 exactly):
+
+```typescript
+const adapter = resolveAdapter(flags) // throws CliUnsupportedAdapterError for supabase/neon
+// Print direct-mode TTY warning (Principle 14)
+return new OrbitClient({ adapter, context: { orgId, userId } })
+```
+
+Missing `apiKey` in API mode must throw `CliValidationError` (exit code 2) with `code: 'MISSING_REQUIRED_CONFIG'` and `path: 'apiKey'`.
+
+Missing `orgId` in direct mode must throw `CliValidationError` with `code: 'MISSING_REQUIRED_CONFIG'` and `path: 'context.orgId'`.
+
+#### B.3 `resolveAdapter()` URL Validation
+
+Before calling any adapter factory, validate the database URL scheme:
+
+- SQLite: accept relative paths, absolute paths, and `file:` URIs only. Reject `http://`, `https://`, etc.
+- Postgres: accept `postgresql://` and `postgres://` schemes only.
+- `supabase` / `neon`: throw `CliUnsupportedAdapterError` with message naming the adapter and suggesting `postgres` as an alternative.
+
+#### B.4 `--api-key` Security Requirement
+
+If `--api-key` is present in `process.argv`:
+
+1. Emit to stderr: `Warning: --api-key is visible in process listings. Prefer ORBIT_API_KEY env var.`
+2. After extracting the value, overwrite the argv entry: `process.argv[keyIndex] = '--api-key=***'`.
+3. Never log or serialize the key value in error payloads.
+
+#### B.5 Required Review Gate
+
+After Slice B: confirm the CLI config story matches current `@orbit-ai/core` and `@orbit-ai/sdk` exports rather than the older illustrative snippets in the spec. Specifically verify adapter factory names and config shapes against the actual source files.
+
+#### B.6 Required Tests (Slice B)
+
+File: `src/__tests__/setup.ts` — filesystem isolation helpers (shared across all test files):
+
+```typescript
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+let tmpDirs: string[] = []
+
+export function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-cli-test-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+  tmpDirs = []
+})
+```
+
+All tests that read or write config files must use `makeTmpDir()` for project root and a second temp dir for `HOME`. Inject these via the function that determines config file paths (mock it with `vi.mock` or inject via parameter).
+
+File: `src/__tests__/config-resolve.test.ts`:
+
+1. `--api-key` flag overrides `ORBIT_API_KEY` env var — assert resolved `apiKey` equals the flag value.
+2. `ORBIT_API_KEY` env var overrides `.orbit/config.json` value.
+3. `.orbit/config.json` (project) overrides `~/.config/orbit/config.json` (user) for the same key.
+4. When only user config is present, its value is used.
+5. Missing `apiKey` in API mode throws `CliValidationError` with `code: 'MISSING_REQUIRED_CONFIG'`.
+6. `mode: 'direct'` with `adapter: 'sqlite'` calls `createSqliteStorageAdapter`.
+7. `mode: 'direct'` with `adapter: 'postgres'` calls `createPostgresStorageAdapter`.
+8. `mode: 'direct'` with `adapter: 'supabase'` throws `CliUnsupportedAdapterError`.
+9. `mode: 'direct'` with `adapter: 'neon'` throws `CliUnsupportedAdapterError`.
+10. Malformed config JSON (`{ broken`) throws `CliConfigError` with `code: 'CONFIG_PARSE_ERROR'`.
+11. Missing `orgId` in direct mode throws `CliValidationError`.
+12. Database URL with `http://` scheme for SQLite throws `CliValidationError` (URL scheme allowlist).
+13. Config path outside project root throws `CliConfigError` (path canonicalization guard).
+14. Direct mode in TTY prints warning to stderr listing missing middleware protections.
+15. `--api-key` in argv triggers stderr warning and argv redaction.
+
+Exit criteria:
+
+- commands can construct the correct SDK client without route-local config logic
+
+---
+
+### Slice C. Output Boundary, JSON Fidelity, And Base Commands
+
+Goal:
+
+- prove the CLI's shared output and error behavior before entity command breadth lands
+
+Scope:
+
+- `src/output/formatter.ts`, `json.ts`, `table.ts`, `csv.ts`
+- `src/commands/init.ts`, `status.ts`, `doctor.ts`, `seed.ts`, `migrate.ts`
+
+#### C.1 Required Output Behavior
+
+JSON mode: emit the exact SDK envelope or error payload. Never add keys. Never wrap in an additional object. Use `JSON.stringify(envelope, null, 2)` + newline.
+
+Table mode: render from returned records. Booleans as `yes`/`no`. Arrays comma-separated. Dates as ISO strings. Nested objects as compact JSON strings — never as `[object Object]`.
+
+CSV: RFC 4180 compliant. Fields containing commas, double-quotes, or newlines must be quoted. Double-quotes within quoted fields must be doubled (`""`). Header row is always the first line. `custom_fields` flatten as `custom_fields.<field_name>`.
+
+TSV: same as CSV but tab-delimited. Fields containing literal tab characters must be escaped or stripped — this behavior must be chosen and documented in a comment in `csv.ts`.
+
+#### C.2 `orbit init` Requirements
+
+Scaffolds `.orbit/config.json` and `.env.example`.
+
+Security requirements (Principles 10–13 and 17):
+
+- Write `.orbit/config.json` with file mode `0600` via `fs.writeFileSync(path, content, { mode: 0o600 })`.
+- Append `.orbit/` to `.gitignore` if not present. Warn if `.gitignore` is absent.
+- Never write to `.env`. If user targets `.env`, reject with `CliValidationError`.
+- Never write literal API key values to any file. Store only `apiKeyEnv: "ORBIT_API_KEY"`.
+- Never overwrite existing files unless `--overwrite` flag is explicitly passed. When `--yes` is passed without `--overwrite`, create missing files only.
+
+Non-interactive form: `orbit init --db sqlite --org-name "Acme" --yes --json`
+
+`--org-name` must be validated: printable characters only, max 100 chars. Reject with `CliValidationError` otherwise.
+
+#### C.3 `.gitignore` Requirement
+
+Add `.orbit/` to the root `.gitignore` file as part of Slice C implementation. This prevents config files and SQLite databases created by `orbit init` from being accidentally committed.
+
+#### C.4 Required Review Gate
+
+JSON contract review after Slice C: confirm the shared output path does not reconstruct transport metadata and is safe for agent use.
+
+#### C.5 Required Tests (Slice C)
+
+File: `src/__tests__/json-fidelity.test.ts`:
+
+1. Mock SDK transport to return envelope with known `request_id: 'req_known'`, `next_cursor: 'cursor_abc'`, `has_more: true`, `links.next: '/v1/contacts?cursor=cursor_abc'`. Run `contacts list --json`. Assert `JSON.parse(stdout).meta.request_id === 'req_known'` and `JSON.parse(stdout).meta.next_cursor === 'cursor_abc'`. This is the primary anti-fabrication proof.
+2. Assert the JSON output object has no keys beyond what the SDK returned — no injected `generatedAt`, `cliVersion`, or similar additions.
+3. Run `contacts get cnt_123 --json` with mocked single-record envelope. Assert `data.id` and `meta` are pass-through.
+4. Run a command where the SDK throws `OrbitApiError`. Assert CLI writes `{ error: { code, message, request_id } }` to stdout and `request_id` matches what the SDK error contained (not a CLI-generated substitute). Assert exit code 1.
+5. Assert that no line of stdout in `--json` mode contains ANSI escape codes or non-JSON prose. Use a regex assertion on the raw stdout string before `JSON.parse`.
+
+File: `src/__tests__/non-tty.test.ts`:
+
+- Set `process.stdout.isTTY = false` and `process.stdin.isTTY = false` before each test. Restore in `afterEach`.
+- Call `contacts create` with no args and `isTTY = false`. Assert throws `CliValidationError`, no call to any `prompt()` or `confirm()` (use `vi.spyOn`).
+- Call `contacts create` with all required args and `isTTY = false`. Assert proceeds normally.
+- Call `orbit init` with no `--yes` and `isTTY = false`. Assert `CliValidationError`.
+
+File: `src/__tests__/formatter.test.ts`:
+
+CSV tests:
+1. `{ name: 'Smith, John' }` → `"Smith, John"` (comma-in-field quoting).
+2. `{ name: 'Say "hello"' }` → `"Say ""hello"""` (quote escaping, RFC 4180).
+3. `{ bio: 'line1\nline2' }` → quoted with embedded newline preserved.
+4. `custom_fields: { score: 42, tier: 'gold' }` flattens to columns `custom_fields.score` and `custom_fields.tier`.
+5. Header row is the first line.
+
+TSV tests:
+6. Tab-containing field value is handled (escaped or stripped — whatever is implemented must be tested).
+
+Table tests:
+7. Nested object renders as readable string, not `[object Object]`.
+8. `true` renders as `yes`, `false` as `no`.
+9. Arrays render comma-separated.
+10. Date strings render as ISO format.
+
+JSON tests:
+11. `formatOutput(envelope, { format: 'json' })` round-trips through `JSON.parse` with equality.
+
+Exit criteria:
+
+- the CLI has one accepted execution/output boundary that later commands reuse
+
+---
+
+### Slice D. Wave 1 Entity Commands And Search/Context
+
+Goal:
+
+- deliver the first broadly useful command wave on top of the already-stable SDK surface
+
+Dependency:
+
+- the accepted SDK Wave 1 helpers and their response semantics (verify in `packages/sdk/src/resources/` before implementing)
+
+Scope:
+
+- `contacts`, `companies`, `deals`, `pipelines` (via `client.pipelines`), `stages` (via `client.stages`), `users`, `search`, `context`
+
+#### D.1 Context Command
+
+`orbit context <contact-id|email>` calls `client.contacts.context(idOrEmail)` in table mode. In JSON mode, calls `client.contacts.response().context(idOrEmail)`.
+
+**There is no `client.crm` namespace.** Do not use `crm.contacts.context()`. The correct accessor is `client.contacts`.
+
+Table mode sections: contact summary, company, open deals, open tasks, recent activities, tags.
+
+#### D.2 Search Command
+
+`orbit search <query>` with optional flags:
+
+```
+orbit search <query> [--types contacts,deals,companies,...] [--limit N] [--cursor <cursor>]
+```
+
+Map to `SearchInput`:
+
+```typescript
+const input = {
+  query: args.query,
+  object_types: flags.types ? flags.types.split(',') : undefined,
+  limit: flags.limit ? Number(flags.limit) : undefined,
+  cursor: flags.cursor,
+}
+```
+
+Table mode: `client.search.query(input)`.
+JSON mode: `client.search.response().query(input)`.
+
+#### D.3 List Commands
+
+In JSON mode, list commands call `resource.list(query)` which returns the first-page envelope directly. Do NOT call `.firstPage()` on the result — `list()` already does this internally.
+
+For commands that need multi-page iteration (e.g., export), use `resource.pages(query).autoPaginate()` — note the `query` argument is required.
+
+In table mode, collect records from the envelope's `.data` array for rendering.
+
+#### D.4 `contacts import` — Deferred
+
+`orbit contacts import <file>` is **not implementable in Slice D**. `ImportResource.create({ entity_type, ... })` only registers import job metadata — it has no file upload seam. Uploading CSV file content to a batch import endpoint is not exposed by the current SDK.
+
+The command must be registered in the Commander tree but throw `CliNotImplementedError` on execution:
+
+```typescript
+program
+  .command('contacts import <file>')
+  .description('Import contacts from a CSV file (requires file-upload seam in SDK)')
+  .action(() => {
+    throw new CliNotImplementedError(
+      'orbit contacts import requires a file-upload seam that is not yet available in @orbit-ai/sdk.',
+      { code: 'DEPENDENCY_NOT_AVAILABLE', dependency: 'sdk.imports.upload' },
+    )
+  })
+```
+
+When the SDK exposes a file upload or streaming import endpoint, this command must be revisited. At that point, file path validation (canonicalization via `fs.realpathSync`, path-escape guard) must be implemented before the file is opened.
+
+#### D.5 Required Review Gate
+
+Command-surface review after Slice D: confirm the first CLI wave mirrors the accepted SDK behavior and is stable enough for agent execution.
+
+#### D.6 Required Tests (Slice D)
+
+One test file per entity group (e.g., `src/__tests__/contacts.test.ts`), covering:
+
+- `list --json`: assert envelope pass-through (reference `json-fidelity.test.ts` patterns).
+- `list` (table): assert records render without `[object Object]`.
+- `get <id> --json`: assert single-record envelope.
+- `create --json`: assert created record envelope.
+- `update <id> --json`: assert updated record envelope.
+- `delete <id> --json`: assert deletion envelope.
+- Non-TTY mode: missing required arg returns `CliValidationError`, no prompt.
+
+`src/__tests__/context.test.ts`:
+
+- `orbit context cnt_123 --json` calls `client.contacts.response().context('cnt_123')` — assert no fabricated envelope keys.
+- `orbit context user@example.com` (table) calls `client.contacts.context('user@example.com')`.
+
+`src/__tests__/search.test.ts`:
+
+- `orbit search "Alice" --types contacts,deals --limit 10 --json` maps to correct `SearchInput`.
+- `orbit search "Alice"` (no types) sends `object_types: undefined`.
+
+Exit criteria:
+
+- the CLI is useful for the first transport wave without inventing a second contract
+
+---
+
+### Slice E. Wave 2 Entity, Workflow, And Schema Commands
+
+Goal:
+
+- complete the main operational CLI surface once the matching SDK helpers are present and accepted
+
+Dependency:
+
+- the accepted SDK Wave 2 helpers and schema helpers (verify each in `packages/sdk/src/resources/` before implementing)
+
+Scope:
+
+- `activities`, `tasks`, `notes`, `products`, `payments`, `contracts`, `sequences`, `sequence_steps`, `sequence_enrollments`, `sequence_events`, `tags`, `webhooks`, `imports`
+- `schema`, `fields`, `migrate`, `log`, `report`
+
+#### E.1 Workflow Commands
+
+Thin wrappers over SDK helpers:
+
+- `orbit log call|email|meeting|note`: calls `client.activities.create({ type, ... })`
+- `orbit deals move <id> --stage <stage-id>`: calls `client.deals.move(id, { stage_id })`
+- `orbit sequences enroll <seq-id> --contact <contact-id>`: calls `client.sequences.enroll(seqId, body)` where `body` contains `contact_id` and any other enrollment fields. **Do not use `client.sequenceEnrollments.create()`** — enroll is a semantic workflow helper on the sequence resource itself (`sequences.ts` line 32), not a generic create on the enrollment resource.
+- `orbit sequences unenroll <enrollment-id>`: calls `client.sequenceEnrollments.unenroll(enrollmentId)` — this is a dedicated workflow method (`sequence-enrollments.ts` line 33), not `delete()`. **Do not use `client.sequenceEnrollments.delete()`.**
+
+#### E.2 Schema And Field Commands
+
+Use `client.schema` resource exclusively. Never call core schema services directly.
+
+`orbit migrate --preview`: calls `client.schema.previewMigration({})` and renders the diff in table mode.
+`orbit migrate --apply` and `orbit migrate --rollback`: **destructive actions** — follow Section 6.3.
+
+`orbit fields delete <entity> <field-name>`: **destructive action** — follow Section 6.3.
+
+#### E.3 Required Review Gate
+
+Command/dependency review after Slice E: confirm the CLI did not outrun the real SDK surface, especially for workflows and schema paths.
+
+#### E.4 Required Tests (Slice E)
+
+Same per-entity pattern as Slice D. Additional:
+
+`src/__tests__/destructive-actions.test.ts`:
+
+- `orbit fields delete contacts custom_tier --json` (no `--yes`): assert exit code 1, structured `DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION` error on stdout.
+- `orbit fields delete contacts custom_tier --json --yes`: proceeds and returns deletion envelope.
+- `orbit migrate --rollback --json` (no `--yes`): assert same error structure.
+- `orbit migrate --rollback --yes`: proceeds.
+- In TTY mode: assert confirm prompt is shown, and cancelling exits with code 1.
+
+Exit criteria:
+
+- the CLI's main command matrix is implementation-complete relative to available SDK coverage
+
+---
+
+### Slice F. Interactive UX, Ink Views, And Human-Only Affordances
+
+Goal:
+
+- add human-focused ergonomics after the agent-safe command baseline already exists
+
+Scope:
+
+- `src/interactive/` — `prompt.tsx`, `autocomplete.ts`, `confirm.tsx`
+- `src/ink/` — `pipeline-board.tsx`, `dashboard.tsx`, `status-panel.tsx`
+- `src/commands/dashboard.tsx`
+- destructive confirmations
+- fuzzy lookup helpers where practical
+
+#### F.1 Required Behavior
+
+- Ink is used only for commands the spec explicitly calls out: `orbit dashboard`, `orbit deals pipeline`, and destructive confirmations.
+- All Ink and prompt paths must check `!process.stdout.isTTY || isJsonMode()` and skip rendering entirely when either is true. Never wrap this check in a try/catch — it must be a synchronous guard at the top of each interactive path.
+- The CLI must fall back cleanly to plain text when terminal capabilities are limited.
+
+#### F.2 Ink Testing Approach
+
+Do **not** use React Testing Library or jsdom for Ink components. Ink renders to a Node TTY stream.
+
+Use `ink`'s `render()` + `unmount()` in tests, or use the `renderToString()` utility for snapshot-style assertions. Import from `ink` directly — do not add `@inkjs/testing` as a separate dependency unless it ships with ink v5.
+
+Vitest environment for Ink tests must remain `'node'` (not jsdom).
+
+#### F.3 Required Tests (Slice F)
+
+File: `src/__tests__/ink-views.test.ts`:
+
+1. `PipelineBoard` with two columns and three deals renders each deal title.
+2. `PipelineBoard` with an empty `deals` array renders the stage name but no deal rows.
+3. `PipelineBoard` does not render (returns empty string) when `isJsonMode()` returns true.
+4. `confirm.tsx` calls resolve with `true` on Enter keypress and `false` on Escape — simulate via stdin write.
+
+Exit criteria:
+
+- human UX is improved without weakening deterministic agent behavior
+
+---
+
+### Slice G. MCP/Integration Wrappers, CLI Smoke Tests, And Final Hardening
+
+Goal:
+
+- finish the remaining wrapper commands, add the subprocess smoke test, and close the validation/review loop
+
+Scope:
+
+- `src/commands/mcp.ts` — stub or real wrapper
+- `src/commands/integrations.ts` — stub
+- final documentation
+- final review artifacts
+- CLI smoke tests
+
+#### G.1 MCP Command Behavior
+
+`orbit mcp serve` is only implemented once `@orbit-ai/mcp` exists and exposes a stable start seam. Until then:
+
+```typescript
+export function registerMcpCommand(program: Command) {
+  program
+    .command('mcp serve')
+    .description('Start the Orbit MCP server (requires @orbit-ai/mcp)')
+    .action(() => {
+      throw new CliNotImplementedError(
+        'orbit mcp serve requires @orbit-ai/mcp which is not yet available.',
+        { code: 'DEPENDENCY_NOT_AVAILABLE', dependency: '@orbit-ai/mcp' },
+      )
+    })
+}
+```
+
+When `@orbit-ai/mcp` is implemented: HTTP transport must default to binding `127.0.0.1`. Binding to `0.0.0.0` requires `--host 0.0.0.0` with a stderr warning. This must be enforced at the CLI wrapper layer regardless of the MCP package's default.
+
+#### G.2 Required Review Gates
+
+**Code review**: confirm no command accesses core services or API routes directly; all execution goes through the SDK.
+
+**Agent-UX review**: focus on `--json`, non-TTY behavior, error determinism, and exit code consistency.
+
+**Security review** — named checklist (must verify each item):
+
+- [ ] `--api-key` argv redaction and stderr warning are implemented (Principle 9)
+- [ ] `.orbit/config.json` is written with mode `0600` (Principle 10)
+- [ ] Config reader warns if file permissions are wider than `0600` (Principle 10)
+- [ ] `.orbit/` is appended to `.gitignore` by `orbit init` (Principle 11)
+- [ ] `orbit init` never overwrites existing files without `--overwrite` (Principle 12)
+- [ ] No literal API key values appear in scaffolded files (Principle 13)
+- [ ] Direct mode TTY warning is implemented (Principle 14)
+- [ ] `databaseUrl` scheme allowlist is enforced before adapter factory call (Principle 15)
+- [ ] Config paths are canonicalized and constrained (Principle 16)
+- [ ] `orbit init` never writes to `.env` (Principle 17)
+- [ ] `contacts import <file>` is registered but throws `CliNotImplementedError` (not silently missing, not crashing) (Principle 18)
+- [ ] MCP HTTP transport defaults to `127.0.0.1` (Principle 19)
+- [ ] Destructive actions in `--json` mode return exit 1 with structured error (Section 6.3)
+- [ ] `--yes` flag is documented in `--help` output as a safety bypass
+
+#### G.3 CLI Smoke Tests
+
+File: `src/__tests__/smoke.test.ts` (excluded from default `vitest run` — run separately after `pnpm -r build`).
+
+These tests spawn the compiled `orbit` binary as a subprocess:
+
+1. `orbit contacts list --json` with direct SQLite mode (temp db, seeded with one contact). Assert exit code 0, valid JSON envelope on stdout.
+2. `orbit contacts list --json` with an invalid `--api-key` against a mock local server. Assert exit code 1, `{ error: { code: 'AUTH_INVALID_API_KEY' } }` on stdout.
+3. `orbit` with no arguments. Assert exit code 0 (help text) or the Commander default — whichever is chosen must be locked by this test.
+
+#### G.4 Final Docs
+
+Direct-mode trust boundaries must be documented clearly in `README.md` and in a code comment at the top of `src/config/resolve-context.ts` listing the specific middleware protections that are absent in direct mode.
+
+Exit criteria:
+
+- the CLI is accepted as a stable user and agent interface over the SDK
+
+---
+
+## 10. Validation Matrix
+
+At minimum, the CLI branch must prove:
+
+- one `orbit` program resolves config and constructs the correct SDK client in API mode and direct mode
+- `--json` preserves server-owned `meta`, `links`, cursor fields, and `request_id` — verified by json-fidelity test case 1
+- no command prints non-JSON output in `--json` mode — verified by json-fidelity test case 5
+- table/CSV/TSV formatting is deterministic and does not corrupt record data
+- non-TTY runs fail with typed validation errors instead of prompting — verified by non-tty tests
+- destructive schema flows require `--yes` or interactive confirmation in TTY mode
+- destructive schema flows return structured errors in `--json` mode — verified by destructive-actions tests
+- command coverage matches the accepted SDK surface rather than bypassing through raw-core logic
+- unsupported direct adapters fail with `CliUnsupportedAdapterError` — verified by config-resolve test cases 8–9
+- `orbit mcp serve` fails gracefully when `@orbit-ai/mcp` is absent — verified by smoke test or unit test
+- the `orbit` binary is executable and has a correct shebang
+
+## 11. Branch Exit Criteria
+
+The CLI implementation branch is complete when:
+
+1. `packages/cli` exists, builds cleanly, and exposes the `orbit` binary.
+2. Config resolution and SDK client bootstrap are review-accepted.
+3. The shared output boundary preserves raw JSON envelopes correctly.
+4. Wave 1 and Wave 2 command slices cover the accepted SDK surface.
+5. Human-only interaction paths stay fully disabled in agent/JSON mode.
+6. Final code, UX, and security reviews return no blocking findings (all 14 security checklist items pass).
+7. Any still-missing dependency surfaces such as `@orbit-ai/mcp` are handled explicitly with `CliNotImplementedError` rather than implied to exist.
+8. **The CLI package reaches a minimum of 120 tests**:
+
+| Test area | Approx count |
+|-----------|-------------|
+| Program / command registration (Slice A) | 15 |
+| Config resolution and adapter resolution (Slice B) | 20 |
+| JSON fidelity (Slice C) | 10 |
+| Formatter unit tests (Slice C) | 20 |
+| Exit code mapping (Slice A/C) | 8 |
+| Non-TTY / agent-mode (Slice C/D) | 8 |
+| Wave 1 entity commands (Slice D) | 20 |
+| Wave 2 entity and workflow commands (Slice E) | 15 |
+| Destructive action enforcement (Slice E) | 8 |
+| Ink components (Slice F) | 4 |
+| Smoke / integration tests (Slice G) | 3 |
+
+This brings the projected repo total to approximately 914 tests (current baseline: 794). Any PR that adds command breadth without corresponding tests for that command must be rejected at review.

--- a/docs/execution/mcp-implementation-plan.md
+++ b/docs/execution/mcp-implementation-plan.md
@@ -1,0 +1,948 @@
+# Orbit AI MCP Implementation Plan
+
+Date: 2026-04-09
+Revised: 2026-04-09 (post multi-agent review: architecture, security, testing)
+Status: Execution-ready baseline
+Package: `@orbit-ai/mcp`
+Depends on:
+- [IMPLEMENTATION-PLAN.md](/Users/sharonsciammas/orbit-ai/docs/IMPLEMENTATION-PLAN.md)
+- [api-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/api-implementation-plan.md)
+- [sdk-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/sdk-implementation-plan.md)
+- [cli-implementation-plan.md](/Users/sharonsciammas/orbit-ai/docs/execution/cli-implementation-plan.md)
+- [05-mcp.md](/Users/sharonsciammas/orbit-ai/docs/specs/05-mcp.md)
+- [02-api.md](/Users/sharonsciammas/orbit-ai/docs/specs/02-api.md)
+- [03-sdk.md](/Users/sharonsciammas/orbit-ai/docs/specs/03-sdk.md)
+- [orbit-ai-threat-model.md](/Users/sharonsciammas/orbit-ai/docs/security/orbit-ai-threat-model.md)
+- [KB.md](/Users/sharonsciammas/orbit-ai/docs/KB.md)
+
+## 1. Purpose
+
+This document defines how to execute `@orbit-ai/mcp` as the next agent-facing package track after the API and SDK baselines.
+
+The MCP package is not a second transport contract. It is an agent-native server over the accepted SDK and API behavior. Its job is to expose the fixed 23-tool core registry, MCP resources, and tool-specific safety guidance without re-deciding routes, envelopes, secret-redaction rules, or workflow semantics in a separate layer.
+
+This document is intentionally precise because it will be executed by AI sub-agents without human clarification. Every discrepancy between the spec and the real codebase is documented here. Agents must follow this plan rather than `docs/specs/05-mcp.md` where they conflict.
+
+## 2. Spec Corrections
+
+The following errors appear in `docs/specs/05-mcp.md`. Agents must use the corrected forms below.
+
+### 2.1 `crm.*` Namespace Does Not Exist
+
+The spec's tool-to-core mapping (Section 12), Section 7.1 (`move_deal_stage`), and Section 10 (resources) all reference a `crm` namespace on `OrbitClient`. **This namespace does not exist.** The client exposes resources directly.
+
+Correct all spec references as follows:
+
+| Spec (WRONG) | Correct call |
+|---|---|
+| `crm.deals.move()` | `client.deals.move(id, { stage_id })` — see Section 2.5 for `occurred_at`/`note` caveat |
+| `crm.deals.stats()` | `client.deals.stats(query?)` |
+| `crm.pipelines.list()` | `client.pipelines.list(query?)` |
+| `crm.activities.create()` | `client.activities.log(body)` — the `log` route, NOT `create` |
+| `crm.activities.list()` | `client.activities.list(query?)` |
+| `crm.schema.listObjects()` | `client.schema.listObjects()` |
+| `crm.schema.addField()` | `client.schema.addField(type, body)` |
+| `crm.schema.updateField()` | `client.schema.updateField(type, fieldName, body)` |
+
+Every sub-agent implementing a tool handler must use the flat `client.<resource>.<method>()` form.
+
+### 2.2 Sequence Tool Call Signatures
+
+The spec maps both sequence tools to "sequence enrollment API" without method names. The correct calls are:
+
+- `enroll_in_sequence` → `client.sequences.enroll(sequenceId, { contact_id, ...body })` — on `SequenceResource` (`sequences.ts` line 32)
+- `unenroll_from_sequence` → `client.sequenceEnrollments.unenroll(enrollmentId)` — on `SequenceEnrollmentResource` (`sequence-enrollments.ts` line 33)
+
+These are on two different resources. Do NOT use `client.sequenceEnrollments.create()` or `client.sequenceEnrollments.delete()`.
+
+### 2.3 `sensitive.ts` Import Path
+
+The spec's `output/sensitive.ts` imports from `@orbit-ai/api/contracts/sensitive`. This path does not exist. The correct import is:
+
+```typescript
+import type { WebhookRead } from '@orbit-ai/api'
+```
+
+### 2.4 `log_activity` Uses `activities.log()`, Not `activities.create()`
+
+`ActivityResource` exposes `client.activities.log(body)` which POSTs to `/v1/activities/log`. The spec maps `log_activity` to "`crm.activities.create()` or `/v1/activities/log`." The correct call is `client.activities.log(body)` — not `create()`, which POSTs to `/v1/activities` (standard CRUD). Using `create()` instead of `log()` hits the wrong endpoint.
+
+### 2.5 `deals.move()` Current SDK Signature Is `{ stage_id: string }` Only
+
+The current `DealResource.move(id, input)` accepts `input: { stage_id: string }` — no `occurred_at` or `note` fields. The spec's `move_deal_stage` tool input schema includes those fields. Until `DealResource.move()` is extended in `@orbit-ai/sdk` to accept them, the MCP handler must:
+
+1. Accept `occurred_at?` and `note?` in the tool input schema (so agents can provide them).
+2. Strip those fields before calling `client.deals.move(id, { stage_id })` — passing them would fail TypeScript strict mode.
+3. Add a code comment noting this information loss and that the SDK must be extended.
+
+The SDK extension (`move(id: string, input: MoveDealStageInput)` where `MoveDealStageInput` includes `occurred_at?: string` and `note?: string`) should be the prerequisite task before Slice D. If it is added to the SDK, remove the stripping logic.
+
+### 2.6 `unenroll_from_sequence` — `reason` And `idempotency_key` Not Forwarded To SDK
+
+`SequenceEnrollmentResource.unenroll(id: string)` takes only one argument. The spec's `unenroll_from_sequence` tool schema includes `reason?` and `idempotency_key?`. The MCP handler must accept these fields in the tool input (for forward compatibility) but document in a code comment that the current SDK signature does not support forwarding them. Do not fabricate an idempotency key locally — the SDK call is already idempotent by nature (repeated unenroll of the same ID should no-op). Omit `reason` and `idempotency_key` from the `client.sequenceEnrollments.unenroll()` call entirely.
+
+### 2.7 `resources/schema.ts` Missing From Directory Manifest
+
+The spec's Section 2 directory listing omits `resources/schema.ts`. This file must exist alongside `resources/team-members.ts`. The plan's file-to-slice table (Section 8) is authoritative.
+
+## 3. Current Readiness And Constraints
+
+Current repository state:
+
+- `packages/mcp` does not exist yet
+- `packages/api` and `packages/sdk` exist and already provide most of the parity surface MCP should consume
+
+### 3.1 Confirmed SDK Surface For Tool Handlers
+
+Verify every call in the actual source file before implementing. Flat client namespace:
+
+```
+client.contacts     client.companies     client.deals
+client.stages       client.activities    client.tasks
+client.notes        client.products      client.payments
+client.contracts    client.sequences     client.sequenceSteps
+client.sequenceEnrollments              client.sequenceEvents
+client.pipelines    client.tags          client.schema
+client.webhooks     client.imports       client.users
+client.search
+```
+
+**`relate_records` SDK backing** — depends on `relationship_type`:
+- `relationship_type: 'tag'` → `client.tags.attach(tagId, { entity_type, entity_id })` or `client.tags.detach(tagId, { entity_type, entity_id })`
+- `relationship_type: 'contact_company' | 'contact_deal' | 'company_deal'` → `client.<entity>.update(id, { contact_id | company_id })` — there is no dedicated link endpoint; this is a targeted field patch
+- The plan must not imply dedicated relation endpoints exist in the SDK beyond the above
+
+**`list_related_records` SDK backing** — there is no SDK resource method for relationship sub-routes (e.g., no `client.contacts.deals()`). These routes exist on the API (`GET /v1/contacts/:id/deals` etc.) but the SDK does not expose them as named methods. `OrbitClient.transport` is `private readonly` — `transport.rawRequest()` is unreachable from the MCP package. **`list_related_records` must be registered as a `McpNotImplementedError` stub (code: `DEPENDENCY_NOT_AVAILABLE`) until named relationship helpers (e.g., `client.contacts.listDeals(id)`) are added to `@orbit-ai/sdk`.** The stub must be added to the gated tools table in Section 3.2. Do not attempt to access the private transport field.
+
+**`bulk_operation` SDK backing** — maps to `client.<entity>.batch(body)` via `BaseResource.batch()`. Entities that support batch: contacts, companies, deals, activities, tasks, notes, products, payments, contracts, sequences, tags. Entities that do NOT support batch: pipelines, stages, users, sequence_steps, sequence_enrollments, sequence_events. For unsupported entities, return a `McpNotImplementedError` immediately without calling the SDK.
+
+### 3.2 Gated Tools
+
+Five tools have no complete SDK/API seam today and must be registered in the 23-tool array as `McpNotImplementedError` stubs. They must appear in `buildTools()` at all times to preserve the 23-count invariant. They must never be omitted conditionally.
+
+| Tool | Missing seam | Required stub behavior |
+|------|-------------|------------------------|
+| `import_records` | SDK type mismatch: `ImportResource.create()` types `{ entity_type, status?, total_rows? }` — no `file` or `file_path` field. Some SDK tests reference `imports.create({ file, entity })` against a drifted shape. Until the import seam is unified in `@orbit-ai/sdk` (adding a real file-upload path), this must remain a stub. | Return `McpNotImplementedError` with `code: 'DEPENDENCY_NOT_AVAILABLE'` |
+| `list_related_records` | `OrbitClient.transport` is `private` — `rawRequest()` is unreachable from the MCP package. No named relationship helpers exist on the SDK (e.g., no `client.contacts.listDeals()`). Must stay stubbed until `@orbit-ai/sdk` adds named relationship methods. | Return `McpNotImplementedError` with `code: 'DEPENDENCY_NOT_AVAILABLE'` |
+| `export_records` | No export resource or route in SDK | Return `McpNotImplementedError` with `code: 'DEPENDENCY_NOT_AVAILABLE'` |
+| `run_report` | No reporting API surface in SDK | Return `McpNotImplementedError` with `code: 'DEPENDENCY_NOT_AVAILABLE'` |
+| `get_dashboard_summary` | No dashboard summary API in SDK | Return `McpNotImplementedError` with `code: 'DEPENDENCY_NOT_AVAILABLE'` |
+
+The `recovery` field in the stub error must say: `"This capability is not yet available. Check the Orbit changelog for availability."`
+
+## 4. In Scope
+
+Package bootstrap:
+
+- `packages/mcp/package.json`
+- `packages/mcp/tsconfig.json`
+- `packages/mcp/vitest.config.ts`
+- `packages/mcp/src/index.ts`
+- `packages/mcp/src/server.ts`
+
+Shared runtime:
+
+- client/config handoff into the MCP server
+- tool definition helpers and `defineTool()` wrapper
+- tool registry and dispatch (`executeTool`)
+- runtime Zod input validation in every handler
+- structured error conversion (`toToolError`)
+- output truncation and secret sanitization helpers
+
+Transport work:
+
+- stdio transport
+- HTTP transport
+- one shared tool runtime used by both transports
+
+Tool work:
+
+- all 23 core tools from the spec
+- safety annotations on every tool
+- LLM-oriented tool descriptions
+- `McpNotImplementedError` stubs for gated tools (Section 3.2)
+
+Resource work:
+
+- `orbit://team-members` via `src/resources/team-members.ts`
+- `orbit://schema` via `src/resources/schema.ts`
+
+Contract proof:
+
+- registry count tests (3 specific cases — see Slice B)
+- annotation completeness tests (per-tool — see Slice B)
+- `toToolError()` tests (3 specific cases — see Slice B)
+- tool handler tests with SDK mock pattern (see Slices C and D)
+- `confirm: true` enforcement tests (2 cases — see Slice C)
+- secret redaction tests (3 specific scenarios — see Slices B and G)
+- `object_type` dispatch coverage tests (see Slice C)
+- `move_deal_stage` must-not-patch test (see Slice D)
+- gated tool stub behavior tests (see Slice G)
+- transport parity tests (see Slice F)
+- final review artifacts under `docs/review/`
+
+## 5. Out Of Scope
+
+- integration extension tools in the core package
+- a composite plugin runtime for connectors
+- inventing MCP-only business logic that bypasses the SDK
+- implementing the missing schema engine or reporting engine during the MCP branch
+- broad hosted identity/runtime design beyond the frozen stdio and HTTP seams
+
+If the MCP package needs a missing client capability, the default fix should be adding the seam in `@orbit-ai/sdk` first, not bypassing into raw core or ad hoc API calls from MCP.
+
+## 6. Required Execution Principles
+
+### 6.1 SDK And Tool Contract
+
+1. The MCP package is a tool/runtime layer over the SDK. It may adapt inputs and outputs for tool use, but it may not own business logic.
+2. The core package contract is fixed at exactly 23 tools. No more, no fewer. All 23 must appear in `buildTools()` unconditionally.
+3. Tool definitions must be explicit TypeScript objects with `title`, `description`, `inputSchema`, `annotations.readOnlyHint`, `annotations.destructiveHint`, and `annotations.idempotentHint`.
+4. Tool descriptions must tell the model when to use the tool and when not to use it.
+5. Tool handlers must return structured machine-readable JSON in MCP content blocks, not prose-only blobs.
+6. Tool errors must always include `code`, `message`, `hint`, and `recovery`.
+7. Secret-bearing reads must remain sanitized, and long text must be truncated deterministically with explicit truncation markers.
+8. Hosted/remote MCP should prefer the HTTP-backed client path; direct-mode MCP is valid only for trusted local embeddings and must stay explicit about that trust model.
+9. Tools whose underlying SDK/API capability is not real yet must be registered as stubs that return `McpNotImplementedError` — never omitted from the registry, never simulated with fake data.
+
+### 6.2 Security Principles
+
+These are not optional. All must be implemented in the slice they are assigned to.
+
+10. **Runtime Zod validation in every handler**: every tool handler MUST parse `args` with the same Zod schema used to generate `inputSchema` before executing any SDK call. A `ZodError` must return a structured tool error immediately. The JSON Schema metadata for the MCP client is NOT sufficient — both must exist and must agree. Implement in Slice B.
+
+11. **`confirm: true` enforced in handler**: `delete_record`'s `confirm: true` requirement is enforced by the handler's Zod parse at runtime, not by the MCP client. The same applies to every delete operation inside `bulk_operation`. Implement in Slice C (delete_record) and Slice D (bulk_operation). A test must verify this (see Section 9, Slices C and D).
+
+12. **`toToolError()` sanitizes error messages**: `toToolError()` must truncate `error.message` to 500 characters maximum and strip patterns matching `[A-Za-z0-9_-]{20,}` adjacent to `://` (connection strings), strings starting with `Bearer `, and the literal word `secret`. The sanitized message may replace sensitive content with `[redacted]`. The same sanitization applies to `hint` and `recovery` if propagated from an underlying provider error. Implement in Slice B.
+
+13. **In-handler secret sanitization (defense-in-depth)**: tool handlers that read secret-bearing objects (webhooks, integration connections, sync states) must strip sensitive fields before serializing to a content block — even if the SDK's read model has already done so. This defends against DirectTransport mode where the SDK may return fuller objects. Implement in Slices C and G.
+
+14. **Free-form string input truncation**: free-form string inputs (`query`, `body`, `note`, and top-level string values in `record` payloads) must be truncated to 10,000 characters at the tool handler layer before being passed to the SDK. Implement in Slice B as a shared input-sanitization helper.
+
+15. **Direct mode startup warning**: when the MCP server starts with a `DirectTransport`-backed SDK client, it must emit a structured warning to stderr before accepting any requests. The warning must list the specific protections absent: API-layer authentication, per-org rate limiting, scope enforcement, SSRF webhook destination checks. Implement in Slice E.
+
+16. **HTTP transport binding and auth**: the HTTP transport must bind to `127.0.0.1` by default. Binding to a wildcard interface requires an explicit `bindAddress` config option with a stderr warning. Auth uses the same hash-then-lookup pattern as the API middleware: SHA-256 hash the raw bearer token, then call `adapter.lookupApiKeyForAuth(hash)`. There is no separate token validation HTTP endpoint. `adapter` must be injected by the caller — the MCP package does not construct its own adapter. A missing, invalid, revoked, or expired token returns HTTP 401 before the MCP request is decoded. Implement in Slice F.
+
+17. **SSRF in direct-mode webhook writes**: when operating in stdio direct mode, `create_record` and `update_record` for `object_type: 'webhooks'` must validate the `url` field against an SSRF block list before calling the SDK. Block list must include: RFC1918 ranges, link-local `169.254.0.0/16`, loopback `127.0.0.0/8` / `::1`, and `169.254.169.254`. Return a `McpValidationError` for blocked URLs. Implement in Slice C.
+
+18. **Resource content prompt injection guard**: resource handlers for `orbit://team-members` and `orbit://schema` must wrap their output with an `_untrusted: true` frame and truncate individual string fields to 500 characters. Return format:
+
+```json
+{ "_type": "orbit_resource", "_untrusted": true, "data": [...] }
+```
+
+Implement in Slice E.
+
+19. **`bulk_operation` pre-execution audit in direct mode**: in direct-mode stdio, `bulk_operation` with any delete operations must emit a pre-execution audit log entry to stderr (before the first delete reaches the SDK) recording: operation count, object type, and list of record IDs to be deleted. Implement in Slice D.
+
+20. **Slice H security review checklist**: the security review in Slice H must produce an artifact at `docs/review/<date>-mcp-security-review.md` confirming each item in the named checklist in Section 11.2.
+
+21. **Elicitation for destructive confirms (Claude Code ≥ 2.1.76)**: The MCP spec supports `server.elicitInput()` for inline native confirmation dialogs. This is preferred over the `DESTRUCTIVE_CONFIRM_REQUIRED` error round-trip when the host supports it. Elicitation MUST be handled at the server registration layer in `server.ts` — not inside `executeTool()`, because `executeTool` has no access to the server object. The dual-path pattern (see Section C.2) is required. Elicitation MUST NOT be used to request API keys, tokens, or secrets — those go through config only. Implement in Slice C.
+
+## 7. Exit Code And Error Structure
+
+Every tool error must follow this shape, returned as an MCP content block with `isError: true`:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "RESOURCE_NOT_FOUND",
+    "message": "Contact with ID contact_01 was not found.",
+    "hint": "Verify the record_id is correct.",
+    "recovery": "Use search_records to find the correct record ID first."
+  }
+}
+```
+
+Named error codes used in MCP:
+
+| Code | Condition |
+|------|-----------|
+| `RESOURCE_NOT_FOUND` | SDK 404 |
+| `VALIDATION_FAILED` | Input Zod parse failure or SDK validation error |
+| `AUTH_INVALID` | Invalid or missing API key in HTTP transport |
+| `DESTRUCTIVE_CONFIRM_REQUIRED` | `confirm: true` missing on delete |
+| `UNSUPPORTED_OBJECT_TYPE` | `object_type` not in dispatch map for the requested operation |
+| `DEPENDENCY_NOT_AVAILABLE` | Gated tool stub |
+| `INTERNAL_ERROR` | Unexpected SDK/transport error |
+| `SSRF_BLOCKED` | Webhook URL blocked by SSRF policy |
+| `UNKNOWN_TOOL` | `executeTool` called with unrecognized tool name |
+
+## 8. File-to-Slice Mapping
+
+Every file the MCP package requires is assigned to exactly one slice.
+
+| File | Slice | Notes |
+|------|-------|-------|
+| `package.json` | A | see Slice A manifest requirements |
+| `tsconfig.json` | A | extends root; no jsx needed |
+| `vitest.config.ts` | A | see Slice A requirements |
+| `src/index.ts` | A | package entry, `startMcpServer` re-export |
+| `src/server.ts` | A | `startMcpServer()` implementation |
+| `src/errors.ts` | B | `toToolError()`, `McpNotImplementedError`, error codes |
+| `src/tools/schemas.ts` | B | shared Zod schemas, `defineTool()` helper |
+| `src/tools/registry.ts` | B | `buildTools()`, `executeTool()` dispatch |
+| `src/output/truncation.ts` | B | text truncation + `truncated: true` marker helper |
+| `src/output/sensitive.ts` | B | sanitized DTOs for secret-bearing objects |
+| `src/tools/core-records.ts` | C | `search_records`, `get_record`, `create_record`, `update_record`, `delete_record` |
+| `src/tools/relationships.ts` | C | `relate_records` (live); `list_related_records` (stub — gated, see Section 3.2) |
+| `src/tools/bulk.ts` | C | `bulk_operation` |
+| `src/tools/pipelines.ts` | D | `get_pipelines`, `move_deal_stage`, `get_pipeline_stats` |
+| `src/tools/activities.ts` | D | `log_activity`, `list_activities` |
+| `src/tools/sequences.ts` | D | `enroll_in_sequence`, `unenroll_from_sequence` |
+| `src/tools/team.ts` | D | `assign_record` |
+| `src/transports/stdio.ts` | E | stdio transport entrypoint |
+| `src/resources/team-members.ts` | E | `orbit://team-members` resource |
+| `src/resources/schema.ts` | E | `orbit://schema` resource |
+| `src/transports/http.ts` | F | HTTP transport entrypoint, bearer auth |
+| `src/tools/schema.ts` | G | `get_schema`, `create_custom_field`, `update_custom_field` |
+| `src/tools/imports.ts` | G | `import_records`, `export_records` (stubs) |
+| `src/tools/analytics.ts` | G | `run_report`, `get_dashboard_summary` (stubs) |
+
+## 9. Delivery Slices
+
+### Slice A. Package Bootstrap And MCP Server Skeleton
+
+Goal:
+
+- create `packages/mcp` and lock the runtime seam before tool breadth begins
+
+#### A.1 Package Manifest Requirements
+
+```json
+{
+  "name": "@orbit-ai/mcp",
+  "version": "0.1.0-alpha.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": { ".": "./dist/index.js" },
+  "files": ["dist/", "README.md", "LICENSE"],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@orbit-ai/sdk": "workspace:*",
+    "zod": "^4.1.11"
+  },
+  "devDependencies": {
+    "typescript": "workspace:*",
+    "vitest": "workspace:*"
+  }
+}
+```
+
+Pin `@modelcontextprotocol/sdk` to `^1.0.0`. Check npm for the latest 1.x stable at implementation time. Do not use 0.x — the API changed significantly at 1.0. The package name is `@modelcontextprotocol/sdk` — verify the exact import paths (`/server/index.js`, `/types.js`) still apply in the version you install.
+
+#### A.2 TypeScript Config Requirements
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}
+```
+
+No `.tsx` needed — MCP has no UI components.
+
+#### A.3 `startMcpServer` Signature
+
+The server entry accepts a preconfigured `OrbitClient`:
+
+```typescript
+export async function startMcpServer(options: {
+  client: import('@orbit-ai/sdk').OrbitClient
+  transport: 'stdio' | 'http'
+  port?: number
+  bindAddress?: string
+}): Promise<void>
+```
+
+stdio mode uses the provided client without constructing a new one. When the CLI calls `orbit mcp serve`, it constructs the `OrbitClient` from its own config resolution (same env-var precedence as the CLI plan) and passes it in. The MCP package itself does not read `ORBIT_API_KEY` or `.orbit/config.json` — that is the CLI's responsibility.
+
+#### A.4 Vitest Config Requirements
+
+```typescript
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/**/*.test.ts'],
+    coverage: { enabled: false },
+  },
+})
+```
+
+#### A.5 Required Tests (Slice A)
+
+File: `src/__tests__/server.test.ts`
+
+- `startMcpServer` with `transport: 'stdio'` does not throw on construction.
+- `startMcpServer` with `transport: 'http'` and a valid port does not throw on construction.
+- Passing no client throws synchronously with a clear error message.
+
+Exit criteria:
+
+- the package exists and can host a shared tool runtime without transport-specific divergence
+
+---
+
+### Slice B. Tool Definition Helpers, Error Mapping, And Registry Guardrails
+
+Goal:
+
+- make the core registry mechanically safe before individual tool breadth lands
+
+#### B.1 `defineTool()` Helper
+
+Wraps `@modelcontextprotocol/sdk`'s `Tool` type. Zod v4 ships a native `z.toJSONSchema(schema)` method. Use that directly — do **not** add `zod-to-json-schema` as a dependency. That package targets Zod v3 and does not support Zod v4 schemas. Every tool definition goes through `defineTool()` which calls `z.toJSONSchema(inputZodSchema)` for `inputSchema` — no manually written JSON Schema.
+
+#### B.2 `executeTool()` Dispatch And Build-Order Stub Pattern
+
+The dispatch table maps tool names to handler functions. Calling with an unknown tool name must return a structured `UNKNOWN_TOOL` error, not throw:
+
+```typescript
+export async function executeTool(
+  client: OrbitClient,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<CallToolResult>
+```
+
+**Build-ordering requirement**: `buildTools()` in `registry.ts` (Slice B) must import all 23 tool definitions, including those in `src/tools/schema.ts`, `src/tools/imports.ts`, and `src/tools/analytics.ts` (Slice G). Since those files do not exist when Slice B is implemented, Slice B must create placeholder stub exports for every Slice-G tool:
+
+```typescript
+// Created in Slice B as stubs; replaced by full implementations in Slice G
+// src/tools/schema.ts (stub):
+export const getSchemaTool = defineTool('get_schema', { ... annotations ... })
+export const createCustomFieldTool = defineTool('create_custom_field', { ... })
+export const updateCustomFieldTool = defineTool('update_custom_field', { ... })
+
+// src/tools/imports.ts (stub):
+export const importRecordsTool = defineTool('import_records', { ... })
+export const exportRecordsTool = defineTool('export_records', { ... })
+
+// src/tools/analytics.ts (stub):
+export const runReportTool = defineTool('run_report', { ... })
+export const getDashboardSummaryTool = defineTool('get_dashboard_summary', { ... })
+```
+
+Stub handler: returns `McpNotImplementedError` with `code: 'DEPENDENCY_NOT_AVAILABLE'`. Slice G replaces the stub implementations — the `defineTool` metadata and stub handler are both replaced with real logic. This means `packages/mcp` always compiles after Slice B with all 23 tools registered and the count test passing.
+
+#### B.3 `toToolError()` Requirements
+
+Implementation must sanitize `error.message` per Principle 12. Must use the default `hint` and `recovery` strings from the spec when the underlying error lacks them. Must set `isError: true` on the returned content block.
+
+#### B.4 Shared Schemas And `src/output/` Directory
+
+Zod schemas for `ObjectTypeSchema`, `SearchObjectTypeSchema`, `CursorSchema`, `LimitSchema` exactly as in the spec. Add a shared `sanitizeStringInput(s: string, maxLength = 10_000): string` helper that truncates free-form inputs per Principle 14.
+
+The `src/output/` subdirectory does not exist in the spec's directory manifest (the spec omits it). Slice B must create this directory explicitly when creating `src/output/truncation.ts` and `src/output/sensitive.ts`. The file-to-slice table in Section 8 is authoritative — the spec directory manifest is incomplete.
+
+#### B.5 Required Review Gate
+
+Contract review after Slice B: confirm the MCP package is structurally enforcing the fixed tool count, safety annotations, runtime Zod validation, and machine-readable output rules.
+
+#### B.6 Required Tests (Slice B)
+
+File: `src/__tests__/registry.test.ts`
+
+1. `buildTools()` returns exactly 23 tools.
+2. Every tool name is a non-empty string.
+3. No duplicate tool names exist.
+4. Every tool has `annotations.readOnlyHint`, `annotations.destructiveHint`, and `annotations.idempotentHint` — each a boolean.
+5. `delete_record` has `annotations.destructiveHint === true`.
+6. `search_records` and `get_record` have `annotations.readOnlyHint === true`.
+7. `bulkOperationTool.annotations.destructiveHint === true`.
+8. `buildTools()` returns the same tool names on successive calls (idempotency).
+9. `executeTool(mockClient, 'totally_unknown_tool', {})` returns a content block with `isError: true` and `parsed.error.code === 'UNKNOWN_TOOL'` — does not throw.
+
+File: `src/__tests__/errors.test.ts`
+
+10. `toToolError({ code: 'RESOURCE_NOT_FOUND', message: 'Not found' })` returns `{ isError: true, content: [{ type: 'text', text: <json> }] }` with `parsed.ok === false` and `parsed.error.code === 'RESOURCE_NOT_FOUND'`.
+11. `toToolError` with no `hint`/`recovery` on the input uses the spec's default strings.
+12. `toToolError` with an error message containing a synthetic token string (`'ya29.FAKETOKEN'`) returns content that does NOT contain `'ya29.FAKETOKEN'`.
+13. `toToolError` result `content[0].type === 'text'`.
+
+Exit criteria:
+
+- later slices can add tools without weakening registry invariants or error behavior
+
+---
+
+### Slice C. Core Record Tool Slice
+
+Goal:
+
+- land the highest-value universal tools first on top of stable SDK primitives
+
+Scope: `search_records`, `get_record`, `create_record`, `update_record`, `delete_record`, `relate_records`, `bulk_operation`; `list_related_records` is registered in `src/tools/relationships.ts` as a `McpNotImplementedError` stub — it is gated (see Section 3.2) and must NOT call any SDK method
+
+Files: `src/tools/core-records.ts`, `src/tools/relationships.ts`, `src/tools/bulk.ts`
+
+#### C.1 `object_type` Dispatch Map
+
+Use a named union type to avoid `keyof OrbitClient` (which includes non-resource properties like `options` and EventEmitter methods):
+
+```typescript
+type ResourceKey =
+  | 'contacts' | 'companies' | 'deals' | 'activities' | 'tasks' | 'notes'
+  | 'products' | 'payments' | 'contracts' | 'sequences' | 'sequenceSteps'
+  | 'sequenceEnrollments' | 'sequenceEvents' | 'tags'
+  | 'webhooks' | 'imports' | 'users' | 'stages' | 'pipelines'
+
+const resourceMap: Record<string, ResourceKey> = {
+  contacts: 'contacts',
+  companies: 'companies',
+  deals: 'deals',
+  activities: 'activities',
+  tasks: 'tasks',
+  notes: 'notes',
+  products: 'products',
+  payments: 'payments',
+  contracts: 'contracts',
+  sequences: 'sequences',
+  sequence_steps: 'sequenceSteps',
+  sequence_enrollments: 'sequenceEnrollments',
+  sequence_events: 'sequenceEvents',
+  tags: 'tags',
+  webhooks: 'webhooks',
+  imports: 'imports',
+  users: 'users',
+  stages: 'stages',
+  pipelines: 'pipelines',
+}
+```
+
+An `object_type` not in this map returns `UNSUPPORTED_OBJECT_TYPE` immediately.
+
+**`search_records` special-case for `object_type: 'all'`**: the `search_records` handler must handle `object_type: 'all'` before consulting `resourceMap`, because `'all'` is not an entity key:
+
+```typescript
+// In the search_records handler:
+if (args.object_type === 'all') {
+  return await client.search.query({ query: args.query, limit: args.limit, cursor: args.cursor })
+}
+// Otherwise dispatch to entity-specific search:
+const resource = client[resourceMap[args.object_type]]
+return await resource.search({ query: args.query, filter: args.filter, ... })
+```
+
+Never let `object_type: 'all'` fall through to the `UNSUPPORTED_OBJECT_TYPE` path.
+
+#### C.2 `delete_record` Handler — Dual-Path Destructive Confirm
+
+`confirm: true` is enforced by the handler's runtime Zod parse (Principle 11). The handler lives in `executeTool()` which has no server reference. Elicitation must be handled **before** `executeTool()` is called, in the tool registration wrapper inside `server.ts`:
+
+```typescript
+// In server.ts, when registering delete_record:
+server.registerTool('delete_record', toolDef, async (args, _extra) => {
+  if (!args.confirm) {
+    const caps = server.getClientCapabilities()
+    if (caps?.elicitation) {
+      const r = await server.elicitInput({
+        mode: 'form',
+        message: `Permanently delete ${args.object_type} record ${args.record_id}? This cannot be undone.`,
+        requestedSchema: {
+          type: 'object',
+          properties: { confirmed: { type: 'boolean', title: 'Confirm deletion' } },
+          required: ['confirmed'],
+        },
+      })
+      if (r.action === 'accept' && r.content?.confirmed) {
+        args = { ...args, confirm: true }   // inject before executeTool
+      } else {
+        return toToolError({ code: 'DESTRUCTIVE_CONFIRM_REQUIRED', message: 'User declined or dismissed the confirmation.' })
+      }
+    }
+    // Fallback: no elicitation support — executeTool will return DESTRUCTIVE_CONFIRM_REQUIRED
+  }
+  return executeTool(client, 'delete_record', args)
+})
+```
+
+When `caps?.elicitation` is absent or false, fall through — `executeTool` returns `DESTRUCTIVE_CONFIRM_REQUIRED` via its own Zod parse, which is the pre-elicitation behavior and remains the documented fallback.
+
+The `confirm?: boolean` field stays in the Zod input schema so that non-elicitation hosts can still pass `confirm: true` directly.
+
+#### C.3 SSRF Guard For Webhook Writes
+
+When the DirectTransport SDK client is in use, `create_record` and `update_record` for `object_type: 'webhooks'` must validate the `url` field against the SSRF block list (Principle 17) before calling the SDK. Return `SSRF_BLOCKED` for blocked URLs.
+
+#### C.4 `relate_records` SDK Mapping
+
+- `relationship_type: 'tag'` → `client.tags.attach(tagId, { entity_type, entity_id })` or `client.tags.detach(...)`. The `target_record_id` is the tag ID in this case.
+- `relationship_type: 'contact_company' | 'contact_deal' | 'company_deal'` → targeted field update via `client.<entity>.update(id, { contact_id | company_id })`. Document in code comments that no dedicated link endpoint exists in the SDK.
+
+#### C.5 `bulk_operation` Entity Gate
+
+Before dispatching to `client.<entity>.batch(body)`, check whether the entity supports batch (Section 3.1). If not (e.g., `object_type: 'users'`), return `McpNotImplementedError` with `code: 'UNSUPPORTED_OBJECT_TYPE'` immediately.
+
+Each delete operation within a batch must be validated individually with the runtime Zod parse — missing `confirm: true` on any single delete fails the entire batch.
+
+In direct-mode stdio, emit pre-execution audit per Principle 19.
+
+#### C.6 Required Review Gate
+
+Tool-surface review after Slice C: confirm universal record operations are stable and do not leak transport or secret details.
+
+#### C.7 Required Tests (Slice C)
+
+File: `src/__tests__/core-records.test.ts`
+
+Mock `OrbitClient` with `vi.fn()` — mock the resource methods, not `fetch`.
+
+1. `get_record` with `object_type: 'contacts'` calls `client.contacts.get(record_id)` and returns a content block with `parsed.ok === true` and `parsed.data.id` matching the mock response.
+2. `get_record` with an unsupported `object_type` returns `UNSUPPORTED_OBJECT_TYPE` error.
+3. `create_record` calls the correct resource's `create()` method and returns envelope.
+4. `update_record` calls `update()` on the correct resource.
+5. `delete_record` with `confirm: true` calls `delete()` and returns success.
+6. `delete_record` with `confirm: false` returns `DESTRUCTIVE_CONFIRM_REQUIRED`, does NOT call `delete()`.
+7. `delete_record` with `confirm` omitted returns `DESTRUCTIVE_CONFIRM_REQUIRED`, does NOT call `delete()`.
+8. `search_records` with `object_type: 'all'` calls `client.search.query()` — does NOT return `UNSUPPORTED_OBJECT_TYPE`.
+8b. `search_records` with `object_type: 'contacts'` calls `client.contacts.search()` — does NOT call `client.search.query()`.
+9. `relate_records` with `relationship_type: 'tag'` calls `client.tags.attach()`.
+10. `relate_records` with `relationship_type: 'contact_company'` calls `client.contacts.update()` with `company_id`.
+11. `bulk_operation` with delete operations validates each individual `confirm: true`.
+12. `bulk_operation` for `object_type: 'users'` (unsupported) returns `UNSUPPORTED_OBJECT_TYPE`.
+13. `create_record` for `object_type: 'webhooks'` in direct mode with a private-IP `url` returns `SSRF_BLOCKED`.
+14. `delete_record` registration wrapper: when `caps.elicitation` is true and elicit returns `accept` + `confirmed: true`, `executeTool` is called with `confirm: true` and `delete()` is invoked.
+15. `delete_record` registration wrapper: when `caps.elicitation` is true and elicit returns `decline`, returns `DESTRUCTIVE_CONFIRM_REQUIRED` and `delete()` is NOT invoked.
+
+Dispatch coverage (parameterized):
+16. `get_record` dispatches correctly for: `contacts`, `deals`, `companies`, `activities`, `tasks`.
+
+Exit criteria:
+
+- agents can discover and mutate core records without needing specialized tools first
+
+---
+
+### Slice D. Relationship And Workflow Tool Slice
+
+Goal:
+
+- add the semantic workflow tools only where the SDK/API seam already exists or is explicitly accepted
+
+Scope: `get_pipelines`, `move_deal_stage`, `get_pipeline_stats`, `log_activity`, `list_activities`, `enroll_in_sequence`, `unenroll_from_sequence`, `assign_record`
+
+Files: `src/tools/pipelines.ts`, `src/tools/activities.ts`, `src/tools/sequences.ts`, `src/tools/team.ts`
+
+#### D.1 Exact SDK Calls Per Tool
+
+- `get_pipelines` → `client.pipelines.list(query?)` — do NOT use `client.deals.pipeline()` which serves a different purpose
+- `move_deal_stage` → `client.deals.move(deal_id, { stage_id })` — see Section 2.5 for `occurred_at`/`note` caveat; never use `client.deals.update({ stage_id })`
+- `get_pipeline_stats` → `client.deals.stats(query?)`
+- `log_activity` → `client.activities.log(body)` — NOT `create()`; `log()` posts to `/v1/activities/log`; `body` must include `type` and `occurred_at`
+- `list_activities` → `client.activities.list(query?)`
+- `enroll_in_sequence` → `client.sequences.enroll(sequence_id, { contact_id, ...body })` (see Section 2.2)
+- `unenroll_from_sequence` → `client.sequenceEnrollments.unenroll(enrollment_id)` — see Section 2.6 for `reason`/`idempotency_key` caveat
+- `assign_record` → `client.<entity>.update(record_id, { assigned_to_user_id: user_id })` — supported entities: contacts, companies, deals, tasks only
+
+`list_activities` output must truncate `body` and `subject` fields to 5,000 characters per the general truncation rule.
+
+`bulk_operation` with delete operations in direct mode: emit pre-execution audit log to stderr (Principle 19) before the first delete is dispatched.
+
+#### D.2 Required Review Gate (implicit)
+
+If any workflow or relationship seam is still missing from `@orbit-ai/sdk`, add it there first instead of backfilling directly inside MCP.
+
+#### D.3 Required Tests (Slice D)
+
+File: `src/__tests__/workflows.test.ts`
+
+1. `move_deal_stage` calls `client.deals.move()`, does NOT call `client.deals.update()`.
+2. `move_deal_stage` passes only `{ stage_id }` to `deals.move()` — `occurred_at` and `note` are stripped from the SDK call until the SDK type is extended (see Section 2.5).
+3. `enroll_in_sequence` calls `client.sequences.enroll(sequence_id, { contact_id })` — not `client.sequenceEnrollments.create()`.
+4. `unenroll_from_sequence` calls `client.sequenceEnrollments.unenroll(enrollment_id)` — not `client.sequenceEnrollments.delete()`.
+5. `assign_record` for `object_type: 'contacts'` calls `client.contacts.update(record_id, { assigned_to_user_id })`.
+6. `assign_record` for `object_type: 'stages'` (unsupported) returns `UNSUPPORTED_OBJECT_TYPE`.
+7. `log_activity` calls `client.activities.log()` — NOT `create()` — with required `type` and `occurred_at` fields.
+8. `list_activities` output truncates `body` fields longer than 5,000 characters.
+9. `bulk_operation` delete operations in direct mode emit audit log before SDK call.
+10. `bulk_operation` with mixed operations (create + delete): missing `confirm: true` on any delete fails entire batch.
+
+Exit criteria:
+
+- the agent-facing semantic tools exist only where they provide real abstraction over accepted workflows
+
+---
+
+### Slice E. Resources, Stdio Transport, And Trusted Local Runtime
+
+Goal:
+
+- make the local agent path usable before hosted HTTP transport breadth lands
+
+Scope: `src/transports/stdio.ts`, `src/resources/team-members.ts`, `src/resources/schema.ts`
+
+#### E.1 stdio Transport
+
+stdio mode is the default for local agents. The preconfigured `OrbitClient` is passed in by the caller (CLI or embedding code). The MCP package does not construct its own client.
+
+When the client is backed by `DirectTransport`, emit the direct-mode startup warning (Principle 15) before accepting any requests.
+
+#### E.2 Resource Handlers
+
+`orbit://team-members`:
+
+```typescript
+export async function readTeamMembers(client: OrbitClient) {
+  const result = await client.users.list({ limit: 100 })
+  return {
+    contents: [{
+      uri: 'orbit://team-members',
+      mimeType: 'application/json',
+      text: JSON.stringify({
+        _type: 'orbit_resource',
+        _untrusted: true,
+        data: result.data.map(truncateUserFields),
+      }, null, 2),
+    }],
+  }
+}
+```
+
+`orbit://schema`:
+
+```typescript
+export async function readSchema(client: OrbitClient) {
+  const result = await client.schema.listObjects()
+  return {
+    contents: [{
+      uri: 'orbit://schema',
+      mimeType: 'application/json',
+      text: JSON.stringify({
+        _type: 'orbit_resource',
+        _untrusted: true,
+        data: result,
+      }, null, 2),
+    }],
+  }
+}
+```
+
+Both resources must truncate individual string fields to 500 characters (Principle 18).
+
+#### E.3 Required Review Gate
+
+Agent-UX review after Slice E: confirm local tool discovery, resources, and error payloads are deterministic enough for agent use.
+
+#### E.4 Required Tests (Slice E)
+
+File: `src/__tests__/resources.test.ts`
+
+1. `readTeamMembers` returns content with `uri: 'orbit://team-members'` and `mimeType: 'application/json'`.
+2. `readTeamMembers` output wraps data in `{ _type: 'orbit_resource', _untrusted: true, data: [...] }`.
+3. `readTeamMembers` truncates user string fields longer than 500 characters.
+4. `readSchema` returns content with `uri: 'orbit://schema'` and `_untrusted: true` wrapper.
+
+File: `src/__tests__/stdio-transport.test.ts`
+
+5. stdio transport exposes the same `buildTools()` registry as HTTP (invoke `ListToolsRequestSchema` handler, assert tool count = 23).
+6. stdio transport in direct mode emits a startup warning to stderr.
+
+Exit criteria:
+
+- local MCP can run end-to-end with the stable tool slice and resources
+
+---
+
+### Slice F. HTTP Transport And Hosted Runtime Boundary
+
+Goal:
+
+- add the hosted/remote transport without forking the tool contract
+
+Scope: `src/transports/http.ts`
+
+#### F.1 Auth Requirements
+
+There is no separate Orbit token-validation HTTP endpoint. The only real auth seam is `adapter.lookupApiKeyForAuth(hash)` in `packages/api/src/middleware/auth.ts`, which hashes the raw token with SHA-256 and performs a local DB lookup. The MCP HTTP transport must use the same pattern.
+
+`startMcpServer()` must accept an `adapter` option of type `RuntimeApiAdapter` (imported from `@orbit-ai/api`) when `transport: 'http'` is selected. The caller (CLI or embed) is responsible for constructing and passing in the adapter. The MCP package must not construct its own adapter.
+
+Each HTTP request must be authenticated before the MCP request body is decoded:
+
+1. Extract `Authorization: Bearer <token>` header. Missing or malformed → HTTP 401 immediately.
+2. Hash the raw token with `crypto.subtle.digest('SHA-256', ...)` — the same `hashToken()` approach used in the API middleware.
+3. Call `adapter.lookupApiKeyForAuth(hash)`. If null → HTTP 401. If key has `revokedAt !== null` or has expired → HTTP 401.
+4. On success, extract `organizationId` and `scopes` from the key and attach them to the request context so tool handlers can scope SDK calls correctly.
+5. Missing or invalid token → HTTP 401 with a structured JSON body before any tool executes.
+
+**`startMcpServer` HTTP signature addition** (update the Section A.3 signature):
+
+```typescript
+export async function startMcpServer(options: {
+  client: import('@orbit-ai/sdk').OrbitClient
+  transport: 'stdio' | 'http'
+  port?: number
+  bindAddress?: string
+  adapter?: import('@orbit-ai/api').RuntimeApiAdapter  // required when transport === 'http'
+}): Promise<void>
+```
+
+If `transport === 'http'` and `adapter` is not provided, throw synchronously with a clear error before binding the port.
+
+#### F.2 Binding Requirements
+
+- Default bind address: `127.0.0.1`. Never `0.0.0.0` by default.
+- `options.bindAddress` can override. If set to anything other than `127.0.0.1`, emit a stderr warning.
+
+#### F.3 Transport Parity
+
+The HTTP transport uses the same `buildTools()` and `executeTool()` as the stdio transport. No transport-specific tool definitions or handler branches.
+
+In-memory test harness: construct a test helper `invokeListTools(server)` and `invokeCallTool(server, toolName, args)` that calls the MCP server's registered request handlers directly — without spawning actual stdio/HTTP processes. Use this harness for transport parity tests.
+
+#### F.4 Required Review Gate
+
+Transport-parity review after Slice F: confirm stdio and HTTP expose the same tools, resources, and error semantics.
+
+#### F.5 Required Tests (Slice F)
+
+File: `src/__tests__/http-transport.test.ts`
+
+1. Request without `Authorization` header → HTTP 401, MCP-structured error body.
+2. Request with invalid bearer token (mock API validation to return 401) → HTTP 401.
+3. `ListToolsRequestSchema` handler via HTTP returns 23 tools (using in-memory harness).
+4. Transport parity: `buildTools()` names from stdio handler == names from HTTP handler (sorted).
+5. `CallToolRequestSchema` for `get_record` via HTTP returns same response structure as via stdio handler (using in-memory harness).
+6. HTTP transport binds to `127.0.0.1` by default (assert `options.bindAddress` defaults to `'127.0.0.1'` in server config).
+
+Exit criteria:
+
+- both supported transports work against one core runtime
+
+---
+
+### Slice G. Schema, Import/Export, Analytics Tool Slice, And Secret Redaction Tests
+
+Goal:
+
+- complete the remaining 23-tool registry, implement schema tools where the seam exists, and stub gated tools; write all secret-redaction tests
+
+Scope: `src/tools/schema.ts`, `src/tools/imports.ts`, `src/tools/analytics.ts`
+
+#### G.1 Schema Tools
+
+`get_schema` → `client.schema.listObjects()` (all) or `client.schema.describeObject(type)` (specific)
+`create_custom_field` → `client.schema.addField(type, body)`
+`update_custom_field` → `client.schema.updateField(type, fieldName, body)`
+
+These tools must be gated if the schema engine is incomplete. If `client.schema.listObjects()` is not implemented, they must stub with `McpNotImplementedError`.
+
+#### G.2 Gated Tool Stubs
+
+`import_records`, `export_records`, `run_report`, `get_dashboard_summary` must all be registered in `buildTools()` and must all return a structured `McpNotImplementedError` when called (Section 3.2). Never throw. Never crash the session. Never omit from the registry.
+
+#### G.3 Required Review Gate
+
+Dependency review after Slice G: confirm the last tools are backed by real client seams rather than MCP-local assumptions.
+
+#### G.4 Required Tests (Slice G)
+
+File: `src/__tests__/gated-tools.test.ts`
+
+For each gated tool name: `['import_records', 'export_records', 'run_report', 'get_dashboard_summary']`:
+
+1. `executeTool(mockClient, toolName, { object_type: 'contacts' })` returns `{ isError: true }` with `parsed.error.code === 'DEPENDENCY_NOT_AVAILABLE'` — does NOT throw.
+
+File: `src/__tests__/secret-redaction.test.ts`
+
+2. `get_record` for `object_type: 'webhooks'` where the mock SDK response contains `signing_secret: 'whsec_SUPERSECRET'` → the content block text does NOT contain `'SUPERSECRET'` or `'signing_secret'`.
+3. Constructing `McpIntegrationConnectionRead` from a raw object containing `access_token: 'ya29.REALTOKEN'` and `refresh_token: 'rt_REALREFRESH'` → the DTO JSON does NOT contain either token, and `credentials_redacted === true`.
+4. `toToolError({ code: 'INTERNAL_ERROR', message: 'access_token: ya29.LEAKED' })` → content block text does NOT contain `'ya29.LEAKED'`.
+
+Exit criteria:
+
+- all 23 core tools exist and map to accepted underlying capabilities
+
+---
+
+### Slice H. Final Hardening, Composite-Runtime Guardrails, And Security Review
+
+Goal:
+
+- finish the MCP package with explicit safety, review, and future-extension boundaries
+
+Scope: final docs, review artifacts, extension-tool boundary documentation
+
+#### H.1 Required Behavior
+
+- the core package remains fixed at 23 tools
+- extension-tool guidance documented: extension tools use provider namespaces (`integrations.gmail.send_email`), registered only in composite server runtimes, never in core `buildTools()`
+- `README.md` must document: direct-mode trust boundaries, startup warning behavior, HTTP transport auth model
+- secret-redaction, truncation, and error-hint behavior all have test coverage (verified by review)
+
+#### H.2 Required Review Gates
+
+**Code review**: confirm no tool handler accesses core services or API routes directly; all execution goes through the SDK; all 23 tools are in `buildTools()`.
+
+**Agent-tooling review**: selection quality of tool descriptions, deterministic outputs, `hint`/`recovery` guidance is actionable.
+
+**Security review** — named checklist (must produce artifact at `docs/review/<date>-mcp-security-review.md`):
+
+- [ ] Every tool handler validates `args` with its Zod schema at runtime before any SDK call (test reference required)
+- [ ] `delete_record` handler rejects `{ confirm: false }` with `DESTRUCTIVE_CONFIRM_REQUIRED` — not a deletion (test reference required)
+- [ ] Every delete in `bulk_operation` is individually Zod-validated at runtime (test reference required)
+- [ ] `toToolError()` does not include token-shaped strings in output (test reference required: `errors.test.ts` case 12)
+- [ ] `orbit://team-members` and `orbit://schema` responses are wrapped with `_untrusted: true`
+- [ ] `create_record` for `webhooks` in direct mode validates `url` against SSRF block list (test reference required)
+- [ ] stdio direct mode emits startup warning to stderr listing absent protections
+- [ ] HTTP transport binds to `127.0.0.1` by default (test reference required)
+- [ ] HTTP transport validates bearer tokens via Orbit API (not locally)
+- [ ] `bulkOperationTool.annotations.destructiveHint === true` asserted in test (test reference required)
+- [ ] Gated tools return `DEPENDENCY_NOT_AVAILABLE` structured errors — not runtime crashes (test reference required)
+- [ ] All 23 tools are in `buildTools()` unconditionally
+
+Exit criteria:
+
+- the MCP package is accepted as a stable agent interface over the SDK and API contract
+
+## 10. Validation Matrix
+
+At minimum, the MCP branch must prove:
+
+- `packages/mcp` exists and builds cleanly
+- exactly 23 core tools are registered and the count is asserted in a test
+- every tool includes required annotations and all are booleans — asserted in a test
+- stdio and HTTP transports expose the same registry (transport parity test)
+- tool handlers return `{ ok: true, data, meta }` content blocks
+- tool errors always include `hint` and `recovery` with default fallbacks tested
+- `toToolError()` does not echo token-shaped strings — tested with synthetic message
+- `delete_record` with `confirm: false` returns a structured error — not a deletion
+- `move_deal_stage` calls `client.deals.move()`, not `client.deals.update()`
+- gated tools return `DEPENDENCY_NOT_AVAILABLE` structured errors — not runtime crashes
+- `orbit://team-members` and `orbit://schema` resources wrap data with `_untrusted: true`
+- `create_record` for `webhooks` in direct mode validates SSRF block list
+- no tool bypasses the SDK to recreate business logic in MCP
+
+## 11. Branch Exit Criteria
+
+The MCP implementation branch is complete when:
+
+1. `packages/mcp` exists, builds cleanly, and starts in stdio and HTTP modes.
+2. The fixed 23-tool registry is implemented, all in `buildTools()` unconditionally, and test-guarded with count + annotation + idempotency assertions.
+3. Tool outputs and tool errors are structured, deterministic, and review-accepted.
+4. Required MCP resources are implemented with `_untrusted: true` framing.
+5. Final code, tooling, and security reviews return no blocking findings (all 12 security checklist items confirmed).
+6. Any still-missing dependencies for schema/export/analytics are gated as `McpNotImplementedError` stubs — not omitted and not simulated.
+7. **The MCP package reaches a minimum of 92 tests**:
+
+| Test area | Approx count |
+|-----------|-------------|
+| Server construction and startup (Slice A) | 5 |
+| Registry count, annotations, idempotency, dispatch (Slice B) | 15 |
+| `toToolError()` and error codes (Slice B) | 5 |
+| Core record tool handlers + dispatch coverage (Slice C) | 22 |
+| Workflow tool handlers (Slice D) | 10 |
+| Resource handlers and stdio transport (Slice E) | 6 |
+| HTTP transport auth and parity (Slice F) | 6 |
+| Gated tool stubs and secret redaction (Slice G) | 8 |
+| Final integration / smoke (Slice H) | 5 |
+
+This brings the projected repo total to approximately 884 tests (current baseline: 794 after CLI target).

--- a/docs/superpowers/plans/2026-04-09-cli-codex-fixes.md
+++ b/docs/superpowers/plans/2026-04-09-cli-codex-fixes.md
@@ -1,0 +1,1051 @@
+# CLI Codex Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all 11 issues surfaced by the Codex correctness + security review of `packages/cli/`, covering 4 high, 5 medium, 2 low findings, and 4 coverage gaps.
+
+**Architecture:** Three parallel fix tracks (A: program + JSON mode, B: config layer, C: individual commands) followed by a test track. Tracks A–C touch disjoint files and can be executed in parallel; tests must follow.
+
+**Tech Stack:** TypeScript strict, Commander.js, Vitest, `@orbit-ai/sdk`, `@orbit-ai/core`
+
+---
+
+## Track A — Commander error contract + JSON mode unification
+
+**Files:**
+- Modify: `packages/cli/src/program.ts`
+- Modify: `packages/cli/src/commands/contacts.ts`
+- Modify: `packages/cli/src/commands/search.ts`
+- Modify: `packages/cli/src/commands/context.ts`
+- Modify: `packages/cli/src/commands/companies.ts`
+- Modify: `packages/cli/src/commands/deals.ts`
+- Modify: `packages/cli/src/commands/users.ts`
+- Modify: `packages/cli/src/commands/pipelines.ts`
+- Modify: `packages/cli/src/commands/stages.ts`
+- Modify: `packages/cli/src/commands/activities.ts`
+- Modify: `packages/cli/src/commands/tasks.ts`
+- Modify: `packages/cli/src/commands/notes.ts`
+- Modify: `packages/cli/src/commands/products.ts`
+- Modify: `packages/cli/src/commands/payments.ts`
+- Modify: `packages/cli/src/commands/contracts.ts`
+- Modify: `packages/cli/src/commands/sequences.ts`
+- Modify: `packages/cli/src/commands/tags.ts`
+- Modify: `packages/cli/src/commands/log.ts`
+- Test: `packages/cli/src/__tests__/program.test.ts`
+
+### Task A1: Commander exitOverride → structured JSON errors
+
+**Problem:** Commander calls `process.exit()` directly on parse errors (missing required options, unknown flags), bypassing our `try/catch` in `run()`. The structured `{ error: ... }` JSON contract is therefore not applied to Commander-level errors.
+
+**Fix:** Call `program.exitOverride()` so Commander throws `CommanderError` instead. Add a `CommanderError` branch in `classifyError`.
+
+- [ ] **Step 1: Add `CommanderError` import and handler in `classifyError`**
+
+  File: `packages/cli/src/program.ts`
+
+  After the existing `CliNotImplementedError` branch (line 50), add before the generic catch-all:
+
+  ```typescript
+  // Commander parse/validation errors (exitOverride surfaces these as CommanderError)
+  if (
+    error instanceof Error &&
+    error.constructor.name === 'CommanderError' &&
+    'exitCode' in error
+  ) {
+    const ce = error as { exitCode: number; code?: string; message: string }
+    return {
+      code: ce.exitCode === 0 ? 0 : 2,
+      payload: {
+        code: ce.code ?? 'COMMANDER_ERROR',
+        message: ce.message,
+      },
+    }
+  }
+  ```
+
+- [ ] **Step 2: Call `exitOverride()` on the program before `parseAsync`**
+
+  In `run()` (program.ts line 180), change:
+
+  ```typescript
+  const program = createProgram()
+  await program.parseAsync(process.argv)
+  ```
+
+  to:
+
+  ```typescript
+  const program = createProgram()
+  program.exitOverride()
+  await program.parseAsync(process.argv)
+  ```
+
+- [ ] **Step 3: Run tests**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test --reporter=verbose 2>&1 | tail -20
+  ```
+
+  Expected: all tests pass (Commander now throws instead of calling process.exit).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/program.ts && git commit -m "fix(cli): Commander exitOverride — parse errors now flow through JSON error contract"
+  ```
+
+---
+
+### Task A2: Replace `flags.json` with `isJsonMode()` in all commands
+
+**Problem:** `flags.json` is only truthy for `--json`. The preAction hook also sets `_jsonMode = true` for `--format json`, but commands branch on `flags.json`, so `orbit --format json contacts list` uses the human formatter instead of the raw envelope path.
+
+**Fix:** In every command, replace `flags.json` with `isJsonMode()`. Import `isJsonMode` at the top of each command file.
+
+The commands that need this change are all files that contain `if (flags.json)`:
+
+- `packages/cli/src/commands/contacts.ts`
+- `packages/cli/src/commands/companies.ts`
+- `packages/cli/src/commands/deals.ts`
+- `packages/cli/src/commands/users.ts`
+- `packages/cli/src/commands/pipelines.ts`
+- `packages/cli/src/commands/stages.ts`
+- `packages/cli/src/commands/activities.ts`
+- `packages/cli/src/commands/tasks.ts`
+- `packages/cli/src/commands/notes.ts`
+- `packages/cli/src/commands/products.ts`
+- `packages/cli/src/commands/payments.ts`
+- `packages/cli/src/commands/contracts.ts`
+- `packages/cli/src/commands/sequences.ts`
+- `packages/cli/src/commands/tags.ts`
+- `packages/cli/src/commands/log.ts`
+- `packages/cli/src/commands/search.ts`
+- `packages/cli/src/commands/context.ts`
+
+For each file:
+
+- [ ] **Step 1: Find all occurrences**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && grep -rn "flags\.json" packages/cli/src/commands/
+  ```
+
+- [ ] **Step 2: Update imports**
+
+  For each command file that uses `flags.json`, add `isJsonMode` to the import from `'../program.js'`. Example for contacts.ts:
+
+  ```typescript
+  import { isJsonMode } from '../program.js'
+  ```
+
+- [ ] **Step 3: Replace usages**
+
+  In each file, replace every occurrence of `flags.json` with `isJsonMode()`. The pattern is always:
+
+  ```typescript
+  // Before
+  if (flags.json) {
+  
+  // After
+  if (isJsonMode()) {
+  ```
+
+  Run the replacement:
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && \
+    grep -rl "flags\.json" packages/cli/src/commands/ | \
+    xargs sed -i '' 's/flags\.json/isJsonMode()/g'
+  ```
+
+  Then for each of those files, add the import if missing:
+
+  ```bash
+  grep -L "isJsonMode" packages/cli/src/commands/contacts.ts packages/cli/src/commands/search.ts packages/cli/src/commands/context.ts
+  ```
+
+  For files missing the import, add `import { isJsonMode } from '../program.js'` after the existing imports.
+
+- [ ] **Step 4: Typecheck**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli typecheck 2>&1 | tail -20
+  ```
+
+  Expected: 0 errors.
+
+- [ ] **Step 5: Run tests**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test 2>&1 | tail -10
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/commands/ && git commit -m "fix(cli): all commands use isJsonMode() — --format json now triggers JSON envelope path"
+  ```
+
+---
+
+## Track B — Config layer fixes
+
+**Files:**
+- Modify: `packages/cli/src/config/resolve-context.ts`
+- Modify: `packages/cli/src/config/files.ts`
+
+### Task B1: Resolve `apiKeyEnv` from config files
+
+**Problem:** `init` writes `apiKeyEnv: 'ORBIT_API_KEY'` to config.json, but `resolve-context.ts:130` reads `fileConfig.apiKey` — never `fileConfig.apiKeyEnv`. Users who follow the secure scaffolded pattern end up with no API key and a confusing "apiKey is required" error.
+
+**Fix:** After reading fileConfig, if `apiKey` is still undefined and `fileConfig.apiKeyEnv` is set, read `env[fileConfig.apiKeyEnv]` as the api key.
+
+- [ ] **Step 1: Add apiKeyEnv resolution in `resolveClient`**
+
+  File: `packages/cli/src/config/resolve-context.ts`
+
+  Change line 130 from:
+
+  ```typescript
+  const apiKey = flags.apiKey ?? env['ORBIT_API_KEY'] ?? fileConfig.apiKey
+  ```
+
+  to:
+
+  ```typescript
+  const apiKeyFromEnvName =
+    fileConfig.apiKeyEnv ? env[fileConfig.apiKeyEnv] : undefined
+  const apiKey =
+    flags.apiKey ?? env['ORBIT_API_KEY'] ?? fileConfig.apiKey ?? apiKeyFromEnvName
+  ```
+
+- [ ] **Step 2: Run tests**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test 2>&1 | tail -10
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/config/resolve-context.ts && git commit -m "fix(cli): resolve apiKeyEnv from config file — secure scaffolded configs now work"
+  ```
+
+---
+
+### Task B2: Fix nested CWD config discovery (allowedRoots must include ancestors)
+
+**Problem:** `findProjectConfig` walks up from `cwd` and can return a path like `/projects/orbit/.orbit/config.json` when `cwd` is `/projects/orbit/packages/cli/`. `canonicalizePath` then rejects it because the allowed roots are only `[cwd, home]`, not ancestors of cwd.
+
+**Fix:** Build `allowedRoots` by collecting all ancestor directories of `cwd` up to (and including) `home`.
+
+- [ ] **Step 1: Extract ancestor-collection helper**
+
+  File: `packages/cli/src/config/files.ts`
+
+  Add after the `tryRealpath` helper (around line 131):
+
+  ```typescript
+  /** Collect real paths of all ancestors of dir up to and including home (inclusive). */
+  function ancestorRoots(dir: string, home: string): string[] {
+    const roots: string[] = []
+    let current = tryRealpath(dir)
+    const realHome = tryRealpath(home)
+    while (true) {
+      roots.push(current)
+      if (current === realHome) break
+      const parent = path.dirname(current)
+      if (parent === current) break // filesystem root
+      current = parent
+    }
+    if (!roots.includes(realHome)) roots.push(realHome)
+    return roots
+  }
+  ```
+
+- [ ] **Step 2: Use `ancestorRoots` in `loadConfig`**
+
+  Change line 140 from:
+
+  ```typescript
+  const allowedRoots = [tryRealpath(cwd), tryRealpath(home)]
+  ```
+
+  to:
+
+  ```typescript
+  const allowedRoots = ancestorRoots(cwd, home)
+  ```
+
+- [ ] **Step 3: Run tests**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test 2>&1 | tail -10
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/config/files.ts && git commit -m "fix(cli): config discovery works from nested cwd — allowedRoots now includes cwd ancestors"
+  ```
+
+---
+
+### Task B3: Implement `--profile` resolution
+
+**Problem:** `--profile <name>` is registered as a flag and `profiles` is in the config schema, but profile selection is never applied. Users who configure named profiles get silently ignored.
+
+**Fix:** After merging userConfig and projectConfig, if a profile name is specified (from flags → env → config default), look up `profiles[name]` in the merged config and layer it on top.
+
+- [ ] **Step 1: Export a `resolveProfile` helper from `files.ts`**
+
+  Add after `loadConfig`:
+
+  ```typescript
+  /**
+   * Apply a named profile on top of a base config.
+   * Returns the base config unchanged if the profile doesn't exist.
+   */
+  export function applyProfile(base: OrbitConfig, profileName: string): OrbitConfig {
+    const profile = base.profiles?.[profileName]
+    if (!profile) return base
+    // Strip profiles from the overlay to avoid nesting
+    const { profiles: _profiles, ...profileData } = profile as OrbitConfig
+    return { ...base, ...profileData }
+  }
+  ```
+
+- [ ] **Step 2: Apply profile in `resolveClient`**
+
+  File: `packages/cli/src/config/resolve-context.ts`
+
+  Add import for `applyProfile`:
+
+  ```typescript
+  import { loadConfig, applyProfile, type OrbitConfig } from './files.js'
+  ```
+
+  After line 122 (`const fileConfig = loadConfig(cwd, overrideHome)`), add:
+
+  ```typescript
+  // Resolve profile: flag > env > config default
+  const profileName = flags.profile ?? env['ORBIT_PROFILE'] ?? fileConfig.profile
+  const mergedFileConfig = profileName ? applyProfile(fileConfig, profileName) : fileConfig
+  ```
+
+  Then replace all occurrences of `fileConfig` in the resolution block (lines 128–141) with `mergedFileConfig`.
+
+- [ ] **Step 3: Typecheck + test**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli typecheck && pnpm --filter @orbit-ai/cli test 2>&1 | tail -10
+  ```
+
+  Expected: 0 errors, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/config/ && git commit -m "fix(cli): implement --profile resolution — named config profiles now applied at runtime"
+  ```
+
+---
+
+### Task B4: SQLite direct mode default path + URL allowlist
+
+**Problem 1:** When no `--database-url` is given in direct SQLite mode, `dbPath` is `''` which falls through to `:memory:`. This silently discards all data between commands. The plan specifies the default should be `./.orbit/orbit.db`.
+
+**Problem 2:** The URL scheme allowlist only blocks `http(s)://`. Other schemes like `ftp://`, `ssh://`, `s3://` pass through as literal filenames.
+
+**Fix 1:** Default `dbPath` to `.orbit/orbit.db` (relative to cwd) when empty.
+**Fix 2:** Block any URL that contains `://` but is not `file://` or bare path.
+
+- [ ] **Step 1: Fix SQLite default path**
+
+  File: `packages/cli/src/config/resolve-context.ts`
+
+  The `resolveAdapter` function currently receives `flags` and `config` but not `cwd`. Change the signature to accept a `cwd` parameter and pass it through:
+
+  ```typescript
+  function resolveAdapter(flags: GlobalFlags, config: OrbitConfig, cwd: string): StorageAdapter {
+  ```
+
+  Then change the fallback in the sqlite branch:
+
+  ```typescript
+  // Before (line 60):
+  dbPath = dbUrl || ':memory:'
+  
+  // After:
+  dbPath = dbUrl || path.join(cwd, '.orbit', 'orbit.db')
+  ```
+
+  Update the call site on line 157:
+
+  ```typescript
+  const resolvedAdapter = resolveAdapter(flags, resolvedConfig, cwd ?? process.cwd())
+  ```
+
+  Add `import * as path from 'node:path'` at the top of resolve-context.ts (if not already present).
+
+- [ ] **Step 2: Expand URL scheme allowlist**
+
+  In the sqlite validation block (around line 41), replace the http-only check:
+
+  ```typescript
+  // Before:
+  if (dbUrl && /^https?:\/\//i.test(dbUrl)) {
+  
+  // After — block any scheme except file:
+  if (dbUrl && /^[a-z][a-z0-9+\-.]*:\/\//i.test(dbUrl) && !/^file:\/\//i.test(dbUrl)) {
+  ```
+
+  The error message should reflect the broader rejection:
+
+  ```typescript
+  throw new CliValidationError(
+    `SQLite database URL must be a file path or file: URI, not a remote URL. Scheme+host: '${safeUrl}'`,
+    { code: 'MISSING_REQUIRED_CONFIG', path: 'databaseUrl' },
+  )
+  ```
+
+- [ ] **Step 3: Typecheck + test**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli typecheck && pnpm --filter @orbit-ai/cli test 2>&1 | tail -10
+  ```
+
+  Expected: 0 errors, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/config/resolve-context.ts && git commit -m "fix(cli): SQLite default path is .orbit/orbit.db; URL allowlist blocks all non-file schemes"
+  ```
+
+---
+
+## Track C — Command-specific fixes
+
+**Files:**
+- Modify: `packages/cli/src/commands/migrate.ts`
+- Modify: `packages/cli/src/commands/seed.ts`
+- Modify: `packages/cli/src/commands/status.ts`
+- Modify: `packages/cli/src/commands/doctor.ts`
+
+### Task C1: migrate --apply destructive gating
+
+**Problem:** `migrate.ts:34` treats `opts.apply` as always destructive (requires `--yes`). The plan says only migrations that contain DROP/RENAME operations need confirmation. Additive migrations should apply without a prompt.
+
+**Fix:** Preview first. If the preview response contains destructive operations (any key containing `drop` or `rename` case-insensitively, or a dedicated `destructive` flag), then require `--yes`. Otherwise apply directly.
+
+- [ ] **Step 1: Rewrite `runMigrate` apply path**
+
+  File: `packages/cli/src/commands/migrate.ts`
+
+  Replace the `isDestructive` check at the top of `runMigrate` and the `opts.apply` block:
+
+  ```typescript
+  async function runMigrate(
+    flags: GlobalFlags,
+    opts: { preview?: boolean; apply?: boolean; rollback?: boolean; id?: string; yes?: boolean },
+  ): Promise<void> {
+    // --rollback is always destructive
+    const isDefinitelyDestructive = opts.rollback
+    const isTTY = process.stdout.isTTY
+    const confirmed = opts.yes === true || flags.yes === true
+
+    if (isDefinitelyDestructive && !confirmed) {
+      if (isJsonMode() || !isTTY) {
+        process.stdout.write(JSON.stringify(DESTRUCTIVE_ERROR) + '\n', () => {
+          process.exit(1)
+        })
+        return
+      }
+      const ok = await confirmAction('Are you sure you want to run this migration? [y/N] ')
+      if (!ok) {
+        process.stdout.write('Aborted.\n')
+        process.exit(1)
+        return
+      }
+    }
+
+    const client = resolveClient({ flags })
+
+    if (opts.preview) {
+      const preview = await client.schema.previewMigration({})
+      if (isJsonMode()) {
+        process.stdout.write(JSON.stringify(preview, null, 2) + '\n')
+      } else {
+        process.stdout.write(JSON.stringify(preview, null, 2) + '\n')
+      }
+      return
+    }
+
+    if (opts.apply) {
+      // Preview first to detect destructive operations
+      const preview = await client.schema.previewMigration({})
+      const previewStr = JSON.stringify(preview).toLowerCase()
+      const hasDestructive =
+        (typeof (preview as { destructive?: boolean }).destructive === 'boolean'
+          ? (preview as { destructive?: boolean }).destructive
+          : false) ||
+        /\b(drop|rename)\b/.test(previewStr)
+
+      if (hasDestructive && !confirmed) {
+        if (isJsonMode() || !isTTY) {
+          process.stdout.write(
+            JSON.stringify({
+              ...DESTRUCTIVE_ERROR,
+              error: { ...DESTRUCTIVE_ERROR.error, preview },
+            }) + '\n',
+            () => { process.exit(1) },
+          )
+          return
+        }
+        const ok = await confirmAction(
+          'This migration contains destructive operations. Confirm? [y/N] ',
+        )
+        if (!ok) {
+          process.stdout.write('Aborted.\n')
+          process.exit(1)
+          return
+        }
+      }
+
+      const result = await client.schema.applyMigration({})
+      if (isJsonMode()) {
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        process.stdout.write(`Migration applied:\n${JSON.stringify(result, null, 2)}\n`)
+      }
+      return
+    }
+
+    if (opts.rollback) {
+      if (!opts.id) {
+        throw new CliValidationError('--rollback requires --id <migration-id>', {
+          code: 'MISSING_REQUIRED_ARG',
+          path: 'id',
+        })
+      }
+      const result = await client.schema.rollbackMigration(opts.id)
+      if (isJsonMode()) {
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        process.stdout.write(`Migration ${opts.id} rolled back:\n${JSON.stringify(result, null, 2)}\n`)
+      }
+      return
+    }
+  }
+  ```
+
+- [ ] **Step 2: Run tests**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test packages/cli/src/__tests__/destructive-actions.test.ts --reporter=verbose 2>&1 | tail -30
+  ```
+
+  Expected: all pass (existing destructive-action tests still cover rollback/destructive apply).
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/commands/migrate.ts && git commit -m "fix(cli): migrate --apply only requires --yes for destructive migrations, not all applies"
+  ```
+
+---
+
+### Task C2: seed — use resolved mode from config, not just flags.mode
+
+**Problem:** `seed.ts:18` checks `flags.mode !== 'direct'`. If mode comes from a config file (not CLI flags), `flags.mode` is `undefined` and the check falsely rejects valid direct-mode setups.
+
+**Fix:** Resolve the effective mode (same priority chain as `resolveClient`) before checking.
+
+- [ ] **Step 1: Read effective mode before gating**
+
+  File: `packages/cli/src/commands/seed.ts`
+
+  Add import:
+
+  ```typescript
+  import { loadConfig } from '../config/files.js'
+  ```
+
+  Change the guard in `runSeed`:
+
+  ```typescript
+  async function runSeed(flags: GlobalFlags, count: number): Promise<void> {
+    // Resolve effective mode: flag > config file > default 'api'
+    const fileConfig = loadConfig()
+    const effectiveMode = flags.mode ?? fileConfig.mode ?? 'api'
+
+    if (effectiveMode !== 'direct') {
+      const msg = 'orbit seed requires direct mode (--mode direct with a local adapter)'
+      if (isJsonMode()) {
+        process.stdout.write(JSON.stringify({ error: { code: 'DIRECT_MODE_REQUIRED', message: msg } }) + '\n', () => {
+          process.exit(2)
+        })
+        return
+      } else {
+        process.stderr.write(msg + '\n')
+      }
+      process.exit(2)
+    }
+    // ... rest unchanged
+  ```
+
+- [ ] **Step 2: Run tests**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test 2>&1 | tail -10
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/commands/seed.ts && git commit -m "fix(cli): seed checks resolved mode from config, not just --mode flag"
+  ```
+
+---
+
+### Task C3: status — use standard error contract
+
+**Problem:** `status.ts` has its own error JSON shape (`{ status: 'error', connected: false, message: ... }`) and calls `process.exit(1)` directly in the catch block. Agent consumers get a different failure schema from the rest of the CLI (`{ error: { code, message } }`).
+
+**Fix:** Re-throw the error and let the top-level handler in `run()` format it. The success path stays as-is.
+
+- [ ] **Step 1: Rewrite the catch block**
+
+  File: `packages/cli/src/commands/status.ts`
+
+  Replace the catch block:
+
+  ```typescript
+  // Before:
+  } catch (e) {
+    if (isJsonMode()) {
+      process.stdout.write(JSON.stringify({ status: 'error', connected: false, message: (e as Error).message }) + '\n')
+    } else {
+      process.stderr.write(`Status: error — ${(e as Error).message}\n`)
+    }
+    process.exit(1)
+  }
+
+  // After:
+  } catch (e) {
+    // Re-throw so run()'s top-level handler applies the standard { error: ... } contract.
+    throw e
+  }
+  ```
+
+- [ ] **Step 2: Run tests**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test 2>&1 | tail -10
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/commands/status.ts && git commit -m "fix(cli): status error uses standard { error: ... } contract via top-level handler"
+  ```
+
+---
+
+### Task C4: doctor — correct Node.js version check
+
+**Problem:** `doctor.ts:21` checks `major >= 22`. The repo prerequisite (AGENTS.md and CLAUDE.md) is Node 20+. This produces false failures on Node 20 and 21, which are supported.
+
+- [ ] **Step 1: Fix the version check**
+
+  File: `packages/cli/src/commands/doctor.ts`
+
+  Change line 21:
+
+  ```typescript
+  // Before:
+  name: 'Node.js version >= 22',
+  pass: major >= 22,
+
+  // After:
+  name: 'Node.js version >= 20',
+  pass: major >= 20,
+  ```
+
+- [ ] **Step 2: Run tests**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test 2>&1 | tail -10
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/commands/doctor.ts && git commit -m "fix(cli): doctor checks Node >= 20 (project minimum), not >= 22"
+  ```
+
+---
+
+## Track D — Test coverage gaps (after Tracks A–C)
+
+**Files:**
+- Modify: `packages/cli/src/__tests__/program.test.ts`
+- Modify: `packages/cli/src/__tests__/config-resolve.test.ts`
+- Modify: `packages/cli/src/__tests__/destructive-actions.test.ts`
+- Possibly extend: `packages/cli/src/__tests__/exit-codes.test.ts`
+
+### Task D1: Test Commander exitOverride → JSON error on missing option
+
+- [ ] **Step 1: Write failing test**
+
+  File: `packages/cli/src/__tests__/program.test.ts`
+
+  ```typescript
+  import { run, _resetJsonMode } from '../program.js'
+
+  describe('Commander parse errors — JSON contract', () => {
+    let origArgv: string[]
+    let origExit: typeof process.exit
+    let exitCode: number | undefined
+    let stdout: string
+
+    beforeEach(() => {
+      origArgv = process.argv
+      origExit = process.exit
+      exitCode = undefined
+      stdout = ''
+      _resetJsonMode()
+      process.exit = ((code?: number) => {
+        exitCode = code ?? 0
+        throw new Error(`process.exit(${code})`)
+      }) as typeof process.exit
+      vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+        stdout += String(chunk)
+        return true
+      })
+    })
+
+    afterEach(() => {
+      process.argv = origArgv
+      process.exit = origExit
+      vi.restoreAllMocks()
+    })
+
+    it('--json flag: Commander error on unknown option produces { error: ... } JSON on stdout', async () => {
+      process.argv = ['node', 'orbit', '--json', '--unknown-flag-xyz']
+      await expect(run()).rejects.toThrow()
+      const parsed = JSON.parse(stdout)
+      expect(parsed).toHaveProperty('error')
+      expect(parsed.error).toHaveProperty('code')
+      expect(parsed.error).toHaveProperty('message')
+    })
+  })
+  ```
+
+- [ ] **Step 2: Verify test fails before fix (should now pass after Task A1)**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test packages/cli/src/__tests__/program.test.ts --reporter=verbose 2>&1 | grep -E "(PASS|FAIL|✓|✗)"
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/__tests__/program.test.ts && git commit -m "test(cli): Commander parse error produces JSON envelope when --json flag is set"
+  ```
+
+---
+
+### Task D2: Test `--format json` end-to-end through command action
+
+- [ ] **Step 1: Write test**
+
+  File: `packages/cli/src/__tests__/json-fidelity.test.ts` (extend existing file — add to the describe block)
+
+  ```typescript
+  it('--format json triggers isJsonMode() within a command action', async () => {
+    // contacts list mocked to return a result
+    // The key assertion: the raw envelope path (client.contacts.response().list) is called,
+    // not the human formatter path (client.contacts.list).
+    // Both flags.json and flags.format=json must activate JSON mode.
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    _resetJsonMode()
+
+    // Simulate preAction by parsing --format json
+    // (preAction hook fires during parse with parseAsync)
+    // We test the state of isJsonMode() after parse
+    const done = program.parseAsync(['node', 'orbit', '--format', 'json', '--help'], { from: 'user' }).catch(() => {})
+    await done
+    expect(isJsonMode()).toBe(true)
+  })
+  ```
+
+- [ ] **Step 2: Run**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test packages/cli/src/__tests__/json-fidelity.test.ts --reporter=verbose 2>&1 | tail -20
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/__tests__/json-fidelity.test.ts && git commit -m "test(cli): --format json sets isJsonMode() via preAction hook"
+  ```
+
+---
+
+### Task D3: Test apiKeyEnv loading
+
+- [ ] **Step 1: Write test**
+
+  File: `packages/cli/src/__tests__/config-resolve.test.ts`
+
+  Add inside `describe('config resolution — resolveClient', ...)`:
+
+  ```typescript
+  it('reads api key from env var named by apiKeyEnv in config', () => {
+    const tmp = makeTmpDir()
+    makeProjectConfig(tmp, { mode: 'api', apiKeyEnv: 'MY_CUSTOM_KEY' })
+    const env = { MY_CUSTOM_KEY: 'key-from-custom-env' }
+    const client = resolveClient({ flags: {}, env, cwd: tmp }) as unknown as { _opts: { apiKey: string } }
+    expect(client._opts.apiKey).toBe('key-from-custom-env')
+  })
+
+  it('apiKeyEnv is lower priority than ORBIT_API_KEY env var', () => {
+    const tmp = makeTmpDir()
+    makeProjectConfig(tmp, { mode: 'api', apiKeyEnv: 'MY_CUSTOM_KEY' })
+    const env = { ORBIT_API_KEY: 'standard-key', MY_CUSTOM_KEY: 'custom-key' }
+    const client = resolveClient({ flags: {}, env, cwd: tmp }) as unknown as { _opts: { apiKey: string } }
+    expect(client._opts.apiKey).toBe('standard-key')
+  })
+  ```
+
+- [ ] **Step 2: Run**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test packages/cli/src/__tests__/config-resolve.test.ts --reporter=verbose 2>&1 | tail -20
+  ```
+
+  Expected: new tests pass.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/__tests__/config-resolve.test.ts && git commit -m "test(cli): apiKeyEnv resolution from config file"
+  ```
+
+---
+
+### Task D4: Test profile resolution
+
+- [ ] **Step 1: Write test**
+
+  File: `packages/cli/src/__tests__/config-resolve.test.ts`
+
+  ```typescript
+  it('applies named profile from config when --profile flag is set', () => {
+    const tmp = makeTmpDir()
+    makeProjectConfig(tmp, {
+      mode: 'api',
+      apiKey: 'default-key',
+      profiles: {
+        staging: { apiKey: 'staging-key', baseUrl: 'https://staging.example.com' },
+      },
+    })
+    const client = resolveClient({
+      flags: { profile: 'staging' },
+      env: {},
+      cwd: tmp,
+    }) as unknown as { _opts: { apiKey: string; baseUrl: string } }
+    expect(client._opts.apiKey).toBe('staging-key')
+    expect(client._opts.baseUrl).toBe('https://staging.example.com')
+  })
+
+  it('falls back to base config when profile name does not exist', () => {
+    const tmp = makeTmpDir()
+    makeProjectConfig(tmp, { mode: 'api', apiKey: 'base-key', profiles: {} })
+    const client = resolveClient({
+      flags: { profile: 'nonexistent' },
+      env: {},
+      cwd: tmp,
+    }) as unknown as { _opts: { apiKey: string } }
+    expect(client._opts.apiKey).toBe('base-key')
+  })
+  ```
+
+- [ ] **Step 2: Run**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test packages/cli/src/__tests__/config-resolve.test.ts --reporter=verbose 2>&1 | tail -20
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/__tests__/config-resolve.test.ts && git commit -m "test(cli): profile resolution from config file and flag"
+  ```
+
+---
+
+### Task D5: Test nested-cwd project config discovery
+
+- [ ] **Step 1: Write test**
+
+  File: `packages/cli/src/__tests__/config-resolve.test.ts`
+
+  ```typescript
+  it('finds project config in ancestor directory when cwd is a subdirectory', () => {
+    const tmp = makeTmpDir()
+    // Config is at project root, cwd is a nested subdirectory
+    makeProjectConfig(tmp, { mode: 'api', apiKey: 'ancestor-key' })
+    const nested = path.join(tmp, 'packages', 'cli')
+    fs.mkdirSync(nested, { recursive: true })
+
+    const client = resolveClient({
+      flags: {},
+      env: {},
+      cwd: nested,
+      overrideHome: tmp,
+    }) as unknown as { _opts: { apiKey: string } }
+    expect(client._opts.apiKey).toBe('ancestor-key')
+  })
+  ```
+
+- [ ] **Step 2: Run**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test packages/cli/src/__tests__/config-resolve.test.ts --reporter=verbose 2>&1 | tail -20
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/__tests__/config-resolve.test.ts && git commit -m "test(cli): config discovery from nested cwd finds ancestor project config"
+  ```
+
+---
+
+### Task D6: Test migrate --apply non-destructive (no --yes needed)
+
+- [ ] **Step 1: Write test**
+
+  File: `packages/cli/src/__tests__/destructive-actions.test.ts`
+
+  ```typescript
+  it('migrate --apply applies non-destructive migration without --yes', async () => {
+    mockSchemaResponse.previewMigration.mockResolvedValue({ operations: [], destructive: false })
+    mockSchemaResponse.applyMigration.mockResolvedValue({ applied: 1 })
+
+    const { output } = await captureStdout(async () => {
+      await createProgram()
+        .exitOverride()
+        .parseAsync(['node', 'orbit', '--api-key', 'key', '--mode', 'api', 'migrate', '--apply', '--yes'], { from: 'user' })
+    })
+
+    expect(mockSchemaResponse.applyMigration).toHaveBeenCalled()
+  })
+
+  it('migrate --apply requires --yes for destructive migration (preview shows drop)', async () => {
+    mockSchemaResponse.previewMigration.mockResolvedValue({
+      operations: [{ type: 'drop_column', table: 'contacts', column: 'old_field' }],
+      destructive: true,
+    })
+
+    const { exitCode, output } = await captureStdout(async () => {
+      await createProgram()
+        .exitOverride()
+        .parseAsync(['node', 'orbit', '--json', '--api-key', 'key', '--mode', 'api', 'migrate', '--apply'], { from: 'user' })
+    })
+
+    expect(exitCode).toBe(1)
+    const parsed = JSON.parse(output)
+    expect(parsed.error.code).toBe('DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION')
+  })
+  ```
+
+- [ ] **Step 2: Run**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test packages/cli/src/__tests__/destructive-actions.test.ts --reporter=verbose 2>&1 | tail -30
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && git add packages/cli/src/__tests__/destructive-actions.test.ts && git commit -m "test(cli): migrate --apply non-destructive skips --yes gate; destructive requires it"
+  ```
+
+---
+
+## Track E — Final verification
+
+### Task E1: Full test suite + typecheck
+
+- [ ] **Step 1: Full typecheck**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli typecheck 2>&1
+  ```
+
+  Expected: 0 errors.
+
+- [ ] **Step 2: Full test run**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli test 2>&1 | tail -5
+  ```
+
+  Expected: ≥ 141 tests passing (the 141 existing + new tests from Track D).
+
+- [ ] **Step 3: Build**
+
+  ```bash
+  cd /Users/sharonsciammas/orbit-ai && pnpm --filter @orbit-ai/cli build 2>&1 | tail -5
+  ```
+
+  Expected: clean build.
+
+- [ ] **Step 4: Request code review**
+
+  Use `superpowers:requesting-code-review` skill to dispatch a review agent against the `feat/cli` branch diff.
+
+---
+
+## Execution Notes
+
+**Parallel execution:** Tracks A, B, and C are fully independent (disjoint files). Dispatch three parallel subagents:
+- **Agent A**: Tasks A1 + A2
+- **Agent B**: Tasks B1 + B2 + B3 + B4
+- **Agent C**: Tasks C1 + C2 + C3 + C4
+
+Track D (tests) depends on A–C completing. Run sequentially after.
+
+**Issue → Task mapping:**
+| Codex Issue | Task | Severity |
+|---|---|---|
+| Commander parse errors bypass JSON contract | A1 | High |
+| --format json doesn't trigger command JSON mode | A2 | High |
+| Config ignores apiKeyEnv | B1 | High |
+| Nested cwd config discovery breaks | B2 | High |
+| --profile unimplemented | B3 | Medium |
+| SQLite defaults to :memory: | B4 | Medium |
+| URL allowlist incomplete | B4 | Medium |
+| migrate --apply always destructive | C1 | Medium |
+| seed checks flags.mode not resolved mode | C2 | Medium |
+| status ad hoc error payload | C3 | Low |
+| doctor checks Node >= 22 | C4 | Low |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,27 @@
+# @orbit-ai/cli
+
+Terminal interface for Orbit AI CRM.
+
+## Quick Start
+
+```bash
+# API mode (default)
+export ORBIT_API_KEY=your-key-here
+orbit contacts list
+
+# Direct mode (local database)
+orbit --mode direct --adapter sqlite --database-url ./orbit.db contacts list
+```
+
+## Direct Mode Trust Boundaries
+
+When using `--mode direct`, the following middleware protections are NOT active:
+
+- **Authentication**: No API key validation. Any caller with access to the database can perform all operations.
+- **Rate limiting**: Unlimited operations. Bulk deletes or inserts have no throttling.
+- **Scope enforcement**: Organization isolation is entirely the caller's responsibility. Set `--org-id` correctly.
+- **SSRF protection**: No outbound request filtering. Do not point direct mode at remote databases from untrusted inputs.
+
+Direct mode is intended for local development, scripts running against a local SQLite database, or trusted server-side automation where the database is private. Do not expose direct mode to untrusted user inputs.
+
+See `.orbit/config.json` for configuration options.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@orbit-ai/cli",
+  "version": "0.1.0-alpha.0",
+  "description": "Terminal interface for Orbit AI CRM",
+  "type": "module",
+  "bin": { "orbit": "./dist/index.js" },
+  "files": ["dist/", "README.md", "LICENSE"],
+  "scripts": {
+    "build": "rm -rf dist && tsc && chmod +x dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@orbit-ai/sdk": "workspace:*",
+    "commander": "^12.0.0",
+    "ink": "^5.0.0",
+    "react": "^18.0.0",
+    "cli-table3": "^0.6.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4",
+    "tsx": "^4.0.0"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,8 +3,14 @@
   "version": "0.1.0-alpha.0",
   "description": "Terminal interface for Orbit AI CRM",
   "type": "module",
-  "bin": { "orbit": "./dist/index.js" },
-  "files": ["dist/", "README.md", "LICENSE"],
+  "bin": {
+    "orbit": "./dist/index.js"
+  },
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "rm -rf dist && tsc && chmod +x dist/index.js",
     "typecheck": "tsc --noEmit",
@@ -12,16 +18,19 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
+    "@orbit-ai/core": "workspace:*",
     "@orbit-ai/sdk": "workspace:*",
+    "cli-table3": "^0.6.0",
     "commander": "^12.0.0",
     "ink": "^5.0.0",
-    "react": "^18.0.0",
-    "cli-table3": "^0.6.0"
+    "pg": "^8.11.0",
+    "react": "^18.0.0"
   },
   "devDependencies": {
+    "@types/pg": "^8.15.5",
     "@types/react": "^18.0.0",
+    "tsx": "^4.0.0",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4",
-    "tsx": "^4.0.0"
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/cli/src/__tests__/activities.test.ts
+++ b/packages/cli/src/__tests__/activities.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createProgram } from '../program.js'
+
+// --- mock setup ---
+const mockActivitiesResponse = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}
+
+const mockActivities = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  log: vi.fn(),
+  response: () => mockActivitiesResponse,
+}
+
+const mockClient = {
+  activities: mockActivities,
+}
+
+vi.mock('@orbit-ai/sdk', () => ({
+  OrbitClient: vi.fn(() => mockClient),
+}))
+
+beforeEach(() => {
+  process.env.ORBIT_API_KEY = 'test-key'
+  vi.clearAllMocks()
+})
+
+function captureOutput(fn: () => Promise<void>): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let output = ''
+    const orig = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+    fn()
+      .then(() => {
+        process.stdout.write = orig
+        resolve(output)
+      })
+      .catch((err) => {
+        process.stdout.write = orig
+        reject(err)
+      })
+  })
+}
+
+describe('activities list', () => {
+  it('list --json passes envelope through', async () => {
+    const envelope = {
+      data: [{ id: 'act_1', object: 'activity', type: 'call' }],
+      meta: { request_id: 'r1', next_cursor: null, has_more: false, total: 1 },
+    }
+    mockActivitiesResponse.list.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'activities', 'list'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data[0].id).toBe('act_1')
+    expect(parsed.meta.request_id).toBe('r1')
+    expect(mockActivitiesResponse.list).toHaveBeenCalledWith({ limit: 20 })
+  })
+})
+
+describe('activities get', () => {
+  it('get --json returns single-record envelope', async () => {
+    const envelope = {
+      data: { id: 'act_123', object: 'activity', type: 'email' },
+      meta: { request_id: 'r2' },
+    }
+    mockActivitiesResponse.get.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'activities', 'get', 'act_123'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('act_123')
+    expect(mockActivitiesResponse.get).toHaveBeenCalledWith('act_123')
+  })
+})
+
+describe('activities create', () => {
+  it('create --json returns created record envelope', async () => {
+    const envelope = {
+      data: { id: 'act_new', object: 'activity', type: 'call' },
+      meta: { request_id: 'r3' },
+    }
+    mockActivitiesResponse.create.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'activities', 'create', '--type', 'call'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('act_new')
+    expect(mockActivitiesResponse.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'call' }))
+  })
+})
+
+describe('activities update', () => {
+  it('update --json returns updated record envelope', async () => {
+    const envelope = {
+      data: { id: 'act_123', object: 'activity', type: 'meeting', subject: 'Updated' },
+      meta: { request_id: 'r4' },
+    }
+    mockActivitiesResponse.update.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync([
+      'node', 'orbit', '--json', 'activities', 'update', 'act_123', '--subject', 'Updated',
+    ])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('act_123')
+    expect(mockActivitiesResponse.update).toHaveBeenCalledWith(
+      'act_123',
+      expect.objectContaining({ subject: 'Updated' }),
+    )
+  })
+})
+
+describe('activities delete', () => {
+  it('delete --json returns deletion envelope', async () => {
+    const envelope = { data: { id: 'act_123', deleted: true }, meta: { request_id: 'r5' } }
+    mockActivitiesResponse.delete.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'activities', 'delete', 'act_123'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('act_123')
+    expect(parsed.data.deleted).toBe(true)
+    expect(mockActivitiesResponse.delete).toHaveBeenCalledWith('act_123')
+  })
+})

--- a/packages/cli/src/__tests__/companies.test.ts
+++ b/packages/cli/src/__tests__/companies.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createProgram } from '../program.js'
+
+const mockCompaniesResponse = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}
+
+const mockCompanies = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  response: () => mockCompaniesResponse,
+}
+
+const mockClient = {
+  companies: mockCompanies,
+}
+
+vi.mock('@orbit-ai/sdk', () => ({
+  OrbitClient: vi.fn(() => mockClient),
+}))
+
+beforeEach(() => {
+  process.env.ORBIT_API_KEY = 'test-key'
+  vi.clearAllMocks()
+})
+
+describe('companies list', () => {
+  it('list --json passes envelope through', async () => {
+    const envelope = {
+      data: [{ id: 'cmp_1', object: 'company', name: 'Acme' }],
+      meta: { request_id: 'r1', next_cursor: null, has_more: false, total: 1 },
+    }
+    mockCompaniesResponse.list.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'companies', 'list'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data[0].id).toBe('cmp_1')
+    expect(parsed.meta.request_id).toBe('r1')
+  })
+
+  it('list table mode renders without [object Object]', async () => {
+    const envelope = {
+      data: [{ id: 'cmp_1', object: 'company', name: 'Acme', domain: 'acme.com' }],
+      meta: { request_id: 'r1', next_cursor: null, has_more: false, total: 1 },
+    }
+    mockCompanies.list.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', 'companies', 'list'])
+    process.stdout.write = origWrite
+
+    expect(output).not.toContain('[object Object]')
+    expect(output).toContain('cmp_1')
+  })
+})
+
+describe('companies get', () => {
+  it('get --json returns single-record envelope', async () => {
+    const envelope = { data: { id: 'cmp_1', object: 'company', name: 'Acme' }, meta: { request_id: 'r2' } }
+    mockCompaniesResponse.get.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'companies', 'get', 'cmp_1'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('cmp_1')
+  })
+})
+
+describe('companies create', () => {
+  it('create --json returns created record envelope', async () => {
+    const envelope = { data: { id: 'cmp_new', object: 'company', name: 'NewCo' }, meta: { request_id: 'r3' } }
+    mockCompaniesResponse.create.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'companies', 'create', '--name', 'NewCo'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('cmp_new')
+    expect(mockCompaniesResponse.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'NewCo' }))
+  })
+})
+
+describe('companies update', () => {
+  it('update --json returns updated record envelope', async () => {
+    const envelope = { data: { id: 'cmp_1', object: 'company', name: 'Acme Updated' }, meta: { request_id: 'r4' } }
+    mockCompaniesResponse.update.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'companies', 'update', 'cmp_1', '--name', 'Acme Updated'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('cmp_1')
+    expect(mockCompaniesResponse.update).toHaveBeenCalledWith('cmp_1', expect.objectContaining({ name: 'Acme Updated' }))
+  })
+})
+
+describe('companies delete', () => {
+  it('delete --json returns deletion envelope', async () => {
+    const envelope = { data: { id: 'cmp_1', deleted: true }, meta: { request_id: 'r5' } }
+    mockCompaniesResponse.delete.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'companies', 'delete', 'cmp_1'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.deleted).toBe(true)
+  })
+})
+
+describe('companies non-TTY validation', () => {
+  it('create without --name throws via Commander requiredOption', async () => {
+    const program = createProgram()
+    program.exitOverride()
+
+    await expect(
+      program.parseAsync(['node', 'orbit', '--json', 'companies', 'create'])
+    ).rejects.toThrow()
+  })
+})

--- a/packages/cli/src/__tests__/config-resolve.test.ts
+++ b/packages/cli/src/__tests__/config-resolve.test.ts
@@ -310,7 +310,7 @@ describe('config resolution — resolveClient', () => {
     }
   })
 
-  // Test 15: --api-key in argv → stderr warning + argv redaction
+  // Test 15: --api-key in argv (two-token form) → stderr warning + argv redaction
   it('15: --api-key in argv → stderr warning + argv redaction', () => {
     const cwd = makeTmpDir()
     process.argv = ['node', 'orbit', '--api-key', 'secret-key-value', '--mode', 'api']
@@ -321,7 +321,24 @@ describe('config resolution — resolveClient', () => {
       overrideHome: cwd,
     })
     expect(stderrOutput).toContain('--api-key')
+    expect(stderrOutput).toContain('visible in process listings')
     expect(process.argv).not.toContain('secret-key-value')
     expect(process.argv).toContain('[REDACTED]')
+  })
+
+  // Test 15b: --api-key=value (single-token form) → stderr warning + argv redaction
+  it('15b: --api-key=value in argv → stderr warning + argv redaction', () => {
+    const cwd = makeTmpDir()
+    process.argv = ['node', 'orbit', '--api-key=secret-key-value', '--mode', 'api']
+    resolveClient({
+      flags: { apiKey: 'secret-key-value', mode: 'api' },
+      env: {},
+      cwd,
+      overrideHome: cwd,
+    })
+    expect(stderrOutput).toContain('--api-key')
+    expect(stderrOutput).toContain('visible in process listings')
+    expect(process.argv).not.toContain('--api-key=secret-key-value')
+    expect(process.argv).toContain('--api-key=[REDACTED]')
   })
 })

--- a/packages/cli/src/__tests__/config-resolve.test.ts
+++ b/packages/cli/src/__tests__/config-resolve.test.ts
@@ -291,23 +291,16 @@ describe('config resolution — resolveClient', () => {
     )
   })
 
-  // Test 14: Direct mode in TTY → warning emitted to stderr
-  it('14: direct mode in TTY → warning emitted to stderr listing missing middleware', () => {
+  // Test 14: Direct mode → warning emitted to stderr regardless of TTY state
+  it('14: direct mode → warning emitted to stderr listing missing middleware', () => {
     const cwd = makeTmpDir()
-    const origIsTTY = process.stdout.isTTY
-    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
-
-    try {
-      resolveClient({
-        flags: { mode: 'direct', adapter: 'sqlite', orgId: 'org_test123' },
-        env: {},
-        cwd,
-        overrideHome: cwd,
-      })
-      expect(stderrOutput).toContain('direct mode')
-    } finally {
-      Object.defineProperty(process.stdout, 'isTTY', { value: origIsTTY, configurable: true })
-    }
+    resolveClient({
+      flags: { mode: 'direct', adapter: 'sqlite', orgId: 'org_test123' },
+      env: {},
+      cwd,
+      overrideHome: cwd,
+    })
+    expect(stderrOutput).toContain('direct mode')
   })
 
   // Test 15: --api-key in argv (two-token form) → stderr warning + argv redaction

--- a/packages/cli/src/__tests__/config-resolve.test.ts
+++ b/packages/cli/src/__tests__/config-resolve.test.ts
@@ -334,4 +334,73 @@ describe('config resolution — resolveClient', () => {
     expect(process.argv).not.toContain('--api-key=secret-key-value')
     expect(process.argv).toContain('--api-key=[REDACTED]')
   })
+
+  // Test D3a: reads api key from env var named by apiKeyEnv in config
+  it('reads api key from env var named by apiKeyEnv in config', () => {
+    const tmp = makeTmpDir()
+    makeProjectConfig(tmp, { mode: 'api', apiKeyEnv: 'MY_CUSTOM_KEY' })
+    const env = { MY_CUSTOM_KEY: 'key-from-custom-env' }
+    resolveClient({ flags: {}, env, cwd: tmp, overrideHome: tmp })
+    expect(OrbitClient).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'key-from-custom-env' }))
+  })
+
+  // Test D3b: apiKeyEnv is lower priority than ORBIT_API_KEY env var
+  it('apiKeyEnv is lower priority than ORBIT_API_KEY env var', () => {
+    const tmp = makeTmpDir()
+    makeProjectConfig(tmp, { mode: 'api', apiKeyEnv: 'MY_CUSTOM_KEY' })
+    const env = { ORBIT_API_KEY: 'standard-key', MY_CUSTOM_KEY: 'custom-key' }
+    resolveClient({ flags: {}, env, cwd: tmp, overrideHome: tmp })
+    expect(OrbitClient).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'standard-key' }))
+  })
+
+  // Test D4a: applies named profile when --profile flag is set
+  it('applies named profile when --profile flag is set', () => {
+    const tmp = makeTmpDir()
+    makeProjectConfig(tmp, {
+      mode: 'api',
+      apiKey: 'default-key',
+      profiles: {
+        staging: { apiKey: 'staging-key', baseUrl: 'https://staging.example.com' },
+      },
+    })
+    resolveClient({
+      flags: { profile: 'staging' },
+      env: {},
+      cwd: tmp,
+      overrideHome: tmp,
+    })
+    expect(OrbitClient).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: 'staging-key',
+      baseUrl: 'https://staging.example.com',
+    }))
+  })
+
+  // Test D4b: falls back to base config when profile name does not exist
+  it('falls back to base config when profile name does not exist in profiles', () => {
+    const tmp = makeTmpDir()
+    makeProjectConfig(tmp, { mode: 'api', apiKey: 'base-key', profiles: {} })
+    resolveClient({
+      flags: { profile: 'nonexistent' },
+      env: {},
+      cwd: tmp,
+      overrideHome: tmp,
+    })
+    expect(OrbitClient).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'base-key' }))
+  })
+
+  // Test D5: finds project config in ancestor directory when cwd is a nested subdirectory
+  it('finds project config in ancestor directory when cwd is a nested subdirectory', () => {
+    const tmp = makeTmpDir()
+    // Config lives at project root, cwd is a nested package dir
+    makeProjectConfig(tmp, { mode: 'api', apiKey: 'ancestor-key' })
+    const nested = path.join(tmp, 'packages', 'cli')
+    fs.mkdirSync(nested, { recursive: true })
+    resolveClient({
+      flags: {},
+      env: {},
+      cwd: nested,
+      overrideHome: tmp,
+    })
+    expect(OrbitClient).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'ancestor-key' }))
+  })
 })

--- a/packages/cli/src/__tests__/config-resolve.test.ts
+++ b/packages/cli/src/__tests__/config-resolve.test.ts
@@ -1,0 +1,327 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { makeTmpDir } from './setup.js'
+import { CliConfigError, CliValidationError, CliUnsupportedAdapterError } from '../errors.js'
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted before any dynamic imports
+// ---------------------------------------------------------------------------
+
+const mockSqliteAdapter = { name: 'sqlite', dialect: 'sqlite' }
+const mockPostgresAdapter = { name: 'postgres', dialect: 'postgres' }
+
+vi.mock('@orbit-ai/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@orbit-ai/core')>()
+  return {
+    ...actual,
+    // Mock SqliteOrbitDatabase to avoid calling node:sqlite DatabaseSync.exec
+    SqliteOrbitDatabase: vi.fn().mockImplementation(() => ({
+      transaction: vi.fn(),
+      execute: vi.fn(),
+      query: vi.fn(),
+      client: { exec: vi.fn(), prepare: vi.fn() },
+    })),
+    createSqliteStorageAdapter: vi.fn(() => mockSqliteAdapter),
+    createPostgresStorageAdapter: vi.fn(() => mockPostgresAdapter),
+  }
+})
+
+vi.mock('@orbit-ai/sdk', () => ({
+  OrbitClient: vi.fn().mockImplementation((opts: unknown) => ({ _opts: opts })),
+}))
+
+// Mock pg Pool to avoid real connections
+vi.mock('pg', () => ({
+  Pool: vi.fn().mockImplementation((opts: unknown) => ({ _opts: opts })),
+}))
+
+// Mock node:sqlite to be safe
+vi.mock('node:sqlite', () => ({
+  DatabaseSync: vi.fn().mockImplementation(() => ({
+    exec: vi.fn(),
+    prepare: vi.fn(),
+  })),
+}))
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { resolveClient } from '../config/resolve-context.js'
+import { readConfigFile, canonicalizePath } from '../config/files.js'
+import { createSqliteStorageAdapter, createPostgresStorageAdapter } from '@orbit-ai/core'
+import { OrbitClient } from '@orbit-ai/sdk'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeConfig(dir: string, subPath: string, data: object): string {
+  const fullPath = path.join(dir, subPath)
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+  fs.writeFileSync(fullPath, JSON.stringify(data), { mode: 0o600 })
+  return fullPath
+}
+
+function makeProjectConfig(cwd: string, data: object): void {
+  writeConfig(cwd, '.orbit/config.json', data)
+}
+
+function makeUserConfig(home: string, data: object): void {
+  writeConfig(home, '.config/orbit/config.json', data)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('config resolution — resolveClient', () => {
+  let originalArgv: string[]
+  let stderrOutput: string
+
+  beforeEach(() => {
+    originalArgv = [...process.argv]
+    stderrOutput = ''
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderrOutput += String(chunk)
+      return true
+    })
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    vi.restoreAllMocks()
+  })
+
+  // Test 1: --api-key flag overrides ORBIT_API_KEY env var
+  it('1: --api-key flag overrides ORBIT_API_KEY env var', () => {
+    const cwd = makeTmpDir()
+    resolveClient({
+      flags: { apiKey: 'flag-key', mode: 'api' },
+      env: { ORBIT_API_KEY: 'env-key' },
+      cwd,
+      overrideHome: cwd,
+    })
+    expect(OrbitClient).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'flag-key' }))
+  })
+
+  // Test 2: ORBIT_API_KEY env var overrides .orbit/config.json value
+  it('2: ORBIT_API_KEY env var overrides .orbit/config.json value', () => {
+    const cwd = makeTmpDir()
+    makeProjectConfig(cwd, { apiKey: 'config-key', mode: 'api' })
+    resolveClient({
+      flags: { mode: 'api' },
+      env: { ORBIT_API_KEY: 'env-key' },
+      cwd,
+      overrideHome: cwd,
+    })
+    expect(OrbitClient).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'env-key' }))
+  })
+
+  // Test 3: .orbit/config.json (project) overrides ~/.config/orbit/config.json (user)
+  it('3: project config overrides user config', () => {
+    const cwd = makeTmpDir()
+    const home = makeTmpDir()
+    makeUserConfig(home, { apiKey: 'user-key', mode: 'api' })
+    makeProjectConfig(cwd, { apiKey: 'project-key', mode: 'api' })
+    resolveClient({
+      flags: {},
+      env: {},
+      cwd,
+      overrideHome: home,
+    })
+    expect(OrbitClient).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'project-key' }))
+  })
+
+  // Test 4: Only user config present → its value is used
+  it('4: only user config present → its value is used', () => {
+    const cwd = makeTmpDir()
+    const home = makeTmpDir()
+    makeUserConfig(home, { apiKey: 'user-only-key', mode: 'api' })
+    resolveClient({
+      flags: {},
+      env: {},
+      cwd,
+      overrideHome: home,
+    })
+    expect(OrbitClient).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'user-only-key' }))
+  })
+
+  // Test 5: Missing apiKey in API mode → CliValidationError
+  it('5: missing apiKey in API mode → CliValidationError', () => {
+    const cwd = makeTmpDir()
+    expect(() =>
+      resolveClient({
+        flags: { mode: 'api' },
+        env: {},
+        cwd,
+        overrideHome: cwd,
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'CliValidationError',
+        details: expect.objectContaining({ code: 'MISSING_REQUIRED_CONFIG' }),
+      }),
+    )
+  })
+
+  // Test 6: mode: 'direct' with adapter: 'sqlite' → calls createSqliteStorageAdapter
+  it('6: direct mode sqlite → calls createSqliteStorageAdapter', () => {
+    const cwd = makeTmpDir()
+    resolveClient({
+      flags: { mode: 'direct', adapter: 'sqlite', orgId: 'org_test123' },
+      env: {},
+      cwd,
+      overrideHome: cwd,
+    })
+    expect(createSqliteStorageAdapter).toHaveBeenCalled()
+  })
+
+  // Test 7: mode: 'direct' with adapter: 'postgres' → calls createPostgresStorageAdapter
+  it('7: direct mode postgres → calls createPostgresStorageAdapter', () => {
+    const cwd = makeTmpDir()
+    resolveClient({
+      flags: {
+        mode: 'direct',
+        adapter: 'postgres',
+        orgId: 'org_test123',
+        databaseUrl: 'postgres://localhost/testdb',
+      },
+      env: {},
+      cwd,
+      overrideHome: cwd,
+    })
+    expect(createPostgresStorageAdapter).toHaveBeenCalled()
+  })
+
+  // Test 8: mode: 'direct' with adapter: 'supabase' → throws CliUnsupportedAdapterError
+  it('8: direct mode supabase → throws CliUnsupportedAdapterError', () => {
+    const cwd = makeTmpDir()
+    expect(() =>
+      resolveClient({
+        flags: { mode: 'direct', adapter: 'supabase', orgId: 'org_test123' },
+        env: {},
+        cwd,
+        overrideHome: cwd,
+      }),
+    ).toThrow(CliUnsupportedAdapterError)
+  })
+
+  // Test 9: mode: 'direct' with adapter: 'neon' → throws CliUnsupportedAdapterError
+  it('9: direct mode neon → throws CliUnsupportedAdapterError', () => {
+    const cwd = makeTmpDir()
+    expect(() =>
+      resolveClient({
+        flags: { mode: 'direct', adapter: 'neon', orgId: 'org_test123' },
+        env: {},
+        cwd,
+        overrideHome: cwd,
+      }),
+    ).toThrow(CliUnsupportedAdapterError)
+  })
+
+  // Test 10: Malformed config JSON → CliConfigError with code: 'CONFIG_PARSE_ERROR'
+  it('10: malformed config JSON → CliConfigError CONFIG_PARSE_ERROR', () => {
+    const cwd = makeTmpDir()
+    const cfgDir = path.join(cwd, '.orbit')
+    fs.mkdirSync(cfgDir, { recursive: true })
+    fs.writeFileSync(path.join(cfgDir, 'config.json'), '{ not valid json', { mode: 0o600 })
+    // readConfigFile directly to bypass allowedRoots check in loadConfig
+    expect(() =>
+      readConfigFile(path.join(cfgDir, 'config.json')),
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'CliConfigError',
+        details: expect.objectContaining({ code: 'CONFIG_PARSE_ERROR' }),
+      }),
+    )
+  })
+
+  // Test 11: Missing orgId in direct mode → CliValidationError MISSING_REQUIRED_CONFIG
+  it('11: missing orgId in direct mode → CliValidationError MISSING_REQUIRED_CONFIG', () => {
+    const cwd = makeTmpDir()
+    expect(() =>
+      resolveClient({
+        flags: { mode: 'direct', adapter: 'sqlite' },
+        env: {},
+        cwd,
+        overrideHome: cwd,
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: 'MISSING_REQUIRED_CONFIG',
+          path: 'context.orgId',
+        }),
+      }),
+    )
+  })
+
+  // Test 12: SQLite with http:// scheme → CliValidationError (URL scheme allowlist)
+  it('12: sqlite with http:// scheme → CliValidationError', () => {
+    const cwd = makeTmpDir()
+    expect(() =>
+      resolveClient({
+        flags: {
+          mode: 'direct',
+          adapter: 'sqlite',
+          orgId: 'org_test123',
+          databaseUrl: 'http://example.com/db.sqlite',
+        },
+        env: {},
+        cwd,
+        overrideHome: cwd,
+      }),
+    ).toThrow(CliValidationError)
+  })
+
+  // Test 13: Config path outside project root → CliConfigError (path canonicalization)
+  it('13: config path outside project root → CliConfigError', () => {
+    const cwd = makeTmpDir()
+    const home = makeTmpDir()
+    expect(() =>
+      canonicalizePath('/etc/passwd', [cwd, home]),
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'CliConfigError',
+        details: expect.objectContaining({ code: 'CONFIG_PATH_OUTSIDE_ALLOWED' }),
+      }),
+    )
+  })
+
+  // Test 14: Direct mode in TTY → warning emitted to stderr
+  it('14: direct mode in TTY → warning emitted to stderr listing missing middleware', () => {
+    const cwd = makeTmpDir()
+    const origIsTTY = process.stdout.isTTY
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+
+    try {
+      resolveClient({
+        flags: { mode: 'direct', adapter: 'sqlite', orgId: 'org_test123' },
+        env: {},
+        cwd,
+        overrideHome: cwd,
+      })
+      expect(stderrOutput).toContain('direct mode')
+    } finally {
+      Object.defineProperty(process.stdout, 'isTTY', { value: origIsTTY, configurable: true })
+    }
+  })
+
+  // Test 15: --api-key in argv → stderr warning + argv redaction
+  it('15: --api-key in argv → stderr warning + argv redaction', () => {
+    const cwd = makeTmpDir()
+    process.argv = ['node', 'orbit', '--api-key', 'secret-key-value', '--mode', 'api']
+    resolveClient({
+      flags: { apiKey: 'secret-key-value', mode: 'api' },
+      env: {},
+      cwd,
+      overrideHome: cwd,
+    })
+    expect(stderrOutput).toContain('--api-key')
+    expect(process.argv).not.toContain('secret-key-value')
+    expect(process.argv).toContain('[REDACTED]')
+  })
+})

--- a/packages/cli/src/__tests__/contacts.test.ts
+++ b/packages/cli/src/__tests__/contacts.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createProgram } from '../program.js'
+
+// --- mock setup ---
+const mockContactsResponse = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  context: vi.fn(),
+}
+
+const mockContacts = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  context: vi.fn(),
+  response: () => mockContactsResponse,
+}
+
+const mockClient = {
+  contacts: mockContacts,
+}
+
+vi.mock('@orbit-ai/sdk', () => ({
+  OrbitClient: vi.fn(() => mockClient),
+}))
+
+// Suppress config-loading errors by providing ORBIT_API_KEY
+beforeEach(() => {
+  process.env.ORBIT_API_KEY = 'test-key'
+  vi.clearAllMocks()
+})
+
+function captureOutput(fn: () => Promise<void>): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let output = ''
+    const orig = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+    fn()
+      .then(() => {
+        process.stdout.write = orig
+        resolve(output)
+      })
+      .catch((err) => {
+        process.stdout.write = orig
+        reject(err)
+      })
+  })
+}
+
+describe('contacts list', () => {
+  it('list --json passes envelope through', async () => {
+    const envelope = {
+      data: [{ id: 'cnt_1', object: 'contact', name: 'Alice' }],
+      meta: { request_id: 'r1', next_cursor: null, has_more: false, total: 1 },
+    }
+    mockContactsResponse.list.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'contacts', 'list'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data[0].id).toBe('cnt_1')
+    expect(parsed.meta.request_id).toBe('r1')
+    expect(mockContactsResponse.list).toHaveBeenCalledWith({ limit: 20 })
+  })
+
+  it('list table mode renders without [object Object]', async () => {
+    const envelope = {
+      data: [{ id: 'cnt_1', object: 'contact', name: 'Alice', email: 'alice@example.com' }],
+      meta: { request_id: 'r1', next_cursor: null, has_more: false, total: 1 },
+    }
+    mockContacts.list.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', 'contacts', 'list'])
+    process.stdout.write = origWrite
+
+    expect(output).not.toContain('[object Object]')
+    expect(output).toContain('cnt_1')
+  })
+})
+
+describe('contacts get', () => {
+  it('get --json returns single-record envelope', async () => {
+    const envelope = { data: { id: 'cnt_123', object: 'contact', name: 'Alice' }, meta: { request_id: 'r2' } }
+    mockContactsResponse.get.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'contacts', 'get', 'cnt_123'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('cnt_123')
+    expect(mockContactsResponse.get).toHaveBeenCalledWith('cnt_123')
+  })
+})
+
+describe('contacts create', () => {
+  it('create --json returns created record envelope', async () => {
+    const envelope = { data: { id: 'cnt_new', object: 'contact', name: 'Bob' }, meta: { request_id: 'r3' } }
+    mockContactsResponse.create.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'contacts', 'create', '--name', 'Bob'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('cnt_new')
+    expect(mockContactsResponse.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Bob' }))
+  })
+})
+
+describe('contacts update', () => {
+  it('update --json returns updated record envelope', async () => {
+    const envelope = { data: { id: 'cnt_123', object: 'contact', name: 'Alice Updated' }, meta: { request_id: 'r4' } }
+    mockContactsResponse.update.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'contacts', 'update', 'cnt_123', '--name', 'Alice Updated'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('cnt_123')
+    expect(mockContactsResponse.update).toHaveBeenCalledWith('cnt_123', expect.objectContaining({ name: 'Alice Updated' }))
+  })
+})
+
+describe('contacts delete', () => {
+  it('delete --json returns deletion envelope', async () => {
+    const envelope = { data: { id: 'cnt_123', deleted: true }, meta: { request_id: 'r5' } }
+    mockContactsResponse.delete.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'contacts', 'delete', 'cnt_123'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('cnt_123')
+    expect(parsed.data.deleted).toBe(true)
+    expect(mockContactsResponse.delete).toHaveBeenCalledWith('cnt_123')
+  })
+})
+
+describe('contacts non-TTY validation', () => {
+  it('create without --name in non-TTY mode throws CliValidationError via Commander requiredOption', async () => {
+    const origIsTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true, configurable: true })
+
+    const program = createProgram()
+    program.exitOverride()
+
+    await expect(
+      program.parseAsync(['node', 'orbit', '--json', 'contacts', 'create'])
+    ).rejects.toThrow()
+
+    Object.defineProperty(process.stdin, 'isTTY', { value: origIsTTY, writable: true, configurable: true })
+  })
+})

--- a/packages/cli/src/__tests__/context.test.ts
+++ b/packages/cli/src/__tests__/context.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createProgram } from '../program.js'
+
+const mockContactsResponse = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  context: vi.fn(),
+}
+
+const mockContacts = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  context: vi.fn(),
+  response: () => mockContactsResponse,
+}
+
+const mockClient = {
+  contacts: mockContacts,
+}
+
+vi.mock('@orbit-ai/sdk', () => ({
+  OrbitClient: vi.fn(() => mockClient),
+}))
+
+beforeEach(() => {
+  process.env.ORBIT_API_KEY = 'test-key'
+  vi.clearAllMocks()
+})
+
+describe('orbit context', () => {
+  it('context <id> --json calls contacts.response().context(id) and returns envelope', async () => {
+    const envelope = {
+      data: {
+        contact: { id: 'cnt_123', name: 'Alice' },
+        deals: [],
+        activities: [],
+      },
+      meta: { request_id: 'ctx_r1' },
+    }
+    mockContactsResponse.context.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'context', 'cnt_123'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.contact.id).toBe('cnt_123')
+    expect(mockContactsResponse.context).toHaveBeenCalledWith('cnt_123')
+  })
+
+  it('context <email> in table mode calls contacts.context(email)', async () => {
+    const contextData = { contact: { id: 'cnt_456', name: 'Bob' }, deals: [], activities: [] }
+    mockContacts.context.mockResolvedValue(contextData)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', 'context', 'user@example.com'])
+    process.stdout.write = origWrite
+
+    expect(mockContacts.context).toHaveBeenCalledWith('user@example.com')
+    expect(output).not.toContain('[object Object]')
+  })
+})

--- a/packages/cli/src/__tests__/deals.test.ts
+++ b/packages/cli/src/__tests__/deals.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createProgram } from '../program.js'
+
+const mockDealsResponse = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  move: vi.fn(),
+}
+
+const mockDeals = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  move: vi.fn(),
+  response: () => mockDealsResponse,
+}
+
+const mockClient = {
+  deals: mockDeals,
+}
+
+vi.mock('@orbit-ai/sdk', () => ({
+  OrbitClient: vi.fn(() => mockClient),
+}))
+
+beforeEach(() => {
+  process.env.ORBIT_API_KEY = 'test-key'
+  vi.clearAllMocks()
+})
+
+describe('deals list', () => {
+  it('list --json passes envelope through', async () => {
+    const envelope = {
+      data: [{ id: 'deal_1', object: 'deal', name: 'Big Deal' }],
+      meta: { request_id: 'r1', next_cursor: null, has_more: false, total: 1 },
+    }
+    mockDealsResponse.list.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'deals', 'list'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data[0].id).toBe('deal_1')
+    expect(parsed.meta.request_id).toBe('r1')
+  })
+
+  it('list table mode renders without [object Object]', async () => {
+    const envelope = {
+      data: [{ id: 'deal_1', object: 'deal', name: 'Big Deal', status: 'open' }],
+      meta: { request_id: 'r1', next_cursor: null, has_more: false, total: 1 },
+    }
+    mockDeals.list.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', 'deals', 'list'])
+    process.stdout.write = origWrite
+
+    expect(output).not.toContain('[object Object]')
+    expect(output).toContain('deal_1')
+  })
+})
+
+describe('deals get', () => {
+  it('get --json returns single-record envelope', async () => {
+    const envelope = { data: { id: 'deal_1', object: 'deal', name: 'Big Deal' }, meta: { request_id: 'r2' } }
+    mockDealsResponse.get.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'deals', 'get', 'deal_1'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('deal_1')
+  })
+})
+
+describe('deals create', () => {
+  it('create --json returns created record envelope', async () => {
+    const envelope = { data: { id: 'deal_new', object: 'deal', name: 'New Deal' }, meta: { request_id: 'r3' } }
+    mockDealsResponse.create.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'deals', 'create', '--name', 'New Deal'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('deal_new')
+    expect(mockDealsResponse.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'New Deal' }))
+  })
+})
+
+describe('deals update', () => {
+  it('update --json returns updated record envelope', async () => {
+    const envelope = { data: { id: 'deal_1', object: 'deal', name: 'Updated Deal' }, meta: { request_id: 'r4' } }
+    mockDealsResponse.update.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'deals', 'update', 'deal_1', '--name', 'Updated Deal'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('deal_1')
+    expect(mockDealsResponse.update).toHaveBeenCalledWith('deal_1', expect.objectContaining({ name: 'Updated Deal' }))
+  })
+})
+
+describe('deals delete', () => {
+  it('delete --json returns deletion envelope', async () => {
+    const envelope = { data: { id: 'deal_1', deleted: true }, meta: { request_id: 'r5' } }
+    mockDealsResponse.delete.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'deals', 'delete', 'deal_1'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.deleted).toBe(true)
+  })
+})
+
+describe('deals move', () => {
+  it('move --json calls deals.response().move with stage_id', async () => {
+    const envelope = { data: { id: 'deal_1', object: 'deal', stage_id: 'stg_2' }, meta: { request_id: 'r6' } }
+    mockDealsResponse.move.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'deals', 'move', 'deal_1', '--stage-id', 'stg_2'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.stage_id).toBe('stg_2')
+    expect(mockDealsResponse.move).toHaveBeenCalledWith('deal_1', { stage_id: 'stg_2' })
+  })
+})
+
+describe('deals non-TTY validation', () => {
+  it('create without --name throws via Commander requiredOption', async () => {
+    const program = createProgram()
+    program.exitOverride()
+
+    await expect(
+      program.parseAsync(['node', 'orbit', '--json', 'deals', 'create'])
+    ).rejects.toThrow()
+  })
+})

--- a/packages/cli/src/__tests__/destructive-actions.test.ts
+++ b/packages/cli/src/__tests__/destructive-actions.test.ts
@@ -140,6 +140,45 @@ describe('fields delete — destructive action', () => {
   })
 })
 
+describe('migrate --apply — destructive gating', () => {
+  it('migrate --apply applies non-destructive migration without --yes', async () => {
+    mockSchema.previewMigration.mockResolvedValue({ operations: [], destructive: false })
+    mockSchema.applyMigration.mockResolvedValue({ applied: 1 })
+
+    const { output } = await captureStdout(async () => {
+      await createProgram()
+        .exitOverride()
+        .parseAsync(
+          ['node', 'orbit', '--json', '--api-key', 'key', '--mode', 'api', 'migrate', '--apply'],
+        )
+    })
+
+    expect(mockSchema.applyMigration).toHaveBeenCalled()
+    const parsed = JSON.parse(output)
+    expect(parsed).toHaveProperty('applied', 1)
+  })
+
+  it('migrate --apply requires --yes for destructive migration (preview has destructive:true)', async () => {
+    mockSchema.previewMigration.mockResolvedValue({
+      operations: [{ type: 'drop_column', table: 'contacts', column: 'old_field' }],
+      destructive: true,
+    })
+
+    const { exitCode, output } = await captureStdout(async () => {
+      await createProgram()
+        .exitOverride()
+        .parseAsync(
+          ['node', 'orbit', '--json', '--api-key', 'key', '--mode', 'api', 'migrate', '--apply'],
+        )
+    })
+
+    expect(exitCode).toBe(1)
+    const parsed = JSON.parse(output)
+    expect(parsed.error.code).toBe('DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION')
+    expect(mockSchema.applyMigration).not.toHaveBeenCalled()
+  })
+})
+
 describe('migrate --rollback — destructive action', () => {
   it('without --yes in JSON mode: exit code 1, DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION on stdout', async () => {
     const program = createProgram()

--- a/packages/cli/src/__tests__/destructive-actions.test.ts
+++ b/packages/cli/src/__tests__/destructive-actions.test.ts
@@ -59,8 +59,11 @@ function captureStdout(fn: () => Promise<unknown>): Promise<{ output: string; ex
   return new Promise((resolve) => {
     let output = ''
     const origWrite = process.stdout.write.bind(process.stdout)
-    process.stdout.write = (chunk: string | Uint8Array) => {
+    // Cast to any to accept optional callback parameter
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(process.stdout as any).write = (chunk: string | Uint8Array, cb?: () => void) => {
       output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      if (typeof cb === 'function') cb()
       return true
     }
     fn()

--- a/packages/cli/src/__tests__/destructive-actions.test.ts
+++ b/packages/cli/src/__tests__/destructive-actions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { createProgram, _resetJsonMode } from '../program.js'
+import { createProgram, run, _resetJsonMode } from '../program.js'
 
 // --- mock schema resource ---
 const mockSchemaResponse = {
@@ -176,6 +176,28 @@ describe('migrate --apply — destructive gating', () => {
     const parsed = JSON.parse(output)
     expect(parsed.error.code).toBe('DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION')
     expect(mockSchema.applyMigration).not.toHaveBeenCalled()
+  })
+})
+
+describe('migrate with no action flag', () => {
+  it('emits MISSING_REQUIRED_ARG error in JSON mode', async () => {
+    let origArgv = [...process.argv]
+    let stdoutOutput = ''
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdoutOutput += String(chunk)
+      return true
+    })
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    process.argv = ['node', 'orbit', '--json', '--api-key', 'key', 'migrate']
+    try {
+      await run()
+    } catch {
+      // run() calls process.exit which throws in beforeEach mock
+    }
+    process.argv = origArgv
+    const parsed = JSON.parse(stdoutOutput)
+    expect(parsed.error.code).toBe('MISSING_REQUIRED_ARG')
+    expect(mockExitCode).toBe(2)
   })
 })
 

--- a/packages/cli/src/__tests__/destructive-actions.test.ts
+++ b/packages/cli/src/__tests__/destructive-actions.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createProgram, _resetJsonMode } from '../program.js'
+
+// --- mock schema resource ---
+const mockSchemaResponse = {
+  deleteField: vi.fn(),
+  describeObject: vi.fn(),
+  addField: vi.fn(),
+  listObjects: vi.fn(),
+  updateField: vi.fn(),
+  previewMigration: vi.fn(),
+  applyMigration: vi.fn(),
+  rollbackMigration: vi.fn(),
+}
+
+const mockSchema = {
+  deleteField: vi.fn(),
+  describeObject: vi.fn(),
+  addField: vi.fn(),
+  listObjects: vi.fn(),
+  applyMigration: vi.fn(),
+  rollbackMigration: vi.fn(),
+  previewMigration: vi.fn(),
+  response: () => mockSchemaResponse,
+}
+
+const mockClient = {
+  schema: mockSchema,
+}
+
+vi.mock('@orbit-ai/sdk', () => ({
+  OrbitClient: vi.fn(() => mockClient),
+}))
+
+let mockExitCode: number | undefined
+let origExit: typeof process.exit
+
+beforeEach(() => {
+  process.env.ORBIT_API_KEY = 'test-key'
+  vi.clearAllMocks()
+  _resetJsonMode()
+  // Mock process.exit so tests don't actually exit
+  origExit = process.exit
+  mockExitCode = undefined
+  process.exit = ((code?: number) => {
+    mockExitCode = code ?? 0
+    throw new Error(`process.exit(${code})`)
+  }) as typeof process.exit
+  // Ensure non-TTY
+  Object.defineProperty(process.stdout, 'isTTY', { value: false, writable: true, configurable: true })
+})
+
+afterEach(() => {
+  process.exit = origExit
+  Object.defineProperty(process.stdout, 'isTTY', { value: undefined, writable: true, configurable: true })
+})
+
+function captureStdout(fn: () => Promise<unknown>): Promise<{ output: string; exitCode: number | undefined }> {
+  return new Promise((resolve) => {
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+    fn()
+      .then(() => {
+        process.stdout.write = origWrite
+        resolve({ output, exitCode: mockExitCode })
+      })
+      .catch(() => {
+        process.stdout.write = origWrite
+        resolve({ output, exitCode: mockExitCode })
+      })
+  })
+}
+
+describe('fields delete — destructive action', () => {
+  it('without --yes in JSON mode: exit code 1, DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION on stdout', async () => {
+    const program = createProgram()
+
+    const { output, exitCode } = await captureStdout(() =>
+      program.parseAsync(['node', 'orbit', '--json', 'fields', 'delete', 'contacts', 'custom_tier']),
+    )
+
+    expect(exitCode).toBe(1)
+    const parsed = JSON.parse(output)
+    expect(parsed.error.code).toBe('DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION')
+    expect(parsed.error.action).toBe('fields.delete')
+    expect(parsed.error.target).toBe('contacts.custom_tier')
+    // SDK delete should NOT have been called
+    expect(mockSchemaResponse.deleteField).not.toHaveBeenCalled()
+  })
+
+  it('with --yes in JSON mode: proceeds and returns deletion envelope', async () => {
+    const envelope = { data: { deleted: true, field: 'custom_tier' }, meta: { request_id: 'r1' } }
+    mockSchemaResponse.deleteField.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync([
+      'node', 'orbit', '--json', 'fields', 'delete', 'contacts', 'custom_tier', '--yes',
+    ])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.deleted).toBe(true)
+    expect(mockSchemaResponse.deleteField).toHaveBeenCalledWith('contacts', 'custom_tier')
+  })
+
+  it('with global --yes flag: proceeds without confirmation', async () => {
+    const envelope = { data: { deleted: true, field: 'custom_tier' }, meta: { request_id: 'r2' } }
+    mockSchemaResponse.deleteField.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync([
+      'node', 'orbit', '--json', '--yes', 'fields', 'delete', 'contacts', 'custom_tier',
+    ])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.deleted).toBe(true)
+    expect(mockSchemaResponse.deleteField).toHaveBeenCalledWith('contacts', 'custom_tier')
+  })
+})
+
+describe('migrate --rollback — destructive action', () => {
+  it('without --yes in JSON mode: exit code 1, DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION on stdout', async () => {
+    const program = createProgram()
+
+    const { output, exitCode } = await captureStdout(() =>
+      program.parseAsync([
+        'node', 'orbit', '--json', 'migrate', '--rollback', '--id', 'mig_123',
+      ]),
+    )
+
+    expect(exitCode).toBe(1)
+    const parsed = JSON.parse(output)
+    expect(parsed.error.code).toBe('DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION')
+    expect(mockSchema.rollbackMigration).not.toHaveBeenCalled()
+  })
+
+  it('with --yes: proceeds and calls rollbackMigration', async () => {
+    const migResult = { id: 'mig_123', rolled_back: true }
+    mockSchema.rollbackMigration.mockResolvedValue(migResult)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync([
+      'node', 'orbit', '--json', 'migrate', '--rollback', '--id', 'mig_123', '--yes',
+    ])
+    process.stdout.write = origWrite
+
+    expect(mockSchema.rollbackMigration).toHaveBeenCalledWith('mig_123')
+    const parsed = JSON.parse(output)
+    expect(parsed).toBeTruthy()
+  })
+})

--- a/packages/cli/src/__tests__/exit-codes.test.ts
+++ b/packages/cli/src/__tests__/exit-codes.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { CliValidationError, CliConfigError, CliUnsupportedAdapterError, CliNotImplementedError } from '../errors.js'
-import { _classifyError } from '../program.js'
+import { _classifyError, run, _resetJsonMode } from '../program.js'
 
 // We test the classifyError logic indirectly by checking the error classes
 describe('exit code contract', () => {
@@ -92,5 +92,57 @@ describe('classifyError end-to-end', () => {
     const result = _classifyError(e)
     expect(result.code).toBe(3)
     expect(result.payload.code).toBe('CONFIG_PARSE_ERROR')
+  })
+})
+
+describe('seed --count validation', () => {
+  let origArgv: string[]
+  let origExit: typeof process.exit
+  let exitCode: number | undefined
+  let stdoutOutput: string
+
+  beforeEach(() => {
+    origArgv = [...process.argv]
+    origExit = process.exit
+    exitCode = undefined
+    stdoutOutput = ''
+    process.env.ORBIT_API_KEY = 'test-key'
+    process.exit = ((code?: number) => {
+      exitCode = code ?? 0
+      throw new Error(`process.exit(${code})`)
+    }) as typeof process.exit
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdoutOutput += String(chunk); return true
+    })
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    process.argv = origArgv
+    process.exit = origExit
+    vi.restoreAllMocks()
+    _resetJsonMode()
+  })
+
+  it('--count 0 exits with INVALID_ARGUMENT in JSON mode', async () => {
+    process.argv = ['node', 'orbit', '--json', 'seed', '--count', '0']
+    await expect(run()).rejects.toThrow()
+    const parsed = JSON.parse(stdoutOutput)
+    expect(parsed.error.code).toBe('INVALID_ARGUMENT')
+    expect(exitCode).toBe(2)
+  })
+
+  it('--count abc (NaN) exits with INVALID_ARGUMENT in JSON mode', async () => {
+    process.argv = ['node', 'orbit', '--json', 'seed', '--count', 'abc']
+    await expect(run()).rejects.toThrow()
+    const parsed = JSON.parse(stdoutOutput)
+    expect(parsed.error.code).toBe('INVALID_ARGUMENT')
+  })
+
+  it('--count 1001 exits with INVALID_ARGUMENT in JSON mode', async () => {
+    process.argv = ['node', 'orbit', '--json', 'seed', '--count', '1001']
+    await expect(run()).rejects.toThrow()
+    const parsed = JSON.parse(stdoutOutput)
+    expect(parsed.error.code).toBe('INVALID_ARGUMENT')
   })
 })

--- a/packages/cli/src/__tests__/exit-codes.test.ts
+++ b/packages/cli/src/__tests__/exit-codes.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { CliValidationError, CliConfigError, CliUnsupportedAdapterError } from '../errors.js'
+
+// We test the classifyError logic indirectly by checking the error classes
+describe('exit code contract', () => {
+  it('CliValidationError has exitCode 2', () => {
+    const e = new CliValidationError('missing arg', { code: 'MISSING_REQUIRED_ARG' })
+    expect(e.exitCode).toBe(2)
+  })
+
+  it('CliConfigError has exitCode 3', () => {
+    const e = new CliConfigError('bad config', { code: 'CONFIG_PARSE_ERROR' })
+    expect(e.exitCode).toBe(3)
+  })
+
+  it('CliUnsupportedAdapterError has exitCode 2 and correct code', () => {
+    const e = new CliUnsupportedAdapterError('supabase')
+    expect(e.exitCode).toBe(2)
+    expect(e.details?.code).toBe('UNSUPPORTED_ADAPTER')
+  })
+
+  it('CliValidationError for missing required config', () => {
+    const e = new CliValidationError('apiKey is required', {
+      code: 'MISSING_REQUIRED_CONFIG',
+      path: 'apiKey',
+    })
+    expect(e.exitCode).toBe(2)
+    expect(e.details?.path).toBe('apiKey')
+  })
+})

--- a/packages/cli/src/__tests__/exit-codes.test.ts
+++ b/packages/cli/src/__tests__/exit-codes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { CliValidationError, CliConfigError, CliUnsupportedAdapterError } from '../errors.js'
+import { CliValidationError, CliConfigError, CliUnsupportedAdapterError, CliNotImplementedError } from '../errors.js'
+import { _classifyError } from '../program.js'
 
 // We test the classifyError logic indirectly by checking the error classes
 describe('exit code contract', () => {
@@ -26,5 +27,70 @@ describe('exit code contract', () => {
     })
     expect(e.exitCode).toBe(2)
     expect(e.details?.path).toBe('apiKey')
+  })
+})
+
+describe('classifyError end-to-end', () => {
+  it('CliNotImplementedError → code 2, payload code NOT_IMPLEMENTED', () => {
+    const e = new CliNotImplementedError('feature not yet built', { code: 'NOT_IMPLEMENTED' })
+    const result = _classifyError(e)
+    expect(result.code).toBe(2)
+    expect(result.payload.code).toBe('NOT_IMPLEMENTED')
+    expect(result.payload.message).toBe('feature not yet built')
+  })
+
+  it('CliNotImplementedError uses default code when no details', () => {
+    const e = new CliNotImplementedError('not built')
+    const result = _classifyError(e)
+    expect(result.code).toBe(2)
+    expect(result.payload.code).toBe('NOT_IMPLEMENTED')
+  })
+
+  it('CliUnsupportedAdapterError → code 2, payload code UNSUPPORTED_ADAPTER', () => {
+    const e = new CliUnsupportedAdapterError('supabase')
+    const result = _classifyError(e)
+    expect(result.code).toBe(2)
+    expect(result.payload.code).toBe('UNSUPPORTED_ADAPTER')
+  })
+
+  it('OrbitApiError-shaped object (duck type) → code 1', () => {
+    const e = Object.assign(new Error('Not found'), {
+      name: 'OrbitApiError',
+      statusCode: 404,
+      code: 'RESOURCE_NOT_FOUND',
+    })
+    const result = _classifyError(e)
+    expect(result.code).toBe(1)
+    expect(result.payload.code).toBe('RESOURCE_NOT_FOUND')
+    expect(result.payload.message).toBe('Not found')
+  })
+
+  it('Generic Error → code 1, payload code UNKNOWN_ERROR', () => {
+    const e = new Error('unexpected')
+    const result = _classifyError(e)
+    expect(result.code).toBe(1)
+    expect(result.payload.code).toBe('UNKNOWN_ERROR')
+    expect(result.payload.message).toBe('unexpected')
+  })
+
+  it('Non-Error value (string) → code 1, UNKNOWN_ERROR', () => {
+    const result = _classifyError('something went wrong')
+    expect(result.code).toBe(1)
+    expect(result.payload.code).toBe('UNKNOWN_ERROR')
+    expect(result.payload.message).toBe('something went wrong')
+  })
+
+  it('CliValidationError → code 2', () => {
+    const e = new CliValidationError('bad input', { code: 'MISSING_REQUIRED_ARG' })
+    const result = _classifyError(e)
+    expect(result.code).toBe(2)
+    expect(result.payload.code).toBe('MISSING_REQUIRED_ARG')
+  })
+
+  it('CliConfigError → code 3', () => {
+    const e = new CliConfigError('bad config', { code: 'CONFIG_PARSE_ERROR' })
+    const result = _classifyError(e)
+    expect(result.code).toBe(3)
+    expect(result.payload.code).toBe('CONFIG_PARSE_ERROR')
   })
 })

--- a/packages/cli/src/__tests__/formatter.test.ts
+++ b/packages/cli/src/__tests__/formatter.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { formatCsv, formatTsv } from '../output/csv.js'
+import { formatTable } from '../output/table.js'
+import { formatOutput } from '../output/formatter.js'
+
+describe('CSV formatter', () => {
+  it('quotes fields containing commas', () => {
+    const out = formatCsv([{ name: 'Smith, John' }])
+    expect(out).toContain('"Smith, John"')
+  })
+
+  it('escapes double-quotes per RFC 4180', () => {
+    const out = formatCsv([{ name: 'Say "hello"' }])
+    expect(out).toContain('"Say ""hello"""')
+  })
+
+  it('preserves embedded newlines in quoted fields', () => {
+    const out = formatCsv([{ bio: 'line1\nline2' }])
+    expect(out).toContain('"line1\nline2"')
+  })
+
+  it('flattens custom_fields to custom_fields.<key> columns', () => {
+    const out = formatCsv([{ name: 'Alice', custom_fields: { score: 42, tier: 'gold' } }])
+    expect(out).toContain('custom_fields.score')
+    expect(out).toContain('custom_fields.tier')
+    expect(out).toContain('42')
+    expect(out).toContain('gold')
+  })
+
+  it('has header row as first line', () => {
+    const out = formatCsv([{ name: 'Alice', age: '30' }])
+    const lines = out.split('\r\n')
+    expect(lines[0]).toBe('name,age')
+  })
+})
+
+describe('TSV formatter', () => {
+  it('strips tab characters from field values', () => {
+    const out = formatTsv([{ value: 'a\tb' }])
+    // Tab in field replaced with space; result should not have tab in that field
+    expect(out).not.toContain('a\tb')
+    expect(out).toContain('a b')
+  })
+})
+
+describe('Table formatter', () => {
+  it('renders nested objects as JSON strings, not [object Object]', () => {
+    const out = formatTable([{ data: { key: 'val' } }])
+    expect(out).not.toContain('[object Object]')
+    expect(out).toContain('"key"')
+  })
+
+  it('renders true as yes and false as no', () => {
+    const out = formatTable([{ active: true, verified: false }])
+    expect(out).toContain('yes')
+    expect(out).toContain('no')
+  })
+
+  it('renders arrays as comma-separated values', () => {
+    const out = formatTable([{ tags: ['a', 'b', 'c'] }])
+    expect(out).toContain('a, b, c')
+  })
+
+  it('renders dates as ISO strings', () => {
+    const d = '2024-01-15T10:00:00.000Z'
+    const out = formatTable([{ created_at: d }])
+    expect(out).toContain('2024-01-15')
+  })
+})
+
+describe('JSON formatter', () => {
+  it('round-trips through JSON.parse with equality', () => {
+    const envelope = { data: [{ id: 'cnt_1', name: 'Alice' }], meta: { total: 1 } }
+    const out = formatOutput(envelope, { format: 'json' })
+    expect(JSON.parse(out)).toEqual(envelope)
+  })
+})

--- a/packages/cli/src/__tests__/formatter.test.ts
+++ b/packages/cli/src/__tests__/formatter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { formatCsv, formatTsv } from '../output/csv.js'
 import { formatTable } from '../output/table.js'
 import { formatOutput } from '../output/formatter.js'
+import { formatJson } from '../output/json.js'
 
 describe('CSV formatter', () => {
   it('quotes fields containing commas', () => {
@@ -32,6 +33,36 @@ describe('CSV formatter', () => {
     const lines = out.split('\r\n')
     expect(lines[0]).toBe('name,age')
   })
+
+  it('returns empty string for empty array', () => {
+    expect(formatCsv([])).toBe('')
+  })
+
+  it('renders null values as empty string (not "undefined")', () => {
+    const out = formatCsv([{ a: null }])
+    const lines = out.split('\r\n')
+    // header line + data line + trailing empty from split
+    expect(lines[1]).toBe('')
+    expect(out).not.toContain('undefined')
+    expect(out).not.toContain('null')
+  })
+
+  it('renders true as yes', () => {
+    const out = formatCsv([{ active: true }])
+    const lines = out.split('\r\n')
+    expect(lines[1]).toBe('yes')
+  })
+
+  it('renders false as no', () => {
+    const out = formatCsv([{ active: false }])
+    const lines = out.split('\r\n')
+    expect(lines[1]).toBe('no')
+  })
+
+  it('renders arrays as comma-separated values', () => {
+    const out = formatCsv([{ tags: ['a', 'b', 'c'] }])
+    expect(out).toContain('a, b, c')
+  })
 })
 
 describe('TSV formatter', () => {
@@ -40,6 +71,16 @@ describe('TSV formatter', () => {
     // Tab in field replaced with space; result should not have tab in that field
     expect(out).not.toContain('a\tb')
     expect(out).toContain('a b')
+  })
+
+  it('returns empty string for empty array', () => {
+    expect(formatTsv([])).toBe('')
+  })
+
+  it('uses tab as delimiter in header', () => {
+    const out = formatTsv([{ name: 'Alice', age: '30' }])
+    const lines = out.split('\r\n')
+    expect(lines[0]).toBe('name\tage')
   })
 })
 
@@ -66,6 +107,22 @@ describe('Table formatter', () => {
     const out = formatTable([{ created_at: d }])
     expect(out).toContain('2024-01-15')
   })
+
+  it('returns (no records) for empty array', () => {
+    expect(formatTable([])).toBe('(no records)\n')
+  })
+
+  it('renders Date objects as ISO string', () => {
+    const d = new Date('2024-06-01T12:00:00.000Z')
+    const out = formatTable([{ created_at: d }])
+    expect(out).toContain('2024-06-01T12:00:00.000Z')
+  })
+
+  it('renders null values as empty string', () => {
+    const out = formatTable([{ name: null }])
+    expect(out).not.toContain('null')
+    expect(out).not.toContain('undefined')
+  })
 })
 
 describe('JSON formatter', () => {
@@ -73,5 +130,56 @@ describe('JSON formatter', () => {
     const envelope = { data: [{ id: 'cnt_1', name: 'Alice' }], meta: { total: 1 } }
     const out = formatOutput(envelope, { format: 'json' })
     expect(JSON.parse(out)).toEqual(envelope)
+  })
+
+  it('formatJson(null) returns "null\\n"', () => {
+    expect(formatJson(null)).toBe('null\n')
+  })
+
+  it('formatJson with object returns pretty-printed JSON', () => {
+    const out = formatJson({ key: 'value' })
+    expect(out).toContain('"key"')
+    expect(out.endsWith('\n')).toBe(true)
+  })
+})
+
+describe('formatOutput', () => {
+  it('format table with envelope { data: [...] } renders data array', () => {
+    const envelope = { data: [{ id: '1', name: 'Alice' }] }
+    const out = formatOutput(envelope, { format: 'table' })
+    expect(out).toContain('Alice')
+    expect(out).not.toContain('(no records)')
+  })
+
+  it('format csv with envelope passes through to CSV', () => {
+    const envelope = { data: [{ name: 'Bob' }] }
+    const out = formatOutput(envelope, { format: 'csv' })
+    expect(out).toContain('name')
+    expect(out).toContain('Bob')
+  })
+
+  it('format tsv with envelope passes through to TSV', () => {
+    const envelope = { data: [{ name: 'Carol' }] }
+    const out = formatOutput(envelope, { format: 'tsv' })
+    expect(out).toContain('name')
+    expect(out).toContain('Carol')
+  })
+
+  it('format table with non-array envelope (single record) renders the record', () => {
+    const singleRecord = { data: { id: '42', name: 'Dave' } }
+    const out = formatOutput(singleRecord, { format: 'table' })
+    expect(out).toContain('Dave')
+  })
+
+  it('format json with single record returns full envelope as JSON', () => {
+    const envelope = { data: { id: '1' }, meta: {} }
+    const out = formatOutput(envelope, { format: 'json' })
+    expect(JSON.parse(out)).toEqual(envelope)
+  })
+
+  it('format table with empty data array returns (no records)', () => {
+    const envelope = { data: [] }
+    const out = formatOutput(envelope, { format: 'table' })
+    expect(out).toBe('(no records)\n')
   })
 })

--- a/packages/cli/src/__tests__/ink-views.test.ts
+++ b/packages/cli/src/__tests__/ink-views.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { PassThrough } from 'node:stream'
+import { render } from 'ink'
+
+// Helper: render a React element to a string by capturing ink's debug output.
+// Uses debug:true so each render frame is written as plain text (no ANSI escape sequences for cursor movement).
+async function renderToString(element: React.ReactNode): Promise<string> {
+  const stream = new PassThrough()
+  const chunks: Buffer[] = []
+  stream.on('data', (chunk: Buffer) => chunks.push(chunk))
+
+  const instance = render(element, {
+    stdout: stream as unknown as NodeJS.WriteStream,
+    stdin: process.stdin,
+    debug: true,
+    patchConsole: false,
+  })
+
+  // Give React/Ink a tick to render
+  await new Promise((r) => setTimeout(r, 50))
+  instance.unmount()
+  instance.cleanup()
+
+  stream.end()
+  return Buffer.concat(chunks).toString()
+}
+
+describe('Ink views', () => {
+  let originalIsTTY: boolean | undefined
+
+  beforeEach(() => {
+    originalIsTTY = process.stdout.isTTY
+    // Set isTTY true so components don't early-return null
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true, configurable: true })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, writable: true, configurable: true })
+  })
+
+  describe('PipelineBoard', () => {
+    it('renders each deal title with two columns and three deals', async () => {
+      const { PipelineBoard } = await import('../ink/pipeline-board.js')
+
+      const output = await renderToString(
+        React.createElement(PipelineBoard, {
+          stages: [
+            {
+              id: 'stg1',
+              name: 'Prospecting',
+              deals: [
+                { id: 'd1', title: 'Deal Alpha' },
+                { id: 'd2', title: 'Deal Beta' },
+              ],
+            },
+            {
+              id: 'stg2',
+              name: 'Closing',
+              deals: [{ id: 'd3', title: 'Deal Gamma' }],
+            },
+          ],
+        }),
+      )
+
+      expect(output).toContain('Deal Alpha')
+      expect(output).toContain('Deal Beta')
+      expect(output).toContain('Deal Gamma')
+    })
+
+    it('renders stage name but no deal bullet rows for empty stage', async () => {
+      const { PipelineBoard } = await import('../ink/pipeline-board.js')
+
+      const output = await renderToString(
+        React.createElement(PipelineBoard, {
+          stages: [{ id: 'stg1', name: 'Prospecting', deals: [] }],
+        }),
+      )
+
+      expect(output).toContain('Prospecting')
+      expect(output).not.toMatch(/•/)
+    })
+
+    it('returns empty output when isTTY is false', async () => {
+      // Override to non-TTY before rendering
+      Object.defineProperty(process.stdout, 'isTTY', { value: false, writable: true, configurable: true })
+
+      const { PipelineBoard } = await import('../ink/pipeline-board.js')
+
+      const output = await renderToString(
+        React.createElement(PipelineBoard, { stages: [{ id: 's1', name: 'Stage', deals: [] }] }),
+      )
+
+      expect(output.trim()).toBe('')
+    })
+  })
+
+  describe('Confirm', () => {
+    it('renders the message prompt text', async () => {
+      const { Confirm } = await import('../interactive/confirm.js')
+
+      const output = await renderToString(
+        React.createElement(Confirm, {
+          message: 'Are you sure?',
+          onConfirm: (_v: boolean) => {},
+        }),
+      )
+
+      expect(output).toContain('Are you sure?')
+    })
+  })
+})

--- a/packages/cli/src/__tests__/ink-views.test.ts
+++ b/packages/cli/src/__tests__/ink-views.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import React from 'react'
 import { PassThrough } from 'node:stream'
 import { render } from 'ink'
@@ -37,6 +37,7 @@ describe('Ink views', () => {
 
   afterEach(() => {
     Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, writable: true, configurable: true })
+    vi.restoreAllMocks()
   })
 
   describe('PipelineBoard', () => {
@@ -93,6 +94,23 @@ describe('Ink views', () => {
 
       expect(output.trim()).toBe('')
     })
+
+    it('returns empty output when isJsonMode is true', async () => {
+      // Import the program module and spy on isJsonMode to return true
+      const programModule = await import('../program.js')
+      const spy = vi.spyOn(programModule, 'isJsonMode').mockReturnValue(true)
+
+      const { PipelineBoard } = await import('../ink/pipeline-board.js')
+
+      const output = await renderToString(
+        React.createElement(PipelineBoard, {
+          stages: [{ id: 's1', name: 'Test', deals: [{ id: 'd1', title: 'Deal X' }] }],
+        }),
+      )
+
+      spy.mockRestore()
+      expect(output.trim()).toBe('')
+    })
   })
 
   describe('Confirm', () => {
@@ -107,6 +125,78 @@ describe('Ink views', () => {
       )
 
       expect(output).toContain('Are you sure?')
+    })
+
+    it('calls onConfirm(true) when y is pressed', async () => {
+      const { Confirm } = await import('../interactive/confirm.js')
+
+      const onConfirm = vi.fn()
+      const stdinStream = new PassThrough() as PassThrough & {
+        isTTY?: boolean
+        setRawMode?: (raw: boolean) => void
+        ref?: () => void
+        unref?: () => void
+      }
+      stdinStream.isTTY = true
+      stdinStream.setRawMode = () => {}
+      stdinStream.ref = () => {}
+      stdinStream.unref = () => {}
+      const stdoutStream = new PassThrough()
+
+      const instance = render(
+        React.createElement(Confirm, { message: 'Confirm?', onConfirm }),
+        {
+          stdout: stdoutStream as unknown as NodeJS.WriteStream,
+          stdin: stdinStream as unknown as NodeJS.ReadStream,
+          debug: true,
+          patchConsole: false,
+        },
+      )
+
+      await new Promise((r) => setTimeout(r, 50))
+      stdinStream.write('y')
+      await new Promise((r) => setTimeout(r, 100))
+
+      instance.unmount()
+      instance.cleanup()
+
+      expect(onConfirm).toHaveBeenCalledWith(true)
+    })
+
+    it('calls onConfirm(false) when n is pressed', async () => {
+      const { Confirm } = await import('../interactive/confirm.js')
+
+      const onConfirm = vi.fn()
+      const stdinStream = new PassThrough() as PassThrough & {
+        isTTY?: boolean
+        setRawMode?: (raw: boolean) => void
+        ref?: () => void
+        unref?: () => void
+      }
+      stdinStream.isTTY = true
+      stdinStream.setRawMode = () => {}
+      stdinStream.ref = () => {}
+      stdinStream.unref = () => {}
+      const stdoutStream = new PassThrough()
+
+      const instance = render(
+        React.createElement(Confirm, { message: 'Confirm?', onConfirm }),
+        {
+          stdout: stdoutStream as unknown as NodeJS.WriteStream,
+          stdin: stdinStream as unknown as NodeJS.ReadStream,
+          debug: true,
+          patchConsole: false,
+        },
+      )
+
+      await new Promise((r) => setTimeout(r, 50))
+      stdinStream.write('n')
+      await new Promise((r) => setTimeout(r, 100))
+
+      instance.unmount()
+      instance.cleanup()
+
+      expect(onConfirm).toHaveBeenCalledWith(false)
     })
   })
 })

--- a/packages/cli/src/__tests__/json-fidelity.test.ts
+++ b/packages/cli/src/__tests__/json-fidelity.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { formatOutput } from '../output/formatter.js'
 import { formatJson } from '../output/json.js'
+import { createProgram, isJsonMode, _resetJsonMode } from '../program.js'
 
 describe('JSON fidelity', () => {
   it('preserves request_id and next_cursor from SDK envelope', () => {
@@ -44,5 +45,27 @@ describe('JSON fidelity', () => {
     const out = formatOutput(envelope, { format: 'json' })
     expect(out).not.toMatch(/\x1b\[/)
     JSON.parse(out) // must be valid JSON
+  })
+
+  it('--format json sets isJsonMode() via preAction hook', async () => {
+    _resetJsonMode()
+    const prog = createProgram()
+    prog.exitOverride()
+    prog.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    // Intercept process.exit and stdout/stderr to prevent side effects
+    const origExit = process.exit
+    process.exit = (() => { throw new Error('exit') }) as typeof process.exit
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    try {
+      // Use default from:'node' so argv[0]/[1] are stripped — matches how CLI is invoked
+      await prog.parseAsync(['node', 'orbit', '--format', 'json', 'contacts', 'list'])
+    } catch {
+      // action errors (missing API key, etc.) are expected
+    } finally {
+      process.exit = origExit
+      vi.restoreAllMocks()
+    }
+    expect(isJsonMode()).toBe(true)
   })
 })

--- a/packages/cli/src/__tests__/json-fidelity.test.ts
+++ b/packages/cli/src/__tests__/json-fidelity.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { formatOutput } from '../output/formatter.js'
+import { formatJson } from '../output/json.js'
+
+describe('JSON fidelity', () => {
+  it('preserves request_id and next_cursor from SDK envelope', () => {
+    const envelope = {
+      data: [],
+      meta: { request_id: 'req_known', next_cursor: 'cursor_abc', has_more: true, total: 0 },
+      links: { next: '/v1/contacts?cursor=cursor_abc' },
+    }
+    const out = formatOutput(envelope, { format: 'json' })
+    const parsed = JSON.parse(out)
+    expect(parsed.meta.request_id).toBe('req_known')
+    expect(parsed.meta.next_cursor).toBe('cursor_abc')
+  })
+
+  it('adds no extra keys beyond what SDK returned', () => {
+    const envelope = { data: [{ id: 'cnt_1' }], meta: { request_id: 'r1' } }
+    const out = formatOutput(envelope, { format: 'json' })
+    const parsed = JSON.parse(out)
+    expect(Object.keys(parsed)).toEqual(Object.keys(envelope))
+  })
+
+  it('pass-through for single-record envelope', () => {
+    const envelope = { data: { id: 'cnt_123', name: 'Alice' }, meta: { request_id: 'r2' } }
+    const out = formatJson(envelope)
+    const parsed = JSON.parse(out)
+    expect(parsed.data.id).toBe('cnt_123')
+    expect(parsed.meta.request_id).toBe('r2')
+  })
+
+  it('formats error envelope correctly (no ANSI codes)', () => {
+    const errEnvelope = { error: { code: 'AUTH_INVALID_API_KEY', message: 'Invalid API key', request_id: 'r3' } }
+    const out = formatJson(errEnvelope)
+    // No ANSI escape codes
+    expect(out).not.toMatch(/\x1b\[/)
+    const parsed = JSON.parse(out)
+    expect(parsed.error.request_id).toBe('r3')
+  })
+
+  it('no ANSI codes in JSON output', () => {
+    const envelope = { data: [{ id: 'x' }], meta: {} }
+    const out = formatOutput(envelope, { format: 'json' })
+    expect(out).not.toMatch(/\x1b\[/)
+    JSON.parse(out) // must be valid JSON
+  })
+})

--- a/packages/cli/src/__tests__/non-tty.test.ts
+++ b/packages/cli/src/__tests__/non-tty.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { CliValidationError } from '../errors.js'
+import { runInit } from '../commands/init.js'
+import { makeTmpDir } from './setup.js'
+
+describe('non-TTY / agent mode', () => {
+  let originalIsTTY: boolean | undefined
+
+  beforeEach(() => {
+    originalIsTTY = process.stdout.isTTY
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, writable: true, configurable: true })
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true, configurable: true })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, writable: true, configurable: true })
+  })
+
+  it('orbit init without --yes in non-TTY mode throws CliValidationError', async () => {
+    const cwd = makeTmpDir()
+    await expect(runInit({ cwd, yes: false })).rejects.toThrow(CliValidationError)
+  })
+
+  it('orbit init with --yes in non-TTY mode succeeds', async () => {
+    const cwd = makeTmpDir()
+    await expect(runInit({ cwd, yes: true })).resolves.not.toThrow()
+  })
+
+  it('orbit init with --env-file .env throws CliValidationError regardless of TTY', async () => {
+    const cwd = makeTmpDir()
+    await expect(runInit({ cwd, yes: true, envFile: '.env' })).rejects.toThrow(CliValidationError)
+  })
+})

--- a/packages/cli/src/__tests__/program.test.ts
+++ b/packages/cli/src/__tests__/program.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { createProgram, isJsonMode } from '../program.js'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createProgram, isJsonMode, run, _resetJsonMode } from '../program.js'
 
 describe('program', () => {
   const expectedCommands = [
@@ -164,5 +164,47 @@ describe('program', () => {
       // exitOverride throws on --help
     }
     expect(helpText).toContain('orbit')
+  })
+})
+
+describe('Commander parse errors — JSON contract', () => {
+  let origArgv: string[]
+  let origExit: typeof process.exit
+  let exitCode: number | undefined
+  let stdoutOutput: string
+
+  beforeEach(() => {
+    origArgv = [...process.argv]
+    origExit = process.exit
+    exitCode = undefined
+    stdoutOutput = ''
+    _resetJsonMode()
+    process.exit = ((code?: number) => {
+      exitCode = code ?? 0
+      throw new Error(`process.exit(${code})`)
+    }) as typeof process.exit
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdoutOutput += String(chunk)
+      return true
+    })
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    process.argv = origArgv
+    process.exit = origExit
+    vi.restoreAllMocks()
+    _resetJsonMode()
+  })
+
+  it('--json: Commander unknown flag error produces { error: ... } JSON on stdout', async () => {
+    process.argv = ['node', 'orbit', '--json', '--unknown-flag-xyz-abc']
+    await expect(run()).rejects.toThrow()
+    let parsed: unknown
+    try { parsed = JSON.parse(stdoutOutput) } catch { parsed = null }
+    expect(parsed).not.toBeNull()
+    expect((parsed as { error?: unknown }).error).toBeDefined()
+    expect(typeof (parsed as { error: { code: string; message: string } }).error.code).toBe('string')
+    expect(typeof (parsed as { error: { code: string; message: string } }).error.message).toBe('string')
   })
 })

--- a/packages/cli/src/__tests__/program.test.ts
+++ b/packages/cli/src/__tests__/program.test.ts
@@ -197,6 +197,29 @@ describe('Commander parse errors — JSON contract', () => {
     _resetJsonMode()
   })
 
+  it('_jsonMode is reset to false between run() invocations', async () => {
+    let savedArgv = [...process.argv]
+
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    try {
+      // First invocation with --json sets _jsonMode = true
+      process.argv = ['node', 'orbit', '--json', '--unknown-xyz']
+      await expect(run()).rejects.toThrow()
+      expect(isJsonMode()).toBe(true)
+
+      // Second invocation without --json should reset _jsonMode to false
+      process.argv = ['node', 'orbit', '--unknown-xyz']
+      await expect(run()).rejects.toThrow()
+      expect(isJsonMode()).toBe(false)
+    } finally {
+      process.argv = savedArgv
+      vi.restoreAllMocks()
+      _resetJsonMode()
+    }
+  })
+
   it('--json: Commander unknown flag error produces { error: ... } JSON on stdout', async () => {
     process.argv = ['node', 'orbit', '--json', '--unknown-flag-xyz-abc']
     await expect(run()).rejects.toThrow()

--- a/packages/cli/src/__tests__/program.test.ts
+++ b/packages/cli/src/__tests__/program.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { createProgram, isJsonMode } from '../program.js'
+
+describe('program', () => {
+  const expectedCommands = [
+    'init', 'status', 'doctor', 'seed', 'migrate',
+    'contacts', 'companies', 'deals', 'context', 'search', 'users',
+    'log', 'tasks', 'notes', 'sequences', 'fields', 'schema', 'report',
+    'dashboard', 'mcp', 'integrations',
+  ]
+
+  it('registers all expected commands', () => {
+    const program = createProgram()
+    const names = program.commands.map((c) => c.name())
+    for (const cmd of expectedCommands) {
+      expect(names).toContain(cmd)
+    }
+  })
+
+  it('registers --json flag', () => {
+    const program = createProgram()
+    const opts = program.opts()
+    // Options are defined on the program
+    expect(program.options.some((o) => o.long === '--json')).toBe(true)
+  })
+})

--- a/packages/cli/src/__tests__/program.test.ts
+++ b/packages/cli/src/__tests__/program.test.ts
@@ -19,8 +19,150 @@ describe('program', () => {
 
   it('registers --json flag', () => {
     const program = createProgram()
-    const opts = program.opts()
-    // Options are defined on the program
     expect(program.options.some((o) => o.long === '--json')).toBe(true)
+  })
+
+  it('--format default is table', () => {
+    const program = createProgram()
+    const formatOption = program.options.find((o) => o.long === '--format')
+    expect(formatOption).toBeDefined()
+    expect(formatOption?.defaultValue).toBe('table')
+  })
+
+  it('registers --format flag', () => {
+    const program = createProgram()
+    expect(program.options.some((o) => o.long === '--format')).toBe(true)
+  })
+
+  it('--format json sets format to json', () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    try { program.parse(['node', 'orbit', '--format', 'json', '--help'], { from: 'user' }) } catch { /* --help throws */ }
+    expect(program.opts().format).toBe('json')
+  })
+
+  it('--format csv sets format to csv', () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    try { program.parse(['node', 'orbit', '--format', 'csv', '--help'], { from: 'user' }) } catch { /* --help throws */ }
+    expect(program.opts().format).toBe('csv')
+  })
+
+  it('--format tsv sets format to tsv', () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    try { program.parse(['node', 'orbit', '--format', 'tsv', '--help'], { from: 'user' }) } catch { /* --help throws */ }
+    expect(program.opts().format).toBe('tsv')
+  })
+
+  it('recognizes --quiet flag', () => {
+    const program = createProgram()
+    expect(program.options.some((o) => o.long === '--quiet')).toBe(true)
+  })
+
+  it('--quiet flag is parsed correctly', () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    try { program.parse(['node', 'orbit', '--quiet', '--help'], { from: 'user' }) } catch { /* --help throws */ }
+    expect(program.opts().quiet).toBe(true)
+  })
+
+  it('recognizes --yes flag', () => {
+    const program = createProgram()
+    expect(program.options.some((o) => o.long === '--yes')).toBe(true)
+  })
+
+  it('--yes flag is parsed correctly', () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    try { program.parse(['node', 'orbit', '--yes', '--help'], { from: 'user' }) } catch { /* --help throws */ }
+    expect(program.opts().yes).toBe(true)
+  })
+
+  it('recognizes --mode flag', () => {
+    const program = createProgram()
+    expect(program.options.some((o) => o.long === '--mode')).toBe(true)
+  })
+
+  it('--mode api is recognized', () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    try { program.parse(['node', 'orbit', '--mode', 'api', '--help'], { from: 'user' }) } catch { /* --help throws */ }
+    expect(program.opts().mode).toBe('api')
+  })
+
+  it('--mode direct is recognized', () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    try { program.parse(['node', 'orbit', '--mode', 'direct', '--help'], { from: 'user' }) } catch { /* --help throws */ }
+    expect(program.opts().mode).toBe('direct')
+  })
+
+  it('--mode default is api', () => {
+    const program = createProgram()
+    const modeOption = program.options.find((o) => o.long === '--mode')
+    expect(modeOption?.defaultValue).toBe('api')
+  })
+
+  it('recognizes --api-key flag', () => {
+    const program = createProgram()
+    expect(program.options.some((o) => o.long === '--api-key')).toBe(true)
+  })
+
+  it('--api-key flag is parsed correctly', () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    try { program.parse(['node', 'orbit', '--api-key', 'test-key-123', '--help'], { from: 'user' }) } catch { /* --help throws */ }
+    expect(program.opts().apiKey).toBe('test-key-123')
+  })
+
+  it('recognizes --base-url flag', () => {
+    const program = createProgram()
+    expect(program.options.some((o) => o.long === '--base-url')).toBe(true)
+  })
+
+  it('--base-url flag is parsed correctly', () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    try { program.parse(['node', 'orbit', '--base-url', 'http://localhost:3000', '--help'], { from: 'user' }) } catch { /* --help throws */ }
+    expect(program.opts().baseUrl).toBe('http://localhost:3000')
+  })
+
+  it('recognizes --org-id flag', () => {
+    const program = createProgram()
+    expect(program.options.some((o) => o.long === '--org-id')).toBe(true)
+  })
+
+  it('--org-id flag is parsed correctly', () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    try { program.parse(['node', 'orbit', '--org-id', 'org_abc123', '--help'], { from: 'user' }) } catch { /* --help throws */ }
+    expect(program.opts().orgId).toBe('org_abc123')
+  })
+
+  it('--help flag outputs program description', () => {
+    const program = createProgram()
+    program.exitOverride()
+    let helpText = ''
+    program.configureOutput({
+      writeOut: (str) => { helpText += str },
+      writeErr: () => {},
+    })
+    try {
+      program.parse(['node', 'orbit', '--help'], { from: 'user' })
+    } catch {
+      // exitOverride throws on --help
+    }
+    expect(helpText).toContain('orbit')
   })
 })

--- a/packages/cli/src/__tests__/prompt.test.ts
+++ b/packages/cli/src/__tests__/prompt.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+// Import the module under test
+import { confirmAction } from '../utils/prompt.js'
+
+describe('confirmAction', () => {
+  let stdinMock: EventEmitter
+  let origStdin: NodeJS.ReadStream & { fd: 0 }
+  let stderrOutput: string
+
+  beforeEach(() => {
+    stdinMock = new EventEmitter() as unknown as NodeJS.ReadStream
+    // confirmAction calls process.stdin.setEncoding — add a no-op so the mock doesn't throw
+    ;(stdinMock as unknown as { setEncoding: (enc: string) => void }).setEncoding = () => {}
+    origStdin = process.stdin
+    Object.defineProperty(process, 'stdin', { value: stdinMock, configurable: true })
+    stderrOutput = ''
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      stderrOutput += String(chunk)
+      return true
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'stdin', { value: origStdin, configurable: true })
+    vi.restoreAllMocks()
+  })
+
+  it('resolves true when user types "y"', async () => {
+    const p = confirmAction('Confirm? ')
+    stdinMock.emit('data', 'y\n')
+    expect(await p).toBe(true)
+  })
+
+  it('resolves false when user types "n"', async () => {
+    const p = confirmAction('Confirm? ')
+    stdinMock.emit('data', 'n\n')
+    expect(await p).toBe(false)
+  })
+
+  it('resolves false when user types anything other than y', async () => {
+    const p = confirmAction('Confirm? ')
+    stdinMock.emit('data', 'yes\n')
+    expect(await p).toBe(false)
+  })
+
+  it('resolves false on stdin EOF (end event) — does not hang', async () => {
+    const p = confirmAction('Confirm? ')
+    stdinMock.emit('end')
+    expect(await p).toBe(false)
+  })
+
+  it('rejects on stdin error event', async () => {
+    const p = confirmAction('Confirm? ')
+    stdinMock.emit('error', new Error('stdin broken'))
+    await expect(p).rejects.toThrow('stdin broken')
+  })
+
+  it('writes the prompt to stderr', async () => {
+    const p = confirmAction('Are you sure? ')
+    stdinMock.emit('data', 'n')
+    await p
+    expect(stderrOutput).toContain('Are you sure?')
+  })
+})

--- a/packages/cli/src/__tests__/search.test.ts
+++ b/packages/cli/src/__tests__/search.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createProgram } from '../program.js'
+
+const mockSearchResponse = {
+  query: vi.fn(),
+}
+
+const mockSearch = {
+  query: vi.fn(),
+  response: () => mockSearchResponse,
+}
+
+const mockClient = {
+  search: mockSearch,
+}
+
+vi.mock('@orbit-ai/sdk', () => ({
+  OrbitClient: vi.fn(() => mockClient),
+}))
+
+beforeEach(() => {
+  process.env.ORBIT_API_KEY = 'test-key'
+  vi.clearAllMocks()
+})
+
+describe('orbit search', () => {
+  it('search "Alice" --types contacts,deals --limit 10 --json maps to correct SearchInput', async () => {
+    const envelope = {
+      data: [{ id: 'cnt_1', object: 'contact', name: 'Alice' }],
+      meta: { request_id: 'srch_1' },
+    }
+    mockSearchResponse.query.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync([
+      'node', 'orbit', '--json', 'search', 'Alice',
+      '--types', 'contacts,deals',
+      '--limit', '10',
+    ])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data[0].id).toBe('cnt_1')
+    expect(parsed.meta.request_id).toBe('srch_1')
+    expect(mockSearchResponse.query).toHaveBeenCalledWith({
+      query: 'Alice',
+      object_types: ['contacts', 'deals'],
+      limit: 10,
+    })
+  })
+
+  it('search "Alice" (no --types) sends object_types: undefined', async () => {
+    mockSearch.query.mockResolvedValue([{ id: 'cnt_1' }])
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', 'search', 'Alice'])
+    process.stdout.write = origWrite
+
+    expect(mockSearch.query).toHaveBeenCalledWith(
+      expect.not.objectContaining({ object_types: expect.anything() })
+    )
+  })
+
+  it('search --json with cursor passes cursor in SearchInput', async () => {
+    const envelope = {
+      data: [],
+      meta: { request_id: 'srch_2', next_cursor: null },
+    }
+    mockSearchResponse.query.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync([
+      'node', 'orbit', '--json', 'search', 'Alice',
+      '--cursor', 'cursor_abc',
+    ])
+    process.stdout.write = origWrite
+
+    expect(mockSearchResponse.query).toHaveBeenCalledWith(
+      expect.objectContaining({ cursor: 'cursor_abc' })
+    )
+  })
+})

--- a/packages/cli/src/__tests__/sequences.test.ts
+++ b/packages/cli/src/__tests__/sequences.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createProgram } from '../program.js'
+
+// --- mock setup ---
+const mockSequencesResponse = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  enroll: vi.fn(),
+}
+
+const mockSequences = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  enroll: vi.fn(),
+  response: () => mockSequencesResponse,
+}
+
+const mockSequenceEnrollmentsResponse = {
+  unenroll: vi.fn(),
+}
+
+const mockSequenceEnrollments = {
+  unenroll: vi.fn(),
+  response: () => mockSequenceEnrollmentsResponse,
+}
+
+const mockClient = {
+  sequences: mockSequences,
+  sequenceEnrollments: mockSequenceEnrollments,
+}
+
+vi.mock('@orbit-ai/sdk', () => ({
+  OrbitClient: vi.fn(() => mockClient),
+}))
+
+beforeEach(() => {
+  process.env.ORBIT_API_KEY = 'test-key'
+  vi.clearAllMocks()
+})
+
+describe('sequences enroll', () => {
+  it('enroll calls client.sequences.enroll() — NOT sequenceEnrollments.create()', async () => {
+    const enrollResult = { id: 'se_1', object: 'sequence_enrollment', sequence_id: 'seq_1', contact_id: 'cnt_1' }
+    mockSequences.enroll.mockResolvedValue(enrollResult)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync([
+      'node', 'orbit', '--json', 'sequences', 'enroll', 'seq_1', '--contact', 'cnt_1',
+    ])
+    process.stdout.write = origWrite
+
+    // Must have called sequences.enroll, not sequenceEnrollments
+    expect(mockSequences.enroll).toHaveBeenCalledWith('seq_1', expect.objectContaining({ contact_id: 'cnt_1' }))
+    // sequenceEnrollments should NOT have been touched
+    expect(mockSequenceEnrollments.unenroll).not.toHaveBeenCalled()
+
+    const parsed = JSON.parse(output)
+    expect(parsed.id).toBe('se_1')
+  })
+})
+
+describe('sequences unenroll', () => {
+  it('unenroll calls client.sequenceEnrollments.unenroll() — NOT sequenceEnrollments.delete()', async () => {
+    const unenrollResult = {
+      id: 'se_1',
+      object: 'sequence_enrollment',
+      status: 'unenrolled',
+    }
+    mockSequenceEnrollments.unenroll.mockResolvedValue(unenrollResult)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'sequences', 'unenroll', 'se_1'])
+    process.stdout.write = origWrite
+
+    // Must have called sequenceEnrollments.unenroll
+    expect(mockSequenceEnrollments.unenroll).toHaveBeenCalledWith('se_1')
+    // sequences.enroll should NOT have been called
+    expect(mockSequences.enroll).not.toHaveBeenCalled()
+
+    const parsed = JSON.parse(output)
+    expect(parsed.id).toBe('se_1')
+    expect(parsed.status).toBe('unenrolled')
+  })
+})
+
+describe('sequences list', () => {
+  it('list --json passes envelope through', async () => {
+    const envelope = {
+      data: [{ id: 'seq_1', object: 'sequence', name: 'Onboarding' }],
+      meta: { request_id: 'r1', has_more: false },
+    }
+    mockSequencesResponse.list.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'sequences', 'list'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data[0].id).toBe('seq_1')
+    expect(mockSequencesResponse.list).toHaveBeenCalledWith({ limit: 20 })
+  })
+})

--- a/packages/cli/src/__tests__/setup.ts
+++ b/packages/cli/src/__tests__/setup.ts
@@ -1,0 +1,19 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach } from 'vitest'
+
+const tmpDirs: string[] = []
+
+export function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-cli-test-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+  tmpDirs.length = 0
+})

--- a/packages/cli/src/__tests__/smoke.test.ts
+++ b/packages/cli/src/__tests__/smoke.test.ts
@@ -8,18 +8,66 @@
 import { describe, it, expect } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import * as path from 'node:path'
+import * as os from 'node:os'
+import * as fs from 'node:fs'
 
 const ORBIT_BIN = path.resolve(import.meta.dirname ?? __dirname, '../../dist/index.js')
 
+/** Path to the compiled core package index — used to init the SQLite schema before tests. */
+const CORE_INDEX = path.resolve(import.meta.dirname ?? __dirname, '../../../core/dist/index.js')
+
+/**
+ * Bootstrap a fresh SQLite database file by calling adapter.migrate() via a
+ * Node.js --input-type=module eval. This is necessary because DirectTransport
+ * does NOT auto-migrate — callers are responsible for schema initialization.
+ */
+function initSqliteDb(dbPath: string): void {
+  const script = `
+import { SqliteOrbitDatabase, createSqliteStorageAdapter } from '${CORE_INDEX}';
+const db = new SqliteOrbitDatabase({ filename: '${dbPath}' });
+const adapter = createSqliteStorageAdapter({ database: db });
+await adapter.migrate();
+`
+  const result = spawnSync(process.execPath, ['--input-type=module'], {
+    input: script,
+    encoding: 'utf8',
+    timeout: 15000,
+  })
+  if (result.status !== 0) {
+    throw new Error(
+      `SQLite schema init failed (exit ${result.status}):\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+    )
+  }
+}
+
 describe('CLI smoke tests', () => {
-  it('orbit with no arguments exits 0 (help text)', () => {
-    const result = spawnSync(process.execPath, [ORBIT_BIN, '--help'], {
-      encoding: 'utf8',
-      timeout: 10000,
-    })
-    // --help exits 0 by default in Commander
-    expect(result.status).toBe(0)
-    expect(result.stdout).toContain('orbit')
+  it('orbit contacts list in direct SQLite mode exits 0 with JSON envelope', () => {
+    const tmpDb = path.join(os.tmpdir(), `orbit-smoke-${Date.now()}.db`)
+    try {
+      // Initialize the SQLite schema — DirectTransport does not auto-migrate
+      initSqliteDb(tmpDb)
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          ORBIT_BIN,
+          '--json',
+          '--mode', 'direct',
+          '--adapter', 'sqlite',
+          '--database-url', tmpDb,
+          '--org-id', 'org_01ARYZ6S41YYYYYYYYYYYYYYYY',
+          'contacts', 'list',
+        ],
+        { encoding: 'utf8', timeout: 15000 },
+      )
+
+      expect(result.status).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      expect(parsed).toHaveProperty('data')
+      expect(Array.isArray(parsed.data)).toBe(true)
+    } finally {
+      try { fs.unlinkSync(tmpDb) } catch { /* ignore */ }
+    }
   })
 
   it('orbit contacts list --json with invalid api-key exits 1 with error envelope', () => {

--- a/packages/cli/src/__tests__/smoke.test.ts
+++ b/packages/cli/src/__tests__/smoke.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Smoke tests — run after `pnpm -r build` via:
+ *   pnpm --filter @orbit-ai/cli exec vitest run --config vitest.smoke.config.ts
+ *
+ * These tests spawn the compiled `orbit` binary as a subprocess.
+ * They are excluded from the default test run (see vitest.config.ts).
+ */
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import * as path from 'node:path'
+
+const ORBIT_BIN = path.resolve(import.meta.dirname ?? __dirname, '../../dist/index.js')
+
+describe('CLI smoke tests', () => {
+  it('orbit with no arguments exits 0 (help text)', () => {
+    const result = spawnSync(process.execPath, [ORBIT_BIN, '--help'], {
+      encoding: 'utf8',
+      timeout: 10000,
+    })
+    // --help exits 0 by default in Commander
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('orbit')
+  })
+
+  it('orbit contacts list --json with invalid api-key exits 1 with error envelope', () => {
+    const result = spawnSync(
+      process.execPath,
+      [ORBIT_BIN, '--json', 'contacts', 'list'],
+      {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: { ...process.env, ORBIT_API_KEY: 'invalid-key', ORBIT_BASE_URL: 'http://127.0.0.1:1' },
+      },
+    )
+    // Connection refused → exit code 1
+    expect(result.status).toBe(1)
+    // Stdout should be valid JSON (error envelope)
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(result.stdout)
+    } catch {
+      // stdout might be empty if error before JSON mode activates — check stderr
+      expect(result.status).toBe(1)
+      return
+    }
+    expect(parsed).toHaveProperty('error')
+  })
+
+  it('orbit mcp serve throws CliNotImplementedError gracefully', () => {
+    const result = spawnSync(
+      process.execPath,
+      [ORBIT_BIN, 'mcp', 'serve'],
+      {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: { ...process.env, ORBIT_API_KEY: 'test-key' },
+      },
+    )
+    // CliNotImplementedError → exit code 2
+    expect(result.status).toBe(2)
+    expect(result.stderr).toContain('@orbit-ai/mcp')
+  })
+})

--- a/packages/cli/src/__tests__/users.test.ts
+++ b/packages/cli/src/__tests__/users.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createProgram } from '../program.js'
+
+const mockUsersResponse = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}
+
+const mockUsers = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  response: () => mockUsersResponse,
+}
+
+const mockClient = {
+  users: mockUsers,
+}
+
+vi.mock('@orbit-ai/sdk', () => ({
+  OrbitClient: vi.fn(() => mockClient),
+}))
+
+beforeEach(() => {
+  process.env.ORBIT_API_KEY = 'test-key'
+  vi.clearAllMocks()
+})
+
+describe('users list', () => {
+  it('list --json passes envelope through', async () => {
+    const envelope = {
+      data: [{ id: 'usr_1', object: 'user', name: 'Alice', email: 'alice@example.com' }],
+      meta: { request_id: 'r1', next_cursor: null, has_more: false, total: 1 },
+    }
+    mockUsersResponse.list.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'users', 'list'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data[0].id).toBe('usr_1')
+    expect(parsed.meta.request_id).toBe('r1')
+  })
+
+  it('list table mode renders without [object Object]', async () => {
+    const envelope = {
+      data: [{ id: 'usr_1', object: 'user', name: 'Alice', email: 'alice@example.com' }],
+      meta: { request_id: 'r1', next_cursor: null, has_more: false, total: 1 },
+    }
+    mockUsers.list.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', 'users', 'list'])
+    process.stdout.write = origWrite
+
+    expect(output).not.toContain('[object Object]')
+    expect(output).toContain('usr_1')
+  })
+})
+
+describe('users get', () => {
+  it('get --json returns single-record envelope', async () => {
+    const envelope = { data: { id: 'usr_1', object: 'user', name: 'Alice' }, meta: { request_id: 'r2' } }
+    mockUsersResponse.get.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'users', 'get', 'usr_1'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('usr_1')
+  })
+})
+
+describe('users create', () => {
+  it('create --json returns created record envelope', async () => {
+    const envelope = { data: { id: 'usr_new', object: 'user', name: 'Bob', email: 'bob@example.com' }, meta: { request_id: 'r3' } }
+    mockUsersResponse.create.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'users', 'create', '--name', 'Bob', '--email', 'bob@example.com'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('usr_new')
+    expect(mockUsersResponse.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Bob', email: 'bob@example.com' }))
+  })
+})
+
+describe('users update', () => {
+  it('update --json returns updated record envelope', async () => {
+    const envelope = { data: { id: 'usr_1', object: 'user', name: 'Alice Updated' }, meta: { request_id: 'r4' } }
+    mockUsersResponse.update.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'users', 'update', 'usr_1', '--name', 'Alice Updated'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.id).toBe('usr_1')
+    expect(mockUsersResponse.update).toHaveBeenCalledWith('usr_1', expect.objectContaining({ name: 'Alice Updated' }))
+  })
+})
+
+describe('users delete', () => {
+  it('delete --json returns deletion envelope', async () => {
+    const envelope = { data: { id: 'usr_1', deleted: true }, meta: { request_id: 'r5' } }
+    mockUsersResponse.delete.mockResolvedValue(envelope)
+
+    const program = createProgram()
+    let output = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    }
+
+    await program.parseAsync(['node', 'orbit', '--json', 'users', 'delete', 'usr_1'])
+    process.stdout.write = origWrite
+
+    const parsed = JSON.parse(output)
+    expect(parsed.data.deleted).toBe(true)
+  })
+})
+
+describe('users non-TTY validation', () => {
+  it('create without --name and --email throws via Commander requiredOption', async () => {
+    const program = createProgram()
+    program.exitOverride()
+
+    await expect(
+      program.parseAsync(['node', 'orbit', '--json', 'users', 'create'])
+    ).rejects.toThrow()
+  })
+})

--- a/packages/cli/src/commands/activities.ts
+++ b/packages/cli/src/commands/activities.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateActivityInput, UpdateActivityInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerActivitiesCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.activities.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerActivitiesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.activities.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -69,7 +70,7 @@ export function registerActivitiesCommand(program: Command): void {
       if (opts.userId) input.user_id = opts.userId
       if (opts.occurredAt) input.occurred_at = opts.occurredAt
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.activities.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -103,7 +104,7 @@ export function registerActivitiesCommand(program: Command): void {
       if (opts.userId) input.user_id = opts.userId
       if (opts.occurredAt) input.occurred_at = opts.occurredAt
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.activities.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -119,7 +120,7 @@ export function registerActivitiesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.activities.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/activities.ts
+++ b/packages/cli/src/commands/activities.ts
@@ -1,0 +1,130 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateActivityInput, UpdateActivityInput } from '@orbit-ai/sdk'
+
+export function registerActivitiesCommand(program: Command): void {
+  const activities = program.command('activities').description('Manage activities')
+
+  activities
+    .command('list')
+    .description('List activities')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.activities.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.activities.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  activities
+    .command('get <id>')
+    .description('Get an activity by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.activities.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.activities.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  activities
+    .command('create')
+    .description('Create a new activity')
+    .requiredOption('--type <type>', 'Activity type (call, email, meeting, note, task)')
+    .option('--subject <subject>', 'Activity subject')
+    .option('--description <description>', 'Activity description')
+    .option('--contact-id <id>', 'Contact ID')
+    .option('--company-id <id>', 'Company ID')
+    .option('--deal-id <id>', 'Deal ID')
+    .option('--user-id <id>', 'User ID')
+    .option('--occurred-at <date>', 'Occurred at (ISO date)')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateActivityInput = { type: opts.type }
+      if (opts.subject) input.subject = opts.subject
+      if (opts.description) input.description = opts.description
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.companyId) input.company_id = opts.companyId
+      if (opts.dealId) input.deal_id = opts.dealId
+      if (opts.userId) input.user_id = opts.userId
+      if (opts.occurredAt) input.occurred_at = opts.occurredAt
+
+      if (flags.json) {
+        const result = await client.activities.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.activities.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  activities
+    .command('update <id>')
+    .description('Update an activity')
+    .option('--type <type>', 'Activity type')
+    .option('--subject <subject>', 'Activity subject')
+    .option('--description <description>', 'Activity description')
+    .option('--contact-id <id>', 'Contact ID')
+    .option('--company-id <id>', 'Company ID')
+    .option('--deal-id <id>', 'Deal ID')
+    .option('--user-id <id>', 'User ID')
+    .option('--occurred-at <date>', 'Occurred at (ISO date)')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateActivityInput = {}
+      if (opts.type) input.type = opts.type
+      if (opts.subject) input.subject = opts.subject
+      if (opts.description) input.description = opts.description
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.companyId) input.company_id = opts.companyId
+      if (opts.dealId) input.deal_id = opts.dealId
+      if (opts.userId) input.user_id = opts.userId
+      if (opts.occurredAt) input.occurred_at = opts.occurredAt
+
+      if (flags.json) {
+        const result = await client.activities.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.activities.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  activities
+    .command('delete <id>')
+    .description('Delete an activity')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.activities.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.activities.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/companies.ts
+++ b/packages/cli/src/commands/companies.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateCompanyInput, UpdateCompanyInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerCompaniesCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.companies.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerCompaniesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.companies.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -63,7 +64,7 @@ export function registerCompaniesCommand(program: Command): void {
       if (opts.size) input.size = opts.size
       if (opts.website) input.website = opts.website
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.companies.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -91,7 +92,7 @@ export function registerCompaniesCommand(program: Command): void {
       if (opts.size) input.size = opts.size
       if (opts.website) input.website = opts.website
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.companies.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -107,7 +108,7 @@ export function registerCompaniesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.companies.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/companies.ts
+++ b/packages/cli/src/commands/companies.ts
@@ -1,0 +1,118 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateCompanyInput, UpdateCompanyInput } from '@orbit-ai/sdk'
+
+export function registerCompaniesCommand(program: Command): void {
+  const companies = program.command('companies').description('Manage companies')
+
+  companies
+    .command('list')
+    .description('List companies')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.companies.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.companies.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  companies
+    .command('get <id>')
+    .description('Get a company by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.companies.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.companies.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  companies
+    .command('create')
+    .description('Create a new company')
+    .requiredOption('--name <name>', 'Company name')
+    .option('--domain <domain>', 'Company domain')
+    .option('--industry <industry>', 'Industry')
+    .option('--size <size>', 'Company size')
+    .option('--website <website>', 'Website URL')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateCompanyInput = { name: opts.name }
+      if (opts.domain) input.domain = opts.domain
+      if (opts.industry) input.industry = opts.industry
+      if (opts.size) input.size = opts.size
+      if (opts.website) input.website = opts.website
+
+      if (flags.json) {
+        const result = await client.companies.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.companies.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  companies
+    .command('update <id>')
+    .description('Update a company')
+    .option('--name <name>', 'Company name')
+    .option('--domain <domain>', 'Company domain')
+    .option('--industry <industry>', 'Industry')
+    .option('--size <size>', 'Company size')
+    .option('--website <website>', 'Website URL')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateCompanyInput = {}
+      if (opts.name) input.name = opts.name
+      if (opts.domain) input.domain = opts.domain
+      if (opts.industry) input.industry = opts.industry
+      if (opts.size) input.size = opts.size
+      if (opts.website) input.website = opts.website
+
+      if (flags.json) {
+        const result = await client.companies.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.companies.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  companies
+    .command('delete <id>')
+    .description('Delete a company')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.companies.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.companies.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/contacts.ts
+++ b/packages/cli/src/commands/contacts.ts
@@ -1,0 +1,145 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import { CliValidationError, CliNotImplementedError } from '../errors.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateContactInput, UpdateContactInput } from '@orbit-ai/sdk'
+
+export function registerContactsCommand(program: Command): void {
+  const contacts = program.command('contacts').description('Manage contacts')
+
+  contacts
+    .command('list')
+    .description('List contacts')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.contacts.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contacts.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  contacts
+    .command('get <id>')
+    .description('Get a contact by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.contacts.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contacts.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  contacts
+    .command('create')
+    .description('Create a new contact')
+    .requiredOption('--name <name>', 'Contact name')
+    .option('--email <email>', 'Contact email')
+    .option('--phone <phone>', 'Contact phone')
+    .option('--title <title>', 'Contact title')
+    .option('--source-channel <channel>', 'Source channel')
+    .option('--status <status>', 'Contact status')
+    .option('--company-id <id>', 'Company ID')
+    .option('--assigned-to <userId>', 'Assigned to user ID')
+    .option('--lead-score <n>', 'Lead score')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateContactInput = { name: opts.name }
+      if (opts.email) input.email = opts.email
+      if (opts.phone) input.phone = opts.phone
+      if (opts.title) input.title = opts.title
+      if (opts.sourceChannel) input.source_channel = opts.sourceChannel
+      if (opts.status) input.status = opts.status
+      if (opts.companyId) input.company_id = opts.companyId
+      if (opts.assignedTo) input.assigned_to_user_id = opts.assignedTo
+      if (opts.leadScore !== undefined) input.lead_score = Number(opts.leadScore)
+
+      if (flags.json) {
+        const result = await client.contacts.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contacts.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  contacts
+    .command('update <id>')
+    .description('Update a contact')
+    .option('--name <name>', 'Contact name')
+    .option('--email <email>', 'Contact email')
+    .option('--phone <phone>', 'Contact phone')
+    .option('--title <title>', 'Contact title')
+    .option('--source-channel <channel>', 'Source channel')
+    .option('--status <status>', 'Contact status')
+    .option('--company-id <id>', 'Company ID')
+    .option('--assigned-to <userId>', 'Assigned to user ID')
+    .option('--lead-score <n>', 'Lead score')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateContactInput = {}
+      if (opts.name) input.name = opts.name
+      if (opts.email) input.email = opts.email
+      if (opts.phone) input.phone = opts.phone
+      if (opts.title) input.title = opts.title
+      if (opts.sourceChannel) input.source_channel = opts.sourceChannel
+      if (opts.status) input.status = opts.status
+      if (opts.companyId) input.company_id = opts.companyId
+      if (opts.assignedTo) input.assigned_to_user_id = opts.assignedTo
+      if (opts.leadScore !== undefined) input.lead_score = Number(opts.leadScore)
+
+      if (flags.json) {
+        const result = await client.contacts.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contacts.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  contacts
+    .command('delete <id>')
+    .description('Delete a contact')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.contacts.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contacts.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  contacts
+    .command('import <file>')
+    .description('Import contacts from CSV (requires file-upload seam in SDK)')
+    .action(() => {
+      throw new CliNotImplementedError(
+        'orbit contacts import requires a file-upload seam that is not yet available in @orbit-ai/sdk.',
+        { code: 'DEPENDENCY_NOT_AVAILABLE', dependency: 'sdk.imports.upload' },
+      )
+    })
+}

--- a/packages/cli/src/commands/contacts.ts
+++ b/packages/cli/src/commands/contacts.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
 import { CliNotImplementedError } from '../errors.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateContactInput, UpdateContactInput } from '@orbit-ai/sdk'
 
@@ -21,7 +22,7 @@ export function registerContactsCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contacts.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -37,7 +38,7 @@ export function registerContactsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contacts.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -72,7 +73,7 @@ export function registerContactsCommand(program: Command): void {
       if (opts.assignedTo) input.assigned_to_user_id = opts.assignedTo
       if (opts.leadScore !== undefined) input.lead_score = Number(opts.leadScore)
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contacts.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -108,7 +109,7 @@ export function registerContactsCommand(program: Command): void {
       if (opts.assignedTo) input.assigned_to_user_id = opts.assignedTo
       if (opts.leadScore !== undefined) input.lead_score = Number(opts.leadScore)
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contacts.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -124,7 +125,7 @@ export function registerContactsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contacts.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/contacts.ts
+++ b/packages/cli/src/commands/contacts.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
-import { CliValidationError, CliNotImplementedError } from '../errors.js'
+import { CliNotImplementedError } from '../errors.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateContactInput, UpdateContactInput } from '@orbit-ai/sdk'
 

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -1,0 +1,31 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import { CliValidationError } from '../errors.js'
+import type { GlobalFlags } from '../types.js'
+
+export function registerContextCommand(program: Command): void {
+  program
+    .command('context <idOrEmail>')
+    .description('Show full CRM context for a contact (by ID or email)')
+    .action(async (idOrEmail) => {
+      const flags = program.opts() as GlobalFlags
+
+      if (!idOrEmail || idOrEmail.trim() === '') {
+        throw new CliValidationError(
+          'A contact ID or email address is required.',
+          { code: 'MISSING_REQUIRED_ARG', path: 'idOrEmail' },
+        )
+      }
+
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.contacts.response().context(idOrEmail)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contacts.context(idOrEmail)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
 import { CliValidationError } from '../errors.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 
 export function registerContextCommand(program: Command): void {
@@ -20,7 +21,7 @@ export function registerContextCommand(program: Command): void {
 
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contacts.response().context(idOrEmail)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/contracts.ts
+++ b/packages/cli/src/commands/contracts.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateContractInput, UpdateContractInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerContractsCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contracts.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerContractsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contracts.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -71,7 +72,7 @@ export function registerContractsCommand(program: Command): void {
       if (opts.contactId) input.contact_id = opts.contactId
       if (opts.companyId) input.company_id = opts.companyId
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contracts.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -107,7 +108,7 @@ export function registerContractsCommand(program: Command): void {
       if (opts.contactId) input.contact_id = opts.contactId
       if (opts.companyId) input.company_id = opts.companyId
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contracts.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -123,7 +124,7 @@ export function registerContractsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.contracts.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/contracts.ts
+++ b/packages/cli/src/commands/contracts.ts
@@ -1,0 +1,134 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateContractInput, UpdateContractInput } from '@orbit-ai/sdk'
+
+export function registerContractsCommand(program: Command): void {
+  const contracts = program.command('contracts').description('Manage contracts')
+
+  contracts
+    .command('list')
+    .description('List contracts')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.contracts.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contracts.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  contracts
+    .command('get <id>')
+    .description('Get a contract by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.contracts.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contracts.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  contracts
+    .command('create')
+    .description('Create a new contract')
+    .requiredOption('--title <title>', 'Contract title')
+    .option('--status <status>', 'Contract status')
+    .option('--value <value>', 'Contract value (number)')
+    .option('--currency <currency>', 'Currency code (e.g. USD, EUR)')
+    .option('--start-date <date>', 'Start date (ISO date)')
+    .option('--end-date <date>', 'End date (ISO date)')
+    .option('--deal-id <id>', 'Deal ID')
+    .option('--contact-id <id>', 'Contact ID')
+    .option('--company-id <id>', 'Company ID')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateContractInput = { title: opts.title }
+      if (opts.status) input.status = opts.status
+      if (opts.value !== undefined) input.value = Number(opts.value)
+      if (opts.currency) input.currency = opts.currency
+      if (opts.startDate) input.start_date = opts.startDate
+      if (opts.endDate) input.end_date = opts.endDate
+      if (opts.dealId) input.deal_id = opts.dealId
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.companyId) input.company_id = opts.companyId
+
+      if (flags.json) {
+        const result = await client.contracts.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contracts.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  contracts
+    .command('update <id>')
+    .description('Update a contract')
+    .option('--title <title>', 'Contract title')
+    .option('--status <status>', 'Contract status')
+    .option('--value <value>', 'Contract value (number)')
+    .option('--currency <currency>', 'Currency code')
+    .option('--start-date <date>', 'Start date (ISO date)')
+    .option('--end-date <date>', 'End date (ISO date)')
+    .option('--deal-id <id>', 'Deal ID')
+    .option('--contact-id <id>', 'Contact ID')
+    .option('--company-id <id>', 'Company ID')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateContractInput = {}
+      if (opts.title) input.title = opts.title
+      if (opts.status) input.status = opts.status
+      if (opts.value !== undefined) input.value = Number(opts.value)
+      if (opts.currency) input.currency = opts.currency
+      if (opts.startDate) input.start_date = opts.startDate
+      if (opts.endDate) input.end_date = opts.endDate
+      if (opts.dealId) input.deal_id = opts.dealId
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.companyId) input.company_id = opts.companyId
+
+      if (flags.json) {
+        const result = await client.contracts.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contracts.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  contracts
+    .command('delete <id>')
+    .description('Delete a contract')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.contracts.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.contracts.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/dashboard.tsx
+++ b/packages/cli/src/commands/dashboard.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render } from 'ink'
+import { Command } from 'commander'
+import { Dashboard } from '../ink/dashboard.js'
+import { isJsonMode } from '../program.js'
+import type { GlobalFlags } from '../types.js'
+
+export function registerDashboardCommand(program: Command): void {
+  program
+    .command('dashboard')
+    .description('Interactive CRM dashboard')
+    .action(() => {
+      // Guard: non-interactive or JSON mode — must be checked synchronously
+      if (isJsonMode() || !process.stdout.isTTY) {
+        if (isJsonMode()) {
+          process.stdout.write(
+            JSON.stringify({
+              error: {
+                code: 'INTERACTIVE_REQUIRED',
+                message: 'dashboard requires a TTY. Use --json for machine output.',
+              },
+            }) + '\n',
+          )
+        }
+        process.exit(1)
+        return
+      }
+
+      render(<Dashboard />)
+    })
+}

--- a/packages/cli/src/commands/deals.ts
+++ b/packages/cli/src/commands/deals.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateDealInput, UpdateDealInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerDealsCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.deals.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerDealsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.deals.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -73,7 +74,7 @@ export function registerDealsCommand(program: Command): void {
       if (opts.closeDate) input.expected_close_date = opts.closeDate
       if (opts.status) input.status = opts.status
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.deals.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -111,7 +112,7 @@ export function registerDealsCommand(program: Command): void {
       if (opts.closeDate) input.expected_close_date = opts.closeDate
       if (opts.status) input.status = opts.status
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.deals.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -127,7 +128,7 @@ export function registerDealsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.deals.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -144,7 +145,7 @@ export function registerDealsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.deals.response().move(id, { stage_id: opts.stageId })
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/deals.ts
+++ b/packages/cli/src/commands/deals.ts
@@ -1,0 +1,155 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateDealInput, UpdateDealInput } from '@orbit-ai/sdk'
+
+export function registerDealsCommand(program: Command): void {
+  const deals = program.command('deals').description('Manage deals')
+
+  deals
+    .command('list')
+    .description('List deals')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.deals.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.deals.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  deals
+    .command('get <id>')
+    .description('Get a deal by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.deals.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.deals.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  deals
+    .command('create')
+    .description('Create a new deal')
+    .requiredOption('--name <name>', 'Deal name')
+    .option('--value <n>', 'Deal value')
+    .option('--currency <currency>', 'Currency code (e.g. USD, EUR)')
+    .option('--stage-id <id>', 'Pipeline stage ID')
+    .option('--pipeline-id <id>', 'Pipeline ID')
+    .option('--contact-id <id>', 'Associated contact ID')
+    .option('--company-id <id>', 'Associated company ID')
+    .option('--assigned-to <userId>', 'Assigned to user ID')
+    .option('--close-date <date>', 'Expected close date (ISO 8601)')
+    .option('--status <status>', 'Deal status')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateDealInput = { name: opts.name }
+      if (opts.value !== undefined) input.value = Number(opts.value)
+      if (opts.currency) input.currency = opts.currency
+      if (opts.stageId) input.stage_id = opts.stageId
+      if (opts.pipelineId) input.pipeline_id = opts.pipelineId
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.companyId) input.company_id = opts.companyId
+      if (opts.assignedTo) input.assigned_to_user_id = opts.assignedTo
+      if (opts.closeDate) input.expected_close_date = opts.closeDate
+      if (opts.status) input.status = opts.status
+
+      if (flags.json) {
+        const result = await client.deals.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.deals.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  deals
+    .command('update <id>')
+    .description('Update a deal')
+    .option('--name <name>', 'Deal name')
+    .option('--value <n>', 'Deal value')
+    .option('--currency <currency>', 'Currency code')
+    .option('--stage-id <id>', 'Pipeline stage ID')
+    .option('--pipeline-id <id>', 'Pipeline ID')
+    .option('--contact-id <id>', 'Associated contact ID')
+    .option('--company-id <id>', 'Associated company ID')
+    .option('--assigned-to <userId>', 'Assigned to user ID')
+    .option('--close-date <date>', 'Expected close date (ISO 8601)')
+    .option('--status <status>', 'Deal status')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateDealInput = {}
+      if (opts.name) input.name = opts.name
+      if (opts.value !== undefined) input.value = Number(opts.value)
+      if (opts.currency) input.currency = opts.currency
+      if (opts.stageId) input.stage_id = opts.stageId
+      if (opts.pipelineId) input.pipeline_id = opts.pipelineId
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.companyId) input.company_id = opts.companyId
+      if (opts.assignedTo) input.assigned_to_user_id = opts.assignedTo
+      if (opts.closeDate) input.expected_close_date = opts.closeDate
+      if (opts.status) input.status = opts.status
+
+      if (flags.json) {
+        const result = await client.deals.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.deals.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  deals
+    .command('delete <id>')
+    .description('Delete a deal')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.deals.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.deals.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  deals
+    .command('move <id>')
+    .description('Move a deal to a different pipeline stage')
+    .requiredOption('--stage-id <id>', 'Target stage ID')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.deals.response().move(id, { stage_id: opts.stageId })
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.deals.move(id, { stage_id: opts.stageId })
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,40 @@
+import { Command } from 'commander'
+import { isJsonMode } from '../program.js'
+
+export function registerDoctorCommand(program: Command): void {
+  program
+    .command('doctor')
+    .description('Run environment diagnostics')
+    .action(async () => {
+      await runDoctor()
+    })
+}
+
+async function runDoctor(): Promise<void> {
+  const checks: Array<{ name: string; pass: boolean; detail?: string }> = []
+
+  // Node.js version
+  const nodeVersion = process.versions.node
+  const majorStr = nodeVersion.split('.')[0]
+  const major = majorStr !== undefined ? Number(majorStr) : 0
+  checks.push({
+    name: 'Node.js version >= 22',
+    pass: major >= 22,
+    detail: `v${nodeVersion}`,
+  })
+
+  // ORBIT_API_KEY env
+  checks.push({
+    name: 'ORBIT_API_KEY set',
+    pass: !!process.env.ORBIT_API_KEY,
+  })
+
+  if (isJsonMode()) {
+    process.stdout.write(JSON.stringify({ checks }) + '\n')
+  } else {
+    for (const check of checks) {
+      const icon = check.pass ? '✓' : '✗'
+      process.stdout.write(`${icon} ${check.name}${check.detail ? ` (${check.detail})` : ''}\n`)
+    }
+  }
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -18,8 +18,8 @@ async function runDoctor(): Promise<void> {
   const majorStr = nodeVersion.split('.')[0]
   const major = majorStr !== undefined ? Number(majorStr) : 0
   checks.push({
-    name: 'Node.js version >= 22',
-    pass: major >= 22,
+    name: 'Node.js version >= 20',
+    pass: major >= 20,
     detail: `v${nodeVersion}`,
   })
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -18,8 +18,8 @@ async function runDoctor(): Promise<void> {
   const majorStr = nodeVersion.split('.')[0]
   const major = majorStr !== undefined ? Number(majorStr) : 0
   checks.push({
-    name: 'Node.js version >= 20',
-    pass: major >= 20,
+    name: 'Node.js version >= 22',
+    pass: major >= 22,
     detail: `v${nodeVersion}`,
   })
 

--- a/packages/cli/src/commands/fields.ts
+++ b/packages/cli/src/commands/fields.ts
@@ -75,8 +75,8 @@ export function registerFieldsCommand(program: Command): void {
         if (isJsonMode() || !isTTY) {
           process.stdout.write(
             JSON.stringify(DESTRUCTIVE_FIELDS_DELETE_ERROR(entity, fieldName)) + '\n',
+            () => { process.exit(1) },
           )
-          process.exit(1)
           return
         }
         // TTY mode: prompt

--- a/packages/cli/src/commands/fields.ts
+++ b/packages/cli/src/commands/fields.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
 import { isJsonMode } from '../program.js'
+import { confirmAction } from '../utils/prompt.js'
 import type { GlobalFlags } from '../types.js'
 
 const DESTRUCTIVE_FIELDS_DELETE_ERROR = (entity: string, fieldName: string) => ({
@@ -100,20 +101,3 @@ export function registerFieldsCommand(program: Command): void {
     })
 }
 
-async function confirmAction(prompt: string): Promise<boolean> {
-  return new Promise((resolve, reject) => {
-    process.stderr.write(prompt)
-    process.stdin.setEncoding('utf8')
-    const onData = (data: Buffer | string) => { cleanup(); resolve(data.toString().trim().toLowerCase() === 'y') }
-    const onEnd = () => { cleanup(); resolve(false) }
-    const onError = (err: Error) => { cleanup(); reject(err) }
-    const cleanup = () => {
-      process.stdin.removeListener('data', onData)
-      process.stdin.removeListener('end', onEnd)
-      process.stdin.removeListener('error', onError)
-    }
-    process.stdin.once('data', onData)
-    process.stdin.once('end', onEnd)
-    process.stdin.once('error', onError)
-  })
-}

--- a/packages/cli/src/commands/fields.ts
+++ b/packages/cli/src/commands/fields.ts
@@ -23,7 +23,7 @@ export function registerFieldsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.schema.response().describeObject(entity)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -51,7 +51,7 @@ export function registerFieldsCommand(program: Command): void {
       if (opts.label) body.label = opts.label
       if (opts.required) body.required = true
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.schema.response().addField(entity, body)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -92,7 +92,7 @@ export function registerFieldsCommand(program: Command): void {
 
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.schema.response().deleteField(entity, fieldName)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/fields.ts
+++ b/packages/cli/src/commands/fields.ts
@@ -73,10 +73,8 @@ export function registerFieldsCommand(program: Command): void {
 
       if (!confirmed) {
         if (isJsonMode() || !isTTY) {
-          process.stdout.write(
-            JSON.stringify(DESTRUCTIVE_FIELDS_DELETE_ERROR(entity, fieldName)) + '\n',
-            () => { process.exit(1) },
-          )
+          process.stdout.write(JSON.stringify(DESTRUCTIVE_FIELDS_DELETE_ERROR(entity, fieldName)) + '\n')
+          process.exit(1)
           return
         }
         // TTY mode: prompt
@@ -103,11 +101,19 @@ export function registerFieldsCommand(program: Command): void {
 }
 
 async function confirmAction(prompt: string): Promise<boolean> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     process.stderr.write(prompt)
     process.stdin.setEncoding('utf8')
-    process.stdin.once('data', (data) => {
-      resolve(data.toString().trim().toLowerCase() === 'y')
-    })
+    const onData = (data: Buffer | string) => { cleanup(); resolve(data.toString().trim().toLowerCase() === 'y') }
+    const onEnd = () => { cleanup(); resolve(false) }
+    const onError = (err: Error) => { cleanup(); reject(err) }
+    const cleanup = () => {
+      process.stdin.removeListener('data', onData)
+      process.stdin.removeListener('end', onEnd)
+      process.stdin.removeListener('error', onError)
+    }
+    process.stdin.once('data', onData)
+    process.stdin.once('end', onEnd)
+    process.stdin.once('error', onError)
   })
 }

--- a/packages/cli/src/commands/fields.ts
+++ b/packages/cli/src/commands/fields.ts
@@ -1,0 +1,113 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
+import type { GlobalFlags } from '../types.js'
+
+const DESTRUCTIVE_FIELDS_DELETE_ERROR = (entity: string, fieldName: string) => ({
+  error: {
+    code: 'DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION',
+    message: 'Use --yes to confirm this destructive action in non-interactive mode.',
+    action: 'fields.delete',
+    target: `${entity}.${fieldName}`,
+  },
+})
+
+export function registerFieldsCommand(program: Command): void {
+  const fields = program.command('fields').description('Manage custom fields')
+
+  fields
+    .command('list <entity>')
+    .description('List custom fields for an entity type')
+    .action(async (entity) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.schema.response().describeObject(entity)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.schema.describeObject(entity)
+        const fieldsData = result.customFields ?? []
+        process.stdout.write(formatOutput({ data: fieldsData }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  fields
+    .command('create <entity>')
+    .description('Add a custom field to an entity type')
+    .requiredOption('--name <name>', 'Field name (snake_case)')
+    .requiredOption('--type <type>', 'Field type (text, number, boolean, date, select)')
+    .option('--label <label>', 'Display label')
+    .option('--required', 'Mark field as required')
+    .action(async (entity, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const body: Record<string, unknown> = {
+        name: opts.name,
+        type: opts.type,
+      }
+      if (opts.label) body.label = opts.label
+      if (opts.required) body.required = true
+
+      if (flags.json) {
+        const result = await client.schema.response().addField(entity, body)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.schema.addField(entity, body)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  fields
+    .command('delete <entity> <field-name>')
+    .description('Delete a custom field from an entity type (destructive — requires --yes)')
+    .option('--yes', 'Confirm destructive deletion')
+    .action(async (entity, fieldName, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const isTTY = process.stdout.isTTY
+
+      // Resolve --yes from either the subcommand opts or the global flags
+      const confirmed = opts.yes === true || flags.yes === true
+
+      if (!confirmed) {
+        if (isJsonMode() || !isTTY) {
+          process.stdout.write(
+            JSON.stringify(DESTRUCTIVE_FIELDS_DELETE_ERROR(entity, fieldName)) + '\n',
+          )
+          process.exit(1)
+          return
+        }
+        // TTY mode: prompt
+        const ok = await confirmAction(
+          `Are you sure you want to delete field '${fieldName}' from '${entity}'? [y/N] `,
+        )
+        if (!ok) {
+          process.stdout.write('Aborted.\n')
+          process.exit(1)
+          return
+        }
+      }
+
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.schema.response().deleteField(entity, fieldName)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.schema.deleteField(entity, fieldName)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}
+
+async function confirmAction(prompt: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    process.stderr.write(prompt)
+    process.stdin.setEncoding('utf8')
+    process.stdin.once('data', (data) => {
+      resolve(data.toString().trim().toLowerCase() === 'y')
+    })
+  })
+}

--- a/packages/cli/src/commands/imports.ts
+++ b/packages/cli/src/commands/imports.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 
 export function registerImportsCommand(program: Command): void {
@@ -19,7 +20,7 @@ export function registerImportsCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.imports.list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -35,7 +36,7 @@ export function registerImportsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.imports.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -60,7 +61,7 @@ export function registerImportsCommand(program: Command): void {
         ...(opts.totalRows !== undefined ? { total_rows: Number(opts.totalRows) } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.imports.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/imports.ts
+++ b/packages/cli/src/commands/imports.ts
@@ -1,0 +1,71 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+
+export function registerImportsCommand(program: Command): void {
+  const imports = program.command('imports').description('Manage data imports (metadata only — no file upload)')
+
+  imports
+    .command('list')
+    .description('List imports')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.imports.list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.imports.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  imports
+    .command('get <id>')
+    .description('Get an import by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.imports.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.imports.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  imports
+    .command('create')
+    .description('Create an import record (metadata only — no file upload)')
+    .requiredOption('--entity-type <type>', 'Entity type to import (e.g. contacts, companies)')
+    .option('--status <status>', 'Import status')
+    .option('--total-rows <n>', 'Expected total rows')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input = {
+        entity_type: opts.entityType,
+        ...(opts.status ? { status: opts.status } : {}),
+        ...(opts.totalRows !== undefined ? { total_rows: Number(opts.totalRows) } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.imports.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.imports.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,112 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { Command } from 'commander'
+import { CliValidationError } from '../errors.js'
+import { isJsonMode } from '../program.js'
+
+export function registerInitCommand(program: Command): void {
+  program
+    .command('init')
+    .description('Scaffold .orbit/config.json and .env.example')
+    .option('--db <type>', 'Database type: sqlite|postgres', 'sqlite')
+    .option('--org-name <name>', 'Organization name')
+    .option('--yes', 'Skip confirmation prompts (non-interactive)')
+    .option('--overwrite', 'Overwrite existing files')
+    .option('--env-file <path>', 'Write .env file (only .env.example is allowed)')
+    .action(async (opts) => {
+      await runInit({ ...opts, cwd: process.cwd() })
+    })
+}
+
+interface InitOptions {
+  db?: string
+  orgName?: string
+  yes?: boolean
+  overwrite?: boolean
+  envFile?: string
+  cwd: string
+}
+
+export async function runInit(opts: InitOptions): Promise<void> {
+  const { db = 'sqlite', orgName, yes, overwrite, envFile, cwd } = opts
+
+  // Security: never write to .env
+  if (envFile) {
+    const normalized = path.basename(envFile)
+    if (normalized === '.env') {
+      throw new CliValidationError(
+        'orbit init cannot write to .env. Only .env.example is allowed.',
+        { code: 'FORBIDDEN_ENV_FILE', target: envFile },
+      )
+    }
+  }
+
+  // Non-interactive mode requires --yes
+  if (!yes && !process.stdout.isTTY) {
+    throw new CliValidationError(
+      'orbit init requires --yes in non-interactive mode.',
+      { code: 'REQUIRES_CONFIRMATION' },
+    )
+  }
+
+  // Validate org name
+  if (orgName !== undefined) {
+    if (orgName.length > 100 || !/^[\x20-\x7E]*$/.test(orgName)) {
+      throw new CliValidationError(
+        'org-name must contain only printable ASCII characters and be 100 characters or fewer.',
+        { code: 'INVALID_ORG_NAME' },
+      )
+    }
+  }
+
+  const orbitDir = path.join(cwd, '.orbit')
+  const configPath = path.join(orbitDir, 'config.json')
+  const envExamplePath = path.join(cwd, '.env.example')
+  const gitignorePath = path.join(cwd, '.gitignore')
+
+  // Create .orbit directory
+  if (!fs.existsSync(orbitDir)) {
+    fs.mkdirSync(orbitDir, { recursive: true })
+  }
+
+  // Write config.json
+  if (fs.existsSync(configPath) && !overwrite) {
+    if (!isJsonMode()) {
+      process.stderr.write(`Skipping existing ${configPath} (use --overwrite to replace)\n`)
+    }
+  } else {
+    const config = {
+      mode: db === 'sqlite' ? 'direct' : 'api',
+      adapter: db,
+      apiKeyEnv: 'ORBIT_API_KEY', // never the literal key
+      ...(orgName ? { orgName } : {}),
+    }
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 })
+  }
+
+  // Write .env.example
+  if (fs.existsSync(envExamplePath) && !overwrite) {
+    if (!isJsonMode()) {
+      process.stderr.write(`Skipping existing ${envExamplePath} (use --overwrite to replace)\n`)
+    }
+  } else {
+    const envExample = `# Orbit AI — environment variables\nORBIT_API_KEY=your-key-here\n# DATABASE_URL=postgresql://user:pass@host/db\n`
+    fs.writeFileSync(envExamplePath, envExample)
+  }
+
+  // Update .gitignore
+  if (fs.existsSync(gitignorePath)) {
+    const content = fs.readFileSync(gitignorePath, 'utf8')
+    if (!content.includes('.orbit/')) {
+      fs.appendFileSync(gitignorePath, '\n.orbit/\n')
+    }
+  } else {
+    process.stderr.write(`Warning: .gitignore not found. Add '.orbit/' to your .gitignore manually.\n`)
+  }
+
+  if (isJsonMode()) {
+    process.stdout.write(JSON.stringify({ success: true, configPath, envExamplePath }) + '\n')
+  } else {
+    process.stdout.write(`Initialized Orbit at ${configPath}\n`)
+  }
+}

--- a/packages/cli/src/commands/integrations.ts
+++ b/packages/cli/src/commands/integrations.ts
@@ -1,0 +1,15 @@
+import { Command } from 'commander'
+import { CliNotImplementedError } from '../errors.js'
+
+export function registerIntegrationsCommand(program: Command): void {
+  program
+    .command('integrations')
+    .description('Integration commands (coming soon)')
+    .allowUnknownOption(true)
+    .action(() => {
+      throw new CliNotImplementedError(
+        'orbit integrations requires @orbit-ai/integrations which is not yet available.',
+        { code: 'DEPENDENCY_NOT_AVAILABLE', dependency: '@orbit-ai/integrations' },
+      )
+    })
+}

--- a/packages/cli/src/commands/log.ts
+++ b/packages/cli/src/commands/log.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
 import type { GlobalFlags } from '../types.js'
+import type { CreateActivityInput } from '@orbit-ai/sdk'
 
 export function registerLogCommand(program: Command): void {
   program
@@ -17,7 +18,7 @@ export function registerLogCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      const body: Record<string, unknown> = { type }
+      const body: CreateActivityInput = { type }
       if (opts.contact) body.contact_id = opts.contact
       if (opts.company) body.company_id = opts.company
       if (opts.deal) body.deal_id = opts.deal
@@ -25,7 +26,7 @@ export function registerLogCommand(program: Command): void {
       if (opts.subject) body.subject = opts.subject
       if (opts.occurredAt) body.occurred_at = opts.occurredAt
 
-      const result = await client.activities.log(body as unknown as Parameters<typeof client.activities.log>[0])
+      const result = await client.activities.log(body)
 
       if (flags.json) {
         process.stdout.write(JSON.stringify({ data: result }, null, 2) + '\n')

--- a/packages/cli/src/commands/log.ts
+++ b/packages/cli/src/commands/log.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateActivityInput } from '@orbit-ai/sdk'
 
@@ -26,7 +27,7 @@ export function registerLogCommand(program: Command): void {
       if (opts.subject) body.subject = opts.subject
       if (opts.occurredAt) body.occurred_at = opts.occurredAt
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.activities.response().log(body)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/log.ts
+++ b/packages/cli/src/commands/log.ts
@@ -26,11 +26,11 @@ export function registerLogCommand(program: Command): void {
       if (opts.subject) body.subject = opts.subject
       if (opts.occurredAt) body.occurred_at = opts.occurredAt
 
-      const result = await client.activities.log(body)
-
       if (flags.json) {
-        process.stdout.write(JSON.stringify({ data: result }, null, 2) + '\n')
+        const result = await client.activities.response().log(body)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
+        const result = await client.activities.log(body)
         process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
       }
     })

--- a/packages/cli/src/commands/log.ts
+++ b/packages/cli/src/commands/log.ts
@@ -1,0 +1,36 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+
+export function registerLogCommand(program: Command): void {
+  program
+    .command('log <type>')
+    .description('Log an activity (call, email, meeting, note, task)')
+    .option('--contact <id>', 'Contact ID')
+    .option('--company <id>', 'Company ID')
+    .option('--deal <id>', 'Deal ID')
+    .option('--note <text>', 'Note text / description')
+    .option('--subject <subject>', 'Activity subject')
+    .option('--occurred-at <date>', 'Occurred at (ISO date)')
+    .action(async (type, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const body: Record<string, unknown> = { type }
+      if (opts.contact) body.contact_id = opts.contact
+      if (opts.company) body.company_id = opts.company
+      if (opts.deal) body.deal_id = opts.deal
+      if (opts.note) body.description = opts.note
+      if (opts.subject) body.subject = opts.subject
+      if (opts.occurredAt) body.occurred_at = opts.occurredAt
+
+      const result = await client.activities.log(body as unknown as Parameters<typeof client.activities.log>[0])
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify({ data: result }, null, 2) + '\n')
+      } else {
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander'
+import { CliNotImplementedError } from '../errors.js'
+
+export function registerMcpCommand(program: Command): void {
+  const mcp = program.command('mcp').description('Orbit MCP server commands')
+
+  mcp
+    .command('serve')
+    .description('Start the Orbit MCP server (requires @orbit-ai/mcp)')
+    .option('--host <host>', 'Bind host (default: 127.0.0.1; use 0.0.0.0 with caution)')
+    .option('--port <port>', 'Listen port', '3001')
+    .action((opts) => {
+      // Security: warn if binding to 0.0.0.0
+      if (opts.host && opts.host !== '127.0.0.1') {
+        process.stderr.write(
+          `Warning: binding MCP server to ${opts.host} exposes it to external connections.\n`,
+        )
+      }
+      throw new CliNotImplementedError(
+        'orbit mcp serve requires @orbit-ai/mcp which is not yet available.',
+        { code: 'DEPENDENCY_NOT_AVAILABLE', dependency: '@orbit-ai/mcp' },
+      )
+    })
+}

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -38,8 +38,9 @@ async function runMigrate(
 
   if (isDestructive && !confirmed) {
     if (isJsonMode() || !isTTY) {
-      process.stdout.write(JSON.stringify(DESTRUCTIVE_ERROR) + '\n')
-      process.exit(1)
+      process.stdout.write(JSON.stringify(DESTRUCTIVE_ERROR) + '\n', () => {
+        process.exit(1)
+      })
       return
     }
     // TTY mode: prompt (basic readline prompt)
@@ -68,7 +69,7 @@ async function runMigrate(
     if (isJsonMode()) {
       process.stdout.write(JSON.stringify(result, null, 2) + '\n')
     } else {
-      process.stdout.write('Migration applied successfully.\n')
+      process.stdout.write(`Migration applied:\n${JSON.stringify(result, null, 2)}\n`)
     }
     return
   }
@@ -84,7 +85,7 @@ async function runMigrate(
     if (isJsonMode()) {
       process.stdout.write(JSON.stringify(result, null, 2) + '\n')
     } else {
-      process.stdout.write(`Migration ${opts.id} rolled back successfully.\n`)
+      process.stdout.write(`Migration ${opts.id} rolled back:\n${JSON.stringify(result, null, 2)}\n`)
     }
     return
   }

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -31,21 +31,20 @@ async function runMigrate(
   flags: GlobalFlags,
   opts: { preview?: boolean; apply?: boolean; rollback?: boolean; id?: string; yes?: boolean },
 ): Promise<void> {
-  const isDestructive = opts.rollback || opts.apply
+  // Only --rollback is always destructive (no preview step)
+  const isDefinitelyDestructive = opts.rollback
   const isTTY = process.stdout.isTTY
-  // --yes may be consumed by the global flag parser (parent opts) or the subcommand opts
   const confirmed = opts.yes === true || flags.yes === true
 
-  if (isDestructive && !confirmed) {
+  if (isDefinitelyDestructive && !confirmed) {
     if (isJsonMode() || !isTTY) {
       process.stdout.write(JSON.stringify(DESTRUCTIVE_ERROR) + '\n', () => {
         process.exit(1)
       })
       return
     }
-    // TTY mode: prompt (basic readline prompt)
-    const confirmed = await confirmAction('Are you sure you want to run this migration? [y/N] ')
-    if (!confirmed) {
+    const ok = await confirmAction('Are you sure you want to run this migration? [y/N] ')
+    if (!ok) {
       process.stdout.write('Aborted.\n')
       process.exit(1)
       return
@@ -65,6 +64,36 @@ async function runMigrate(
   }
 
   if (opts.apply) {
+    // Preview first to detect destructive operations
+    const preview = await client.schema.previewMigration({})
+    const previewStr = JSON.stringify(preview).toLowerCase()
+    const hasDestructive =
+      (typeof (preview as { destructive?: boolean }).destructive === 'boolean'
+        ? (preview as { destructive?: boolean }).destructive
+        : false) ||
+      /\b(drop|rename)\b/.test(previewStr)
+
+    if (hasDestructive && !confirmed) {
+      if (isJsonMode() || !isTTY) {
+        process.stdout.write(
+          JSON.stringify({
+            ...DESTRUCTIVE_ERROR,
+            error: { ...DESTRUCTIVE_ERROR.error, preview },
+          }) + '\n',
+          () => { process.exit(1) },
+        )
+        return
+      }
+      const ok = await confirmAction(
+        'This migration contains destructive operations. Confirm? [y/N] ',
+      )
+      if (!ok) {
+        process.stdout.write('Aborted.\n')
+        process.exit(1)
+        return
+      }
+    }
+
     const result = await client.schema.applyMigration({})
     if (isJsonMode()) {
       process.stdout.write(JSON.stringify(result, null, 2) + '\n')

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -66,12 +66,12 @@ async function runMigrate(
   if (opts.apply) {
     // Preview first to detect destructive operations
     const preview = await client.schema.previewMigration({})
-    const previewStr = JSON.stringify(preview).toLowerCase()
+    // Rely only on the explicit destructive flag — regex matching on serialised JSON
+    // causes false positives for field names or descriptions containing "drop"/"rename"
     const hasDestructive =
-      (typeof (preview as { destructive?: boolean }).destructive === 'boolean'
+      typeof (preview as { destructive?: boolean }).destructive === 'boolean'
         ? (preview as { destructive?: boolean }).destructive
-        : false) ||
-      /\b(drop|rename)\b/.test(previewStr)
+        : false
 
     if (hasDestructive && !confirmed) {
       if (isJsonMode() || !isTTY) {

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -123,11 +123,19 @@ async function runMigrate(
 }
 
 async function confirmAction(prompt: string): Promise<boolean> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     process.stderr.write(prompt)
     process.stdin.setEncoding('utf8')
-    process.stdin.once('data', (data) => {
-      resolve(data.toString().trim().toLowerCase() === 'y')
-    })
+    const onData = (data: Buffer | string) => { cleanup(); resolve(data.toString().trim().toLowerCase() === 'y') }
+    const onEnd = () => { cleanup(); resolve(false) }
+    const onError = (err: Error) => { cleanup(); reject(err) }
+    const cleanup = () => {
+      process.stdin.removeListener('data', onData)
+      process.stdin.removeListener('end', onEnd)
+      process.stdin.removeListener('error', onError)
+    }
+    process.stdin.once('data', onData)
+    process.stdin.once('end', onEnd)
+    process.stdin.once('error', onError)
   })
 }

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -33,8 +33,10 @@ async function runMigrate(
 ): Promise<void> {
   const isDestructive = opts.rollback || opts.apply
   const isTTY = process.stdout.isTTY
+  // --yes may be consumed by the global flag parser (parent opts) or the subcommand opts
+  const confirmed = opts.yes === true || flags.yes === true
 
-  if (isDestructive && !opts.yes) {
+  if (isDestructive && !confirmed) {
     if (isJsonMode() || !isTTY) {
       process.stdout.write(JSON.stringify(DESTRUCTIVE_ERROR) + '\n')
       process.exit(1)

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
+import { CliValidationError } from '../errors.js'
 import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 
@@ -17,7 +18,8 @@ export function registerMigrateCommand(program: Command): void {
     .description('Run schema migrations')
     .option('--preview', 'Preview pending migrations')
     .option('--apply', 'Apply pending migrations')
-    .option('--rollback', 'Roll back the last migration (destructive)')
+    .option('--rollback', 'Roll back the migration specified by --id (destructive)')
+    .option('--id <id>', 'Migration ID required for --rollback')
     .option('--yes', 'Confirm destructive operation')
     .action(async (opts) => {
       const flags = program.opts() as GlobalFlags
@@ -27,7 +29,7 @@ export function registerMigrateCommand(program: Command): void {
 
 async function runMigrate(
   flags: GlobalFlags,
-  opts: { preview?: boolean; apply?: boolean; rollback?: boolean; yes?: boolean },
+  opts: { preview?: boolean; apply?: boolean; rollback?: boolean; id?: string; yes?: boolean },
 ): Promise<void> {
   const isDestructive = opts.rollback || opts.apply
   const isTTY = process.stdout.isTTY
@@ -59,16 +61,36 @@ async function runMigrate(
     return
   }
 
-  if (isJsonMode()) {
-    process.stdout.write(JSON.stringify({ success: true, action: opts.rollback ? 'rollback' : 'apply' }) + '\n')
-  } else {
-    process.stdout.write(`Migration ${opts.rollback ? 'rolled back' : 'applied'} successfully.\n`)
+  if (opts.apply) {
+    const result = await client.schema.applyMigration({})
+    if (isJsonMode()) {
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+    } else {
+      process.stdout.write('Migration applied successfully.\n')
+    }
+    return
+  }
+
+  if (opts.rollback) {
+    if (!opts.id) {
+      throw new CliValidationError('--rollback requires --id <migration-id>', {
+        code: 'MISSING_REQUIRED_ARG',
+        path: 'id',
+      })
+    }
+    const result = await client.schema.rollbackMigration(opts.id)
+    if (isJsonMode()) {
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+    } else {
+      process.stdout.write(`Migration ${opts.id} rolled back successfully.\n`)
+    }
+    return
   }
 }
 
 async function confirmAction(prompt: string): Promise<boolean> {
   return new Promise((resolve) => {
-    process.stdout.write(prompt)
+    process.stderr.write(prompt)
     process.stdin.setEncoding('utf8')
     process.stdin.once('data', (data) => {
       resolve(data.toString().trim().toLowerCase() === 'y')

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,0 +1,77 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { isJsonMode } from '../program.js'
+import type { GlobalFlags } from '../types.js'
+
+const DESTRUCTIVE_ERROR = {
+  error: {
+    code: 'DESTRUCTIVE_ACTION_REQUIRES_CONFIRMATION',
+    message: 'Use --yes to confirm this destructive action in non-interactive mode.',
+    action: 'migrate',
+  },
+}
+
+export function registerMigrateCommand(program: Command): void {
+  program
+    .command('migrate')
+    .description('Run schema migrations')
+    .option('--preview', 'Preview pending migrations')
+    .option('--apply', 'Apply pending migrations')
+    .option('--rollback', 'Roll back the last migration (destructive)')
+    .option('--yes', 'Confirm destructive operation')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      await runMigrate(flags, opts)
+    })
+}
+
+async function runMigrate(
+  flags: GlobalFlags,
+  opts: { preview?: boolean; apply?: boolean; rollback?: boolean; yes?: boolean },
+): Promise<void> {
+  const isDestructive = opts.rollback || opts.apply
+  const isTTY = process.stdout.isTTY
+
+  if (isDestructive && !opts.yes) {
+    if (isJsonMode() || !isTTY) {
+      process.stdout.write(JSON.stringify(DESTRUCTIVE_ERROR) + '\n')
+      process.exit(1)
+      return
+    }
+    // TTY mode: prompt (basic readline prompt)
+    const confirmed = await confirmAction('Are you sure you want to run this migration? [y/N] ')
+    if (!confirmed) {
+      process.stdout.write('Aborted.\n')
+      process.exit(1)
+      return
+    }
+  }
+
+  const client = resolveClient({ flags })
+
+  if (opts.preview) {
+    const preview = await client.schema.previewMigration({})
+    if (isJsonMode()) {
+      process.stdout.write(JSON.stringify(preview, null, 2) + '\n')
+    } else {
+      process.stdout.write(JSON.stringify(preview, null, 2) + '\n')
+    }
+    return
+  }
+
+  if (isJsonMode()) {
+    process.stdout.write(JSON.stringify({ success: true, action: opts.rollback ? 'rollback' : 'apply' }) + '\n')
+  } else {
+    process.stdout.write(`Migration ${opts.rollback ? 'rolled back' : 'applied'} successfully.\n`)
+  }
+}
+
+async function confirmAction(prompt: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    process.stdout.write(prompt)
+    process.stdin.setEncoding('utf8')
+    process.stdin.once('data', (data) => {
+      resolve(data.toString().trim().toLowerCase() === 'y')
+    })
+  })
+}

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { CliValidationError } from '../errors.js'
 import { isJsonMode } from '../program.js'
+import { confirmAction } from '../utils/prompt.js'
 import type { GlobalFlags } from '../types.js'
 
 const DESTRUCTIVE_ERROR = {
@@ -122,20 +123,3 @@ async function runMigrate(
   }
 }
 
-async function confirmAction(prompt: string): Promise<boolean> {
-  return new Promise((resolve, reject) => {
-    process.stderr.write(prompt)
-    process.stdin.setEncoding('utf8')
-    const onData = (data: Buffer | string) => { cleanup(); resolve(data.toString().trim().toLowerCase() === 'y') }
-    const onEnd = () => { cleanup(); resolve(false) }
-    const onError = (err: Error) => { cleanup(); reject(err) }
-    const cleanup = () => {
-      process.stdin.removeListener('data', onData)
-      process.stdin.removeListener('end', onEnd)
-      process.stdin.removeListener('error', onError)
-    }
-    process.stdin.once('data', onData)
-    process.stdin.once('end', onEnd)
-    process.stdin.once('error', onError)
-  })
-}

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -31,6 +31,13 @@ async function runMigrate(
   flags: GlobalFlags,
   opts: { preview?: boolean; apply?: boolean; rollback?: boolean; id?: string; yes?: boolean },
 ): Promise<void> {
+  if (!opts.preview && !opts.apply && !opts.rollback) {
+    throw new CliValidationError(
+      'orbit migrate requires --preview, --apply, or --rollback.',
+      { code: 'MISSING_REQUIRED_ARG', path: 'subcommand' },
+    )
+  }
+
   // Only --rollback is always destructive (no preview step)
   const isDefinitelyDestructive = opts.rollback
   const isTTY = process.stdout.isTTY
@@ -38,9 +45,8 @@ async function runMigrate(
 
   if (isDefinitelyDestructive && !confirmed) {
     if (isJsonMode() || !isTTY) {
-      process.stdout.write(JSON.stringify(DESTRUCTIVE_ERROR) + '\n', () => {
-        process.exit(1)
-      })
+      process.stdout.write(JSON.stringify(DESTRUCTIVE_ERROR) + '\n')
+      process.exit(1)
       return
     }
     const ok = await confirmAction('Are you sure you want to run this migration? [y/N] ')
@@ -55,11 +61,7 @@ async function runMigrate(
 
   if (opts.preview) {
     const preview = await client.schema.previewMigration({})
-    if (isJsonMode()) {
-      process.stdout.write(JSON.stringify(preview, null, 2) + '\n')
-    } else {
-      process.stdout.write(JSON.stringify(preview, null, 2) + '\n')
-    }
+    process.stdout.write(JSON.stringify(preview, null, 2) + '\n')
     return
   }
 
@@ -80,8 +82,8 @@ async function runMigrate(
             ...DESTRUCTIVE_ERROR,
             error: { ...DESTRUCTIVE_ERROR.error, preview },
           }) + '\n',
-          () => { process.exit(1) },
         )
+        process.exit(1)
         return
       }
       const ok = await confirmAction(

--- a/packages/cli/src/commands/notes.ts
+++ b/packages/cli/src/commands/notes.ts
@@ -1,0 +1,118 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateNoteInput, UpdateNoteInput } from '@orbit-ai/sdk'
+
+export function registerNotesCommand(program: Command): void {
+  const notes = program.command('notes').description('Manage notes')
+
+  notes
+    .command('list')
+    .description('List notes')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.notes.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.notes.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  notes
+    .command('get <id>')
+    .description('Get a note by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.notes.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.notes.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  notes
+    .command('create')
+    .description('Create a new note')
+    .requiredOption('--body <body>', 'Note body text')
+    .option('--contact-id <id>', 'Contact ID')
+    .option('--company-id <id>', 'Company ID')
+    .option('--deal-id <id>', 'Deal ID')
+    .option('--user-id <id>', 'User ID')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateNoteInput = { body: opts.body }
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.companyId) input.company_id = opts.companyId
+      if (opts.dealId) input.deal_id = opts.dealId
+      if (opts.userId) input.user_id = opts.userId
+
+      if (flags.json) {
+        const result = await client.notes.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.notes.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  notes
+    .command('update <id>')
+    .description('Update a note')
+    .option('--body <body>', 'Note body text')
+    .option('--contact-id <id>', 'Contact ID')
+    .option('--company-id <id>', 'Company ID')
+    .option('--deal-id <id>', 'Deal ID')
+    .option('--user-id <id>', 'User ID')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateNoteInput = {}
+      if (opts.body) input.body = opts.body
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.companyId) input.company_id = opts.companyId
+      if (opts.dealId) input.deal_id = opts.dealId
+      if (opts.userId) input.user_id = opts.userId
+
+      if (flags.json) {
+        const result = await client.notes.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.notes.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  notes
+    .command('delete <id>')
+    .description('Delete a note')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.notes.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.notes.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/notes.ts
+++ b/packages/cli/src/commands/notes.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateNoteInput, UpdateNoteInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerNotesCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.notes.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerNotesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.notes.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -63,7 +64,7 @@ export function registerNotesCommand(program: Command): void {
       if (opts.dealId) input.deal_id = opts.dealId
       if (opts.userId) input.user_id = opts.userId
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.notes.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -91,7 +92,7 @@ export function registerNotesCommand(program: Command): void {
       if (opts.dealId) input.deal_id = opts.dealId
       if (opts.userId) input.user_id = opts.userId
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.notes.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -107,7 +108,7 @@ export function registerNotesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.notes.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/payments.ts
+++ b/packages/cli/src/commands/payments.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreatePaymentInput, UpdatePaymentInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerPaymentsCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.payments.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerPaymentsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.payments.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -69,7 +70,7 @@ export function registerPaymentsCommand(program: Command): void {
       if (opts.paymentMethod) input.payment_method = opts.paymentMethod
       if (opts.paidAt) input.paid_at = opts.paidAt
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.payments.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -101,7 +102,7 @@ export function registerPaymentsCommand(program: Command): void {
       if (opts.paymentMethod) input.payment_method = opts.paymentMethod
       if (opts.paidAt) input.paid_at = opts.paidAt
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.payments.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -117,7 +118,7 @@ export function registerPaymentsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.payments.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/payments.ts
+++ b/packages/cli/src/commands/payments.ts
@@ -1,0 +1,128 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreatePaymentInput, UpdatePaymentInput } from '@orbit-ai/sdk'
+
+export function registerPaymentsCommand(program: Command): void {
+  const payments = program.command('payments').description('Manage payments')
+
+  payments
+    .command('list')
+    .description('List payments')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.payments.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.payments.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  payments
+    .command('get <id>')
+    .description('Get a payment by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.payments.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.payments.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  payments
+    .command('create')
+    .description('Record a new payment')
+    .requiredOption('--amount <amount>', 'Payment amount (number)')
+    .requiredOption('--currency <currency>', 'Currency code (e.g. USD, EUR)')
+    .option('--status <status>', 'Payment status')
+    .option('--deal-id <id>', 'Deal ID')
+    .option('--contact-id <id>', 'Contact ID')
+    .option('--payment-method <method>', 'Payment method')
+    .option('--paid-at <date>', 'Paid at (ISO date)')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreatePaymentInput = {
+        amount: Number(opts.amount),
+        currency: opts.currency,
+      }
+      if (opts.status) input.status = opts.status
+      if (opts.dealId) input.deal_id = opts.dealId
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.paymentMethod) input.payment_method = opts.paymentMethod
+      if (opts.paidAt) input.paid_at = opts.paidAt
+
+      if (flags.json) {
+        const result = await client.payments.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.payments.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  payments
+    .command('update <id>')
+    .description('Update a payment')
+    .option('--amount <amount>', 'Payment amount (number)')
+    .option('--currency <currency>', 'Currency code')
+    .option('--status <status>', 'Payment status')
+    .option('--deal-id <id>', 'Deal ID')
+    .option('--contact-id <id>', 'Contact ID')
+    .option('--payment-method <method>', 'Payment method')
+    .option('--paid-at <date>', 'Paid at (ISO date)')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdatePaymentInput = {}
+      if (opts.amount !== undefined) input.amount = Number(opts.amount)
+      if (opts.currency) input.currency = opts.currency
+      if (opts.status) input.status = opts.status
+      if (opts.dealId) input.deal_id = opts.dealId
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.paymentMethod) input.payment_method = opts.paymentMethod
+      if (opts.paidAt) input.paid_at = opts.paidAt
+
+      if (flags.json) {
+        const result = await client.payments.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.payments.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  payments
+    .command('delete <id>')
+    .description('Delete a payment')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.payments.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.payments.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/pipelines.ts
+++ b/packages/cli/src/commands/pipelines.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreatePipelineInput, UpdatePipelineInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerPipelinesCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.pipelines.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerPipelinesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.pipelines.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -59,7 +60,7 @@ export function registerPipelinesCommand(program: Command): void {
       if (opts.description) input.description = opts.description
       if (opts.default) input.is_default = true
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.pipelines.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -83,7 +84,7 @@ export function registerPipelinesCommand(program: Command): void {
       if (opts.description) input.description = opts.description
       if (opts.default) input.is_default = true
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.pipelines.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -99,7 +100,7 @@ export function registerPipelinesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.pipelines.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/pipelines.ts
+++ b/packages/cli/src/commands/pipelines.ts
@@ -1,0 +1,110 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreatePipelineInput, UpdatePipelineInput } from '@orbit-ai/sdk'
+
+export function registerPipelinesCommand(program: Command): void {
+  const pipelines = program.command('pipelines').description('Manage pipelines')
+
+  pipelines
+    .command('list')
+    .description('List pipelines')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.pipelines.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.pipelines.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  pipelines
+    .command('get <id>')
+    .description('Get a pipeline by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.pipelines.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.pipelines.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  pipelines
+    .command('create')
+    .description('Create a new pipeline')
+    .requiredOption('--name <name>', 'Pipeline name')
+    .option('--description <description>', 'Pipeline description')
+    .option('--default', 'Set as default pipeline')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreatePipelineInput = { name: opts.name }
+      if (opts.description) input.description = opts.description
+      if (opts.default) input.is_default = true
+
+      if (flags.json) {
+        const result = await client.pipelines.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.pipelines.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  pipelines
+    .command('update <id>')
+    .description('Update a pipeline')
+    .option('--name <name>', 'Pipeline name')
+    .option('--description <description>', 'Pipeline description')
+    .option('--default', 'Set as default pipeline')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdatePipelineInput = {}
+      if (opts.name) input.name = opts.name
+      if (opts.description) input.description = opts.description
+      if (opts.default) input.is_default = true
+
+      if (flags.json) {
+        const result = await client.pipelines.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.pipelines.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  pipelines
+    .command('delete <id>')
+    .description('Delete a pipeline')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.pipelines.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.pipelines.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/products.ts
+++ b/packages/cli/src/commands/products.ts
@@ -1,0 +1,122 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateProductInput, UpdateProductInput } from '@orbit-ai/sdk'
+
+export function registerProductsCommand(program: Command): void {
+  const products = program.command('products').description('Manage products')
+
+  products
+    .command('list')
+    .description('List products')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.products.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.products.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  products
+    .command('get <id>')
+    .description('Get a product by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.products.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.products.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  products
+    .command('create')
+    .description('Create a new product')
+    .requiredOption('--name <name>', 'Product name')
+    .option('--description <description>', 'Product description')
+    .option('--price <price>', 'Price (number)')
+    .option('--currency <currency>', 'Currency code (e.g. USD, EUR)')
+    .option('--sku <sku>', 'Product SKU')
+    .option('--status <status>', 'Product status')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateProductInput = { name: opts.name }
+      if (opts.description) input.description = opts.description
+      if (opts.price !== undefined) input.price = Number(opts.price)
+      if (opts.currency) input.currency = opts.currency
+      if (opts.sku) input.sku = opts.sku
+      if (opts.status) input.status = opts.status
+
+      if (flags.json) {
+        const result = await client.products.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.products.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  products
+    .command('update <id>')
+    .description('Update a product')
+    .option('--name <name>', 'Product name')
+    .option('--description <description>', 'Product description')
+    .option('--price <price>', 'Price (number)')
+    .option('--currency <currency>', 'Currency code')
+    .option('--sku <sku>', 'Product SKU')
+    .option('--status <status>', 'Product status')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateProductInput = {}
+      if (opts.name) input.name = opts.name
+      if (opts.description) input.description = opts.description
+      if (opts.price !== undefined) input.price = Number(opts.price)
+      if (opts.currency) input.currency = opts.currency
+      if (opts.sku) input.sku = opts.sku
+      if (opts.status) input.status = opts.status
+
+      if (flags.json) {
+        const result = await client.products.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.products.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  products
+    .command('delete <id>')
+    .description('Delete a product')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.products.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.products.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/products.ts
+++ b/packages/cli/src/commands/products.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateProductInput, UpdateProductInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerProductsCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.products.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerProductsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.products.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -65,7 +66,7 @@ export function registerProductsCommand(program: Command): void {
       if (opts.sku) input.sku = opts.sku
       if (opts.status) input.status = opts.status
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.products.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -95,7 +96,7 @@ export function registerProductsCommand(program: Command): void {
       if (opts.sku) input.sku = opts.sku
       if (opts.status) input.status = opts.status
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.products.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -111,7 +112,7 @@ export function registerProductsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.products.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander'
+import { CliNotImplementedError } from '../errors.js'
+
+export function registerReportCommand(program: Command): void {
+  const report = program.command('report').description('Generate reports')
+
+  report
+    .command('summary')
+    .description('Generate a CRM summary report (coming soon)')
+    .action(() => {
+      throw new CliNotImplementedError(
+        'orbit report summary is not yet implemented. Reporting will be available in a future release.',
+        { code: 'NOT_IMPLEMENTED', feature: 'reporting' },
+      )
+    })
+
+  // Default action when no sub-command is given
+  report.action(() => {
+    throw new CliNotImplementedError(
+      'orbit report is not yet implemented. Reporting will be available in a future release.',
+      { code: 'NOT_IMPLEMENTED', feature: 'reporting' },
+    )
+  })
+}

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 
 export function registerSchemaCommand(program: Command): void {
@@ -13,7 +14,7 @@ export function registerSchemaCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.schema.response().listObjects()
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -29,7 +30,7 @@ export function registerSchemaCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.schema.response().describeObject(entity)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -1,0 +1,40 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+
+export function registerSchemaCommand(program: Command): void {
+  const schema = program.command('schema').description('Inspect CRM schema and object definitions')
+
+  schema
+    .command('list')
+    .description('List all registered object types')
+    .action(async () => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.schema.response().listObjects()
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.schema.listObjects()
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  schema
+    .command('get <entity>')
+    .description('Describe an object type and its custom fields')
+    .action(async (entity) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.schema.response().describeObject(entity)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.schema.describeObject(entity)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,0 +1,42 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import { CliValidationError } from '../errors.js'
+import type { GlobalFlags } from '../types.js'
+import type { SearchInput } from '@orbit-ai/sdk'
+
+export function registerSearchCommand(program: Command): void {
+  program
+    .command('search <query>')
+    .description('Search across CRM entities')
+    .option('--types <types>', 'Comma-separated object types to search (e.g. contacts,deals)')
+    .option('--limit <n>', 'Max results', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (query, opts) => {
+      const flags = program.opts() as GlobalFlags
+
+      if (!query || query.trim() === '') {
+        throw new CliValidationError(
+          'A search query is required.',
+          { code: 'MISSING_REQUIRED_ARG', path: 'query' },
+        )
+      }
+
+      const client = resolveClient({ flags })
+
+      const input: SearchInput = { query }
+      if (opts.types) {
+        input.object_types = opts.types.split(',').map((t: string) => t.trim()).filter(Boolean)
+      }
+      if (opts.limit !== undefined) input.limit = Number(opts.limit)
+      if (opts.cursor) input.cursor = opts.cursor
+
+      if (flags.json) {
+        const result = await client.search.response().query(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.search.query(input)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
 import { CliValidationError } from '../errors.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { SearchInput } from '@orbit-ai/sdk'
 
@@ -31,7 +32,7 @@ export function registerSearchCommand(program: Command): void {
       if (opts.limit !== undefined) input.limit = Number(opts.limit)
       if (opts.cursor) input.cursor = opts.cursor
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.search.response().query(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -18,7 +18,10 @@ async function runSeed(flags: GlobalFlags, count: number): Promise<void> {
   if (flags.mode !== 'direct') {
     const msg = 'orbit seed requires direct mode (--mode direct with a local adapter)'
     if (isJsonMode()) {
-      process.stdout.write(JSON.stringify({ error: { code: 'DIRECT_MODE_REQUIRED', message: msg } }) + '\n')
+      process.stdout.write(JSON.stringify({ error: { code: 'DIRECT_MODE_REQUIRED', message: msg } }) + '\n', () => {
+        process.exit(2)
+      })
+      return
     } else {
       process.stderr.write(msg + '\n')
     }
@@ -28,12 +31,18 @@ async function runSeed(flags: GlobalFlags, count: number): Promise<void> {
   const client = resolveClient({ flags })
   const created: unknown[] = []
 
-  for (let i = 0; i < count; i++) {
-    const contact = await client.contacts.create({
-      name: `Seed${i + 1} Contact`,
-      email: `seed${i + 1}@example.com`,
-    })
-    created.push(contact)
+  try {
+    for (let i = 0; i < count; i++) {
+      const contact = await client.contacts.create({ name: `Seed ${i + 1}`, email: `seed${i + 1}@example.com` })
+      created.push(contact)
+    }
+  } catch (e) {
+    if (isJsonMode()) {
+      process.stdout.write(JSON.stringify({ seeded: created.length, total: count, error: (e as Error).message }) + '\n')
+    } else {
+      process.stderr.write(`Seeded ${created.length}/${count} contacts before error: ${(e as Error).message}\n`)
+    }
+    process.exit(1)
   }
 
   if (isJsonMode()) {

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { loadConfig } from '../config/files.js'
 import { resolveClient } from '../config/resolve-context.js'
+import { CliValidationError } from '../errors.js'
 import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 
@@ -11,7 +12,14 @@ export function registerSeedCommand(program: Command): void {
     .option('--count <n>', 'Number of example records to create', '5')
     .action(async (opts) => {
       const flags = program.opts() as GlobalFlags
-      await runSeed(flags, Number(opts.count), process.cwd())
+      const count = Number(opts.count)
+      if (!Number.isInteger(count) || count < 1 || count > 1000) {
+        throw new CliValidationError(
+          `--count must be a positive integer between 1 and 1000, got: '${opts.count}'`,
+          { code: 'INVALID_ARGUMENT', path: 'count' },
+        )
+      }
+      await runSeed(flags, count, process.cwd())
     })
 }
 
@@ -24,14 +32,12 @@ async function runSeed(flags: GlobalFlags, count: number, cwd?: string): Promise
   if (effectiveMode !== 'direct') {
     const msg = 'orbit seed requires direct mode (--mode direct with a local adapter)'
     if (isJsonMode()) {
-      process.stdout.write(JSON.stringify({ error: { code: 'DIRECT_MODE_REQUIRED', message: msg } }) + '\n', () => {
-        process.exit(2)
-      })
-      return
+      process.stdout.write(JSON.stringify({ error: { code: 'DIRECT_MODE_REQUIRED', message: msg } }) + '\n')
     } else {
       process.stderr.write(msg + '\n')
     }
     process.exit(2)
+    return
   }
 
   const client = resolveClient({ flags })
@@ -43,10 +49,11 @@ async function runSeed(flags: GlobalFlags, count: number, cwd?: string): Promise
       created.push(contact)
     }
   } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
     if (isJsonMode()) {
-      process.stdout.write(JSON.stringify({ seeded: created.length, total: count, error: (e as Error).message }) + '\n')
+      process.stdout.write(JSON.stringify({ seeded: created.length, total: count, error: msg }) + '\n')
     } else {
-      process.stderr.write(`Seeded ${created.length}/${count} contacts before error: ${(e as Error).message}\n`)
+      process.stderr.write(`Seeded ${created.length}/${count} contacts before error: ${msg}\n`)
     }
     process.exit(1)
   }

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -1,0 +1,44 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { isJsonMode } from '../program.js'
+import type { GlobalFlags } from '../types.js'
+
+export function registerSeedCommand(program: Command): void {
+  program
+    .command('seed')
+    .description('Seed the database with example data (direct mode only)')
+    .option('--count <n>', 'Number of example records to create', '5')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      await runSeed(flags, Number(opts.count))
+    })
+}
+
+async function runSeed(flags: GlobalFlags, count: number): Promise<void> {
+  if (flags.mode !== 'direct') {
+    const msg = 'orbit seed requires direct mode (--mode direct with a local adapter)'
+    if (isJsonMode()) {
+      process.stdout.write(JSON.stringify({ error: { code: 'DIRECT_MODE_REQUIRED', message: msg } }) + '\n')
+    } else {
+      process.stderr.write(msg + '\n')
+    }
+    process.exit(2)
+  }
+
+  const client = resolveClient({ flags })
+  const created: unknown[] = []
+
+  for (let i = 0; i < count; i++) {
+    const contact = await client.contacts.create({
+      name: `Seed${i + 1} Contact`,
+      email: `seed${i + 1}@example.com`,
+    })
+    created.push(contact)
+  }
+
+  if (isJsonMode()) {
+    process.stdout.write(JSON.stringify({ seeded: created.length }) + '\n')
+  } else {
+    process.stdout.write(`Seeded ${created.length} contacts.\n`)
+  }
+}

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander'
+import { loadConfig } from '../config/files.js'
 import { resolveClient } from '../config/resolve-context.js'
 import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
@@ -15,7 +16,11 @@ export function registerSeedCommand(program: Command): void {
 }
 
 async function runSeed(flags: GlobalFlags, count: number): Promise<void> {
-  if (flags.mode !== 'direct') {
+  // Resolve effective mode: flag > config file > default 'api'
+  const fileConfig = loadConfig()
+  const effectiveMode = flags.mode ?? fileConfig.mode ?? 'api'
+
+  if (effectiveMode !== 'direct') {
     const msg = 'orbit seed requires direct mode (--mode direct with a local adapter)'
     if (isJsonMode()) {
       process.stdout.write(JSON.stringify({ error: { code: 'DIRECT_MODE_REQUIRED', message: msg } }) + '\n', () => {

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -11,13 +11,14 @@ export function registerSeedCommand(program: Command): void {
     .option('--count <n>', 'Number of example records to create', '5')
     .action(async (opts) => {
       const flags = program.opts() as GlobalFlags
-      await runSeed(flags, Number(opts.count))
+      await runSeed(flags, Number(opts.count), process.cwd())
     })
 }
 
-async function runSeed(flags: GlobalFlags, count: number): Promise<void> {
+async function runSeed(flags: GlobalFlags, count: number, cwd?: string): Promise<void> {
   // Resolve effective mode: flag > config file > default 'api'
-  const fileConfig = loadConfig()
+  // Pass cwd so resolution matches what resolveClient will use (avoids divergence in tests)
+  const fileConfig = loadConfig(cwd)
   const effectiveMode = flags.mode ?? fileConfig.mode ?? 'api'
 
   if (effectiveMode !== 'direct') {

--- a/packages/cli/src/commands/sequences.ts
+++ b/packages/cli/src/commands/sequences.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
 import { CliValidationError } from '../errors.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateSequenceInput, UpdateSequenceInput } from '@orbit-ai/sdk'
 
@@ -21,7 +22,7 @@ export function registerSequencesCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.sequences.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -37,7 +38,7 @@ export function registerSequencesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.sequences.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -62,7 +63,7 @@ export function registerSequencesCommand(program: Command): void {
       if (opts.status) input.status = opts.status
       if (opts.triggerType) input.trigger_type = opts.triggerType
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.sequences.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -88,7 +89,7 @@ export function registerSequencesCommand(program: Command): void {
       if (opts.status) input.status = opts.status
       if (opts.triggerType) input.trigger_type = opts.triggerType
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.sequences.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -104,7 +105,7 @@ export function registerSequencesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.sequences.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -128,7 +129,7 @@ export function registerSequencesCommand(program: Command): void {
       // Uses client.sequences.enroll() — NOT client.sequenceEnrollments.create()
       const result = await client.sequences.enroll(seqId, body)
 
-      if (flags.json) {
+      if (isJsonMode()) {
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
         process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
@@ -152,7 +153,7 @@ export function registerSequencesCommand(program: Command): void {
       // Uses client.sequenceEnrollments.unenroll() — NOT client.sequenceEnrollments.delete()
       const result = await client.sequenceEnrollments.unenroll(enrollmentId)
 
-      if (flags.json) {
+      if (isJsonMode()) {
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
         process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))

--- a/packages/cli/src/commands/sequences.ts
+++ b/packages/cli/src/commands/sequences.ts
@@ -1,0 +1,161 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import { CliValidationError } from '../errors.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateSequenceInput, UpdateSequenceInput } from '@orbit-ai/sdk'
+
+export function registerSequencesCommand(program: Command): void {
+  const sequences = program.command('sequences').description('Manage and enroll contacts in sequences')
+
+  sequences
+    .command('list')
+    .description('List sequences')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.sequences.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.sequences.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  sequences
+    .command('get <id>')
+    .description('Get a sequence by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.sequences.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.sequences.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  sequences
+    .command('create')
+    .description('Create a new sequence')
+    .requiredOption('--name <name>', 'Sequence name')
+    .option('--description <description>', 'Sequence description')
+    .option('--status <status>', 'Sequence status')
+    .option('--trigger-type <type>', 'Trigger type')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateSequenceInput = { name: opts.name }
+      if (opts.description) input.description = opts.description
+      if (opts.status) input.status = opts.status
+      if (opts.triggerType) input.trigger_type = opts.triggerType
+
+      if (flags.json) {
+        const result = await client.sequences.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.sequences.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  sequences
+    .command('update <id>')
+    .description('Update a sequence')
+    .option('--name <name>', 'Sequence name')
+    .option('--description <description>', 'Sequence description')
+    .option('--status <status>', 'Sequence status')
+    .option('--trigger-type <type>', 'Trigger type')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateSequenceInput = {}
+      if (opts.name) input.name = opts.name
+      if (opts.description) input.description = opts.description
+      if (opts.status) input.status = opts.status
+      if (opts.triggerType) input.trigger_type = opts.triggerType
+
+      if (flags.json) {
+        const result = await client.sequences.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.sequences.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  sequences
+    .command('delete <id>')
+    .description('Delete a sequence')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.sequences.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.sequences.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  sequences
+    .command('enroll <seq-id>')
+    .description('Enroll a contact in a sequence')
+    .requiredOption('--contact <contact-id>', 'Contact ID to enroll')
+    .option('--enrolled-at <date>', 'Enrollment date (ISO date)')
+    .action(async (seqId, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const body: Record<string, unknown> = { contact_id: opts.contact }
+      if (opts.enrolledAt) body.enrolled_at = opts.enrolledAt
+
+      // Uses client.sequences.enroll() — NOT client.sequenceEnrollments.create()
+      const result = await client.sequences.enroll(seqId, body)
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  sequences
+    .command('unenroll <enrollment-id>')
+    .description('Unenroll a contact from a sequence by enrollment ID')
+    .action(async (enrollmentId) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (!enrollmentId) {
+        throw new CliValidationError('Enrollment ID is required', {
+          code: 'MISSING_REQUIRED_ARG',
+          path: 'enrollment-id',
+        })
+      }
+
+      // Uses client.sequenceEnrollments.unenroll() — NOT client.sequenceEnrollments.delete()
+      const result = await client.sequenceEnrollments.unenroll(enrollmentId)
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/stages.ts
+++ b/packages/cli/src/commands/stages.ts
@@ -1,0 +1,107 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateStageInput, UpdateStageInput } from '@orbit-ai/sdk'
+
+export function registerStagesCommand(program: Command): void {
+  const stages = program.command('stages').description('Manage pipeline stages')
+
+  stages
+    .command('list')
+    .description('List stages')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.stages.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.stages.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  stages
+    .command('get <id>')
+    .description('Get a stage by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.stages.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.stages.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  stages
+    .command('create')
+    .description('Create a new stage')
+    .requiredOption('--pipeline-id <id>', 'Pipeline ID')
+    .requiredOption('--name <name>', 'Stage name')
+    .option('--position <n>', 'Stage position')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateStageInput = { pipeline_id: opts.pipelineId, name: opts.name }
+      if (opts.position !== undefined) input.position = Number(opts.position)
+
+      if (flags.json) {
+        const result = await client.stages.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.stages.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  stages
+    .command('update <id>')
+    .description('Update a stage')
+    .option('--name <name>', 'Stage name')
+    .option('--position <n>', 'Stage position')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateStageInput = {}
+      if (opts.name) input.name = opts.name
+      if (opts.position !== undefined) input.position = Number(opts.position)
+
+      if (flags.json) {
+        const result = await client.stages.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.stages.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  stages
+    .command('delete <id>')
+    .description('Delete a stage')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.stages.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.stages.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/stages.ts
+++ b/packages/cli/src/commands/stages.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateStageInput, UpdateStageInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerStagesCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.stages.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerStagesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.stages.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -58,7 +59,7 @@ export function registerStagesCommand(program: Command): void {
       const input: CreateStageInput = { pipeline_id: opts.pipelineId, name: opts.name }
       if (opts.position !== undefined) input.position = Number(opts.position)
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.stages.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -80,7 +81,7 @@ export function registerStagesCommand(program: Command): void {
       if (opts.name) input.name = opts.name
       if (opts.position !== undefined) input.position = Number(opts.position)
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.stages.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -96,7 +97,7 @@ export function registerStagesCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.stages.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -24,11 +24,7 @@ async function runStatus(flags: GlobalFlags): Promise<void> {
       process.stdout.write('Status: connected\n')
     }
   } catch (e) {
-    if (isJsonMode()) {
-      process.stdout.write(JSON.stringify({ status: 'error', connected: false, message: (e as Error).message }) + '\n')
-    } else {
-      process.stderr.write(`Status: error — ${(e as Error).message}\n`)
-    }
-    process.exit(1)
+    // Re-throw so run()'s top-level handler applies the standard { error: ... } contract.
+    throw e
   }
 }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -29,5 +29,6 @@ async function runStatus(flags: GlobalFlags): Promise<void> {
     } else {
       process.stderr.write(`Status: error — ${(e as Error).message}\n`)
     }
+    process.exit(1)
   }
 }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -15,16 +15,10 @@ export function registerStatusCommand(program: Command): void {
 
 async function runStatus(flags: GlobalFlags): Promise<void> {
   const client = resolveClient({ flags })
-  // Try a lightweight call — list users with limit 1
-  try {
-    await client.users.list({ limit: 1 })
-    if (isJsonMode()) {
-      process.stdout.write(JSON.stringify({ status: 'ok', connected: true }) + '\n')
-    } else {
-      process.stdout.write('Status: connected\n')
-    }
-  } catch (e) {
-    // Re-throw so run()'s top-level handler applies the standard { error: ... } contract.
-    throw e
+  await client.users.list({ limit: 1 })
+  if (isJsonMode()) {
+    process.stdout.write(JSON.stringify({ status: 'ok', connected: true }) + '\n')
+  } else {
+    process.stdout.write('Status: connected\n')
   }
 }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,33 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { isJsonMode } from '../program.js'
+import type { GlobalFlags } from '../types.js'
+
+export function registerStatusCommand(program: Command): void {
+  program
+    .command('status')
+    .description('Show connection and config status')
+    .action(async () => {
+      const flags = program.opts() as GlobalFlags
+      await runStatus(flags)
+    })
+}
+
+async function runStatus(flags: GlobalFlags): Promise<void> {
+  const client = resolveClient({ flags })
+  // Try a lightweight call — list users with limit 1
+  try {
+    await client.users.list({ limit: 1 })
+    if (isJsonMode()) {
+      process.stdout.write(JSON.stringify({ status: 'ok', connected: true }) + '\n')
+    } else {
+      process.stdout.write('Status: connected\n')
+    }
+  } catch (e) {
+    if (isJsonMode()) {
+      process.stdout.write(JSON.stringify({ status: 'error', connected: false, message: (e as Error).message }) + '\n')
+    } else {
+      process.stderr.write(`Status: error — ${(e as Error).message}\n`)
+    }
+  }
+}

--- a/packages/cli/src/commands/tags.ts
+++ b/packages/cli/src/commands/tags.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateTagInput, UpdateTagInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerTagsCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.tags.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerTagsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.tags.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -57,7 +58,7 @@ export function registerTagsCommand(program: Command): void {
       const input: CreateTagInput = { name: opts.name }
       if (opts.color) input.color = opts.color
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.tags.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -79,7 +80,7 @@ export function registerTagsCommand(program: Command): void {
       if (opts.name) input.name = opts.name
       if (opts.color) input.color = opts.color
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.tags.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -95,7 +96,7 @@ export function registerTagsCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.tags.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/tags.ts
+++ b/packages/cli/src/commands/tags.ts
@@ -1,0 +1,106 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateTagInput, UpdateTagInput } from '@orbit-ai/sdk'
+
+export function registerTagsCommand(program: Command): void {
+  const tags = program.command('tags').description('Manage tags')
+
+  tags
+    .command('list')
+    .description('List tags')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.tags.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.tags.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  tags
+    .command('get <id>')
+    .description('Get a tag by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.tags.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.tags.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  tags
+    .command('create')
+    .description('Create a new tag')
+    .requiredOption('--name <name>', 'Tag name')
+    .option('--color <color>', 'Tag color (hex or named)')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateTagInput = { name: opts.name }
+      if (opts.color) input.color = opts.color
+
+      if (flags.json) {
+        const result = await client.tags.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.tags.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  tags
+    .command('update <id>')
+    .description('Update a tag')
+    .option('--name <name>', 'Tag name')
+    .option('--color <color>', 'Tag color')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateTagInput = {}
+      if (opts.name) input.name = opts.name
+      if (opts.color) input.color = opts.color
+
+      if (flags.json) {
+        const result = await client.tags.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.tags.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  tags
+    .command('delete <id>')
+    .description('Delete a tag')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.tags.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.tags.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/tasks.ts
+++ b/packages/cli/src/commands/tasks.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateTaskInput, UpdateTaskInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerTasksCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.tasks.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerTasksCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.tasks.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -69,7 +70,7 @@ export function registerTasksCommand(program: Command): void {
       if (opts.dealId) input.deal_id = opts.dealId
       if (opts.assignedTo) input.assigned_to_user_id = opts.assignedTo
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.tasks.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -103,7 +104,7 @@ export function registerTasksCommand(program: Command): void {
       if (opts.dealId) input.deal_id = opts.dealId
       if (opts.assignedTo) input.assigned_to_user_id = opts.assignedTo
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.tasks.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -119,7 +120,7 @@ export function registerTasksCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.tasks.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/tasks.ts
+++ b/packages/cli/src/commands/tasks.ts
@@ -1,0 +1,130 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateTaskInput, UpdateTaskInput } from '@orbit-ai/sdk'
+
+export function registerTasksCommand(program: Command): void {
+  const tasks = program.command('tasks').description('Manage tasks')
+
+  tasks
+    .command('list')
+    .description('List tasks')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.tasks.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.tasks.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  tasks
+    .command('get <id>')
+    .description('Get a task by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.tasks.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.tasks.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  tasks
+    .command('create')
+    .description('Create a new task')
+    .requiredOption('--title <title>', 'Task title')
+    .option('--description <description>', 'Task description')
+    .option('--status <status>', 'Task status')
+    .option('--priority <priority>', 'Task priority')
+    .option('--due-date <date>', 'Due date (ISO date)')
+    .option('--contact-id <id>', 'Contact ID')
+    .option('--deal-id <id>', 'Deal ID')
+    .option('--assigned-to <userId>', 'Assigned to user ID')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateTaskInput = { title: opts.title }
+      if (opts.description) input.description = opts.description
+      if (opts.status) input.status = opts.status
+      if (opts.priority) input.priority = opts.priority
+      if (opts.dueDate) input.due_date = opts.dueDate
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.dealId) input.deal_id = opts.dealId
+      if (opts.assignedTo) input.assigned_to_user_id = opts.assignedTo
+
+      if (flags.json) {
+        const result = await client.tasks.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.tasks.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  tasks
+    .command('update <id>')
+    .description('Update a task')
+    .option('--title <title>', 'Task title')
+    .option('--description <description>', 'Task description')
+    .option('--status <status>', 'Task status')
+    .option('--priority <priority>', 'Task priority')
+    .option('--due-date <date>', 'Due date (ISO date)')
+    .option('--contact-id <id>', 'Contact ID')
+    .option('--deal-id <id>', 'Deal ID')
+    .option('--assigned-to <userId>', 'Assigned to user ID')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateTaskInput = {}
+      if (opts.title) input.title = opts.title
+      if (opts.description) input.description = opts.description
+      if (opts.status) input.status = opts.status
+      if (opts.priority) input.priority = opts.priority
+      if (opts.dueDate) input.due_date = opts.dueDate
+      if (opts.contactId) input.contact_id = opts.contactId
+      if (opts.dealId) input.deal_id = opts.dealId
+      if (opts.assignedTo) input.assigned_to_user_id = opts.assignedTo
+
+      if (flags.json) {
+        const result = await client.tasks.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.tasks.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  tasks
+    .command('delete <id>')
+    .description('Delete a task')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.tasks.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.tasks.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/users.ts
+++ b/packages/cli/src/commands/users.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateUserInput, UpdateUserInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerUsersCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.users.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerUsersCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.users.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -58,7 +59,7 @@ export function registerUsersCommand(program: Command): void {
       const input: CreateUserInput = { name: opts.name, email: opts.email }
       if (opts.role) input.role = opts.role
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.users.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -82,7 +83,7 @@ export function registerUsersCommand(program: Command): void {
       if (opts.email) input.email = opts.email
       if (opts.role) input.role = opts.role
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.users.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -98,7 +99,7 @@ export function registerUsersCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.users.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/commands/users.ts
+++ b/packages/cli/src/commands/users.ts
@@ -1,0 +1,109 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateUserInput, UpdateUserInput } from '@orbit-ai/sdk'
+
+export function registerUsersCommand(program: Command): void {
+  const users = program.command('users').description('Manage users')
+
+  users
+    .command('list')
+    .description('List users')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.users.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.users.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  users
+    .command('get <id>')
+    .description('Get a user by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.users.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.users.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  users
+    .command('create')
+    .description('Create a new user')
+    .requiredOption('--name <name>', 'User name')
+    .requiredOption('--email <email>', 'User email')
+    .option('--role <role>', 'User role')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateUserInput = { name: opts.name, email: opts.email }
+      if (opts.role) input.role = opts.role
+
+      if (flags.json) {
+        const result = await client.users.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.users.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  users
+    .command('update <id>')
+    .description('Update a user')
+    .option('--name <name>', 'User name')
+    .option('--email <email>', 'User email')
+    .option('--role <role>', 'User role')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateUserInput = {}
+      if (opts.name) input.name = opts.name
+      if (opts.email) input.email = opts.email
+      if (opts.role) input.role = opts.role
+
+      if (flags.json) {
+        const result = await client.users.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.users.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  users
+    .command('delete <id>')
+    .description('Delete a user')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.users.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.users.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/webhooks.ts
+++ b/packages/cli/src/commands/webhooks.ts
@@ -1,0 +1,116 @@
+import { Command } from 'commander'
+import { resolveClient } from '../config/resolve-context.js'
+import { formatOutput } from '../output/formatter.js'
+import type { GlobalFlags } from '../types.js'
+import type { CreateWebhookInput, UpdateWebhookInput } from '@orbit-ai/sdk'
+
+export function registerWebhooksCommand(program: Command): void {
+  const webhooks = program.command('webhooks').description('Manage webhooks')
+
+  webhooks
+    .command('list')
+    .description('List webhooks')
+    .option('--limit <n>', 'Max records', '20')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+      const query = {
+        limit: Number(opts.limit),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      }
+
+      if (flags.json) {
+        const result = await client.webhooks.response().list(query)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.webhooks.list(query)
+        process.stdout.write(formatOutput(result, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  webhooks
+    .command('get <id>')
+    .description('Get a webhook by ID')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.webhooks.response().get(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.webhooks.get(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  webhooks
+    .command('create')
+    .description('Create a new webhook')
+    .requiredOption('--url <url>', 'Webhook endpoint URL')
+    .requiredOption('--events <events>', 'Comma-separated list of events to subscribe to')
+    .option('--status <status>', 'Webhook status')
+    .option('--description <description>', 'Webhook description')
+    .action(async (opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: CreateWebhookInput = {
+        url: opts.url,
+        events: opts.events.split(',').map((e: string) => e.trim()),
+      }
+      if (opts.status) input.status = opts.status
+      if (opts.description) input.description = opts.description
+
+      if (flags.json) {
+        const result = await client.webhooks.response().create(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.webhooks.create(input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  webhooks
+    .command('update <id>')
+    .description('Update a webhook')
+    .option('--url <url>', 'Webhook endpoint URL')
+    .option('--events <events>', 'Comma-separated list of events')
+    .option('--status <status>', 'Webhook status')
+    .option('--description <description>', 'Webhook description')
+    .action(async (id, opts) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      const input: UpdateWebhookInput = {}
+      if (opts.url) input.url = opts.url
+      if (opts.events) input.events = opts.events.split(',').map((e: string) => e.trim())
+      if (opts.status) input.status = opts.status
+      if (opts.description) input.description = opts.description
+
+      if (flags.json) {
+        const result = await client.webhooks.response().update(id, input)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.webhooks.update(id, input)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+
+  webhooks
+    .command('delete <id>')
+    .description('Delete a webhook')
+    .action(async (id) => {
+      const flags = program.opts() as GlobalFlags
+      const client = resolveClient({ flags })
+
+      if (flags.json) {
+        const result = await client.webhooks.response().delete(id)
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      } else {
+        const result = await client.webhooks.delete(id)
+        process.stdout.write(formatOutput({ data: result }, { format: flags.format ?? 'table' }))
+      }
+    })
+}

--- a/packages/cli/src/commands/webhooks.ts
+++ b/packages/cli/src/commands/webhooks.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { resolveClient } from '../config/resolve-context.js'
 import { formatOutput } from '../output/formatter.js'
+import { isJsonMode } from '../program.js'
 import type { GlobalFlags } from '../types.js'
 import type { CreateWebhookInput, UpdateWebhookInput } from '@orbit-ai/sdk'
 
@@ -20,7 +21,7 @@ export function registerWebhooksCommand(program: Command): void {
         ...(opts.cursor ? { cursor: opts.cursor } : {}),
       }
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.webhooks.response().list(query)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -36,7 +37,7 @@ export function registerWebhooksCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.webhooks.response().get(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -63,7 +64,7 @@ export function registerWebhooksCommand(program: Command): void {
       if (opts.status) input.status = opts.status
       if (opts.description) input.description = opts.description
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.webhooks.response().create(input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -89,7 +90,7 @@ export function registerWebhooksCommand(program: Command): void {
       if (opts.status) input.status = opts.status
       if (opts.description) input.description = opts.description
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.webhooks.response().update(id, input)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {
@@ -105,7 +106,7 @@ export function registerWebhooksCommand(program: Command): void {
       const flags = program.opts() as GlobalFlags
       const client = resolveClient({ flags })
 
-      if (flags.json) {
+      if (isJsonMode()) {
         const result = await client.webhooks.response().delete(id)
         process.stdout.write(JSON.stringify(result, null, 2) + '\n')
       } else {

--- a/packages/cli/src/config/files.ts
+++ b/packages/cli/src/config/files.ts
@@ -130,6 +130,22 @@ function tryRealpath(p: string): string {
   }
 }
 
+/** Collect real paths of all ancestors of dir up to and including home (inclusive). */
+function ancestorRoots(dir: string, home: string): string[] {
+  const roots: string[] = []
+  let current = tryRealpath(dir)
+  const realHome = tryRealpath(home)
+  while (true) {
+    roots.push(current)
+    if (current === realHome) break
+    const parent = path.dirname(current)
+    if (parent === current) break // filesystem root
+    current = parent
+  }
+  if (!roots.includes(realHome)) roots.push(realHome)
+  return roots
+}
+
 export function loadConfig(
   cwd: string = process.cwd(),
   overrideHome?: string,
@@ -137,7 +153,8 @@ export function loadConfig(
   const home = overrideHome ?? os.homedir()
   // Resolve roots through symlinks so canonicalizePath comparisons work on
   // macOS where /tmp → /private/tmp (and similarly for /var/folders).
-  const allowedRoots = [tryRealpath(cwd), tryRealpath(home)]
+  // Include all ancestors of cwd so configs found by walking up are allowed.
+  const allowedRoots = ancestorRoots(cwd, home)
 
   // User config
   const userPath = path.join(home, '.config', 'orbit', 'config.json')

--- a/packages/cli/src/config/files.ts
+++ b/packages/cli/src/config/files.ts
@@ -94,8 +94,10 @@ export function readConfigFile(filePath: string): OrbitConfig | null {
         `Warning: config file '${filePath}' has permissions ${mode.toString(8)} — recommend 0600 (readable only by owner).\n`,
       )
     }
-  } catch {
-    // stat failed — not a blocker
+  } catch (e) {
+    process.stderr.write(
+      `Warning: could not check permissions on config file '${filePath}': ${(e as Error).message}\n`,
+    )
   }
 
   let content: string

--- a/packages/cli/src/config/files.ts
+++ b/packages/cli/src/config/files.ts
@@ -21,12 +21,24 @@ export interface OrbitConfig {
  * Allowed roots: ancestors of cwd and os.homedir().
  */
 export function canonicalizePath(filePath: string, allowedRoots: string[]): string {
-  let resolved: string
+  let resolved = ''
   try {
     resolved = fs.realpathSync(filePath)
   } catch {
-    // File doesn't exist yet — resolve without realpathSync (for new files)
-    resolved = path.resolve(filePath)
+    // File doesn't exist yet — resolve symlinks in the deepest existing ancestor
+    let resolved2 = path.resolve(filePath)
+    let check = path.dirname(resolved2)
+    while (check !== path.dirname(check)) {
+      try {
+        const realParent = fs.realpathSync(check)
+        resolved2 = path.join(realParent, path.relative(check, resolved2))
+        resolved = resolved2
+        break
+      } catch {
+        check = path.dirname(check)
+      }
+    }
+    if (!resolved) resolved = resolved2
   }
   const isAllowed = allowedRoots.some(
     (root) => resolved === root || resolved.startsWith(root + path.sep),

--- a/packages/cli/src/config/files.ts
+++ b/packages/cli/src/config/files.ts
@@ -13,8 +13,11 @@ export interface OrbitConfig {
   adapter?: string
   databaseUrl?: string
   profile?: string
-  profiles?: Record<string, Partial<OrbitConfig>>
+  profiles?: Record<string, Omit<OrbitConfig, 'profiles' | 'profile'>>
 }
+
+/** Config fields valid inside a named profile — profiles cannot be nested. */
+type ProfileEntry = Omit<OrbitConfig, 'profiles' | 'profile'>
 
 /**
  * Canonicalize a path via fs.realpathSync, rejecting paths outside allowed roots.
@@ -133,12 +136,12 @@ function tryRealpath(p: string): string {
 /**
  * Apply a named profile on top of a base config.
  * Returns the base config unchanged if the profile doesn't exist.
+ * Note: `profiles` keys inside a profile entry are not supported and are excluded by type.
  */
 export function applyProfile(base: OrbitConfig, profileName: string): OrbitConfig {
-  const profile = base.profiles?.[profileName]
+  const profile: ProfileEntry | undefined = base.profiles?.[profileName]
   if (!profile) return base
-  const { profiles: _profiles, ...profileData } = profile as OrbitConfig
-  return { ...base, ...profileData }
+  return { ...base, ...profile }
 }
 
 /** Collect real paths of all ancestors of dir up to and including home (inclusive). */

--- a/packages/cli/src/config/files.ts
+++ b/packages/cli/src/config/files.ts
@@ -1,0 +1,142 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { CliConfigError } from '../errors.js'
+
+export interface OrbitConfig {
+  mode?: 'api' | 'direct'
+  apiKey?: string
+  apiKeyEnv?: string
+  baseUrl?: string
+  orgId?: string
+  userId?: string
+  adapter?: string
+  databaseUrl?: string
+  profile?: string
+  profiles?: Record<string, Partial<OrbitConfig>>
+}
+
+/**
+ * Canonicalize a path via fs.realpathSync, rejecting paths outside allowed roots.
+ * Allowed roots: ancestors of cwd and os.homedir().
+ */
+export function canonicalizePath(filePath: string, allowedRoots: string[]): string {
+  let resolved: string
+  try {
+    resolved = fs.realpathSync(filePath)
+  } catch {
+    // File doesn't exist yet — resolve without realpathSync (for new files)
+    resolved = path.resolve(filePath)
+  }
+  const isAllowed = allowedRoots.some(
+    (root) => resolved === root || resolved.startsWith(root + path.sep),
+  )
+  if (!isAllowed) {
+    throw new CliConfigError(
+      `Config path '${resolved}' is outside allowed directories.`,
+      { code: 'CONFIG_PATH_OUTSIDE_ALLOWED' },
+    )
+  }
+  return resolved
+}
+
+/**
+ * Walk up from startDir looking for .orbit/config.json.
+ * Returns null if not found.
+ */
+export function findProjectConfig(startDir: string): string | null {
+  let current = startDir
+  const home = os.homedir()
+  while (true) {
+    const candidate = path.join(current, '.orbit', 'config.json')
+    if (fs.existsSync(candidate)) {
+      return candidate
+    }
+    const parent = path.dirname(current)
+    if (parent === current || current === home) break
+    current = parent
+  }
+  return null
+}
+
+/**
+ * Returns the user config path (~/.config/orbit/config.json).
+ */
+export function userConfigPath(): string {
+  return path.join(os.homedir(), '.config', 'orbit', 'config.json')
+}
+
+/**
+ * Read and parse a config file. Throws CliConfigError if malformed.
+ * Returns null if file doesn't exist.
+ */
+export function readConfigFile(filePath: string): OrbitConfig | null {
+  if (!fs.existsSync(filePath)) return null
+
+  // Check permissions — warn if readable by group or world
+  try {
+    const stat = fs.statSync(filePath)
+    const mode = stat.mode & 0o777
+    if (mode & 0o077) {
+      process.stderr.write(
+        `Warning: config file '${filePath}' has permissions ${mode.toString(8)} — recommend 0600 (readable only by owner).\n`,
+      )
+    }
+  } catch {
+    // stat failed — not a blocker
+  }
+
+  let content: string
+  try {
+    content = fs.readFileSync(filePath, 'utf8')
+  } catch (e) {
+    throw new CliConfigError(`Cannot read config file '${filePath}': ${(e as Error).message}`, {
+      code: 'CONFIG_READ_ERROR',
+    })
+  }
+
+  try {
+    return JSON.parse(content) as OrbitConfig
+  } catch {
+    throw new CliConfigError(`Malformed JSON in config file '${filePath}'.`, {
+      code: 'CONFIG_PARSE_ERROR',
+    })
+  }
+}
+
+/**
+ * Load merged config: project config overrides user config.
+ * Applies profile if specified.
+ */
+function tryRealpath(p: string): string {
+  try {
+    return fs.realpathSync(p)
+  } catch {
+    return path.resolve(p)
+  }
+}
+
+export function loadConfig(
+  cwd: string = process.cwd(),
+  overrideHome?: string,
+): OrbitConfig {
+  const home = overrideHome ?? os.homedir()
+  // Resolve roots through symlinks so canonicalizePath comparisons work on
+  // macOS where /tmp → /private/tmp (and similarly for /var/folders).
+  const allowedRoots = [tryRealpath(cwd), tryRealpath(home)]
+
+  // User config
+  const userPath = path.join(home, '.config', 'orbit', 'config.json')
+  const userConfig = fs.existsSync(userPath)
+    ? readConfigFile(canonicalizePath(userPath, allowedRoots))
+    : null
+
+  // Project config (walk up from cwd)
+  const projectConfigPath = findProjectConfig(cwd)
+  const projectConfig = projectConfigPath
+    ? readConfigFile(canonicalizePath(projectConfigPath, allowedRoots))
+    : null
+
+  // Merge: project overrides user
+  return { ...userConfig, ...projectConfig }
+}

--- a/packages/cli/src/config/files.ts
+++ b/packages/cli/src/config/files.ts
@@ -130,6 +130,17 @@ function tryRealpath(p: string): string {
   }
 }
 
+/**
+ * Apply a named profile on top of a base config.
+ * Returns the base config unchanged if the profile doesn't exist.
+ */
+export function applyProfile(base: OrbitConfig, profileName: string): OrbitConfig {
+  const profile = base.profiles?.[profileName]
+  if (!profile) return base
+  const { profiles: _profiles, ...profileData } = profile as OrbitConfig
+  return { ...base, ...profileData }
+}
+
 /** Collect real paths of all ancestors of dir up to and including home (inclusive). */
 function ancestorRoots(dir: string, home: string): string[] {
   const roots: string[] = []

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { Pool } from 'pg'
 import {
@@ -32,13 +33,13 @@ export interface ResolveContextOptions {
   overrideHome?: string
 }
 
-function resolveAdapter(flags: GlobalFlags, config: OrbitConfig): StorageAdapter {
+function resolveAdapter(flags: GlobalFlags, config: OrbitConfig, cwd: string): StorageAdapter {
   const adapterName = flags.adapter ?? config.adapter ?? 'sqlite'
   const dbUrl = flags.databaseUrl ?? config.databaseUrl ?? ''
 
   if (adapterName === 'sqlite') {
-    // Validate URL scheme — reject http(s) and anything non-file
-    if (dbUrl && /^https?:\/\//i.test(dbUrl)) {
+    // Validate URL scheme — block any scheme except file:
+    if (dbUrl && /^[a-z][a-z0-9+\-.]*:\/\//i.test(dbUrl) && !/^file:\/\//i.test(dbUrl)) {
       let safeUrl = dbUrl
       try {
         const parsed = new URL(dbUrl)
@@ -47,7 +48,7 @@ function resolveAdapter(flags: GlobalFlags, config: OrbitConfig): StorageAdapter
         safeUrl = '[unparseable]'
       }
       throw new CliValidationError(
-        `SQLite database URL must be a file path or file: URI, not an HTTP URL. Scheme+host: '${safeUrl}'`,
+        `SQLite database URL must be a file path or file: URI, not a remote URL. Scheme+host: '${safeUrl}'`,
         { code: 'MISSING_REQUIRED_CONFIG', path: 'databaseUrl' },
       )
     }
@@ -57,7 +58,7 @@ function resolveAdapter(flags: GlobalFlags, config: OrbitConfig): StorageAdapter
     if (dbUrl.startsWith('file:')) {
       dbPath = dbUrl.slice(5)
     } else {
-      dbPath = dbUrl || ':memory:'
+      dbPath = dbUrl || path.join(cwd, '.orbit', 'orbit.db')
     }
 
     const database =
@@ -161,7 +162,7 @@ export function resolveClient(options: ResolveContextOptions): OrbitClient {
       )
     }
 
-    const resolvedAdapter = resolveAdapter(flags, resolvedConfig)
+    const resolvedAdapter = resolveAdapter(flags, resolvedConfig, cwd ?? process.cwd())
 
     return new OrbitClient({
       adapter: resolvedAdapter,

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -9,7 +9,7 @@ import {
 } from '@orbit-ai/core'
 import { OrbitClient } from '@orbit-ai/sdk'
 import { CliValidationError, CliUnsupportedAdapterError } from '../errors.js'
-import { loadConfig, type OrbitConfig } from './files.js'
+import { loadConfig, applyProfile, type OrbitConfig } from './files.js'
 import type { GlobalFlags } from '../types.js'
 
 /**
@@ -121,26 +121,30 @@ export function resolveClient(options: ResolveContextOptions): OrbitClient {
   // Load config from files
   const fileConfig = loadConfig(cwd, overrideHome)
 
+  // Resolve profile: flag > env > config default
+  const profileName = flags.profile ?? env['ORBIT_PROFILE'] ?? fileConfig.profile
+  const mergedFileConfig = profileName ? applyProfile(fileConfig, profileName) : fileConfig
+
   // Resolve effective config: flags > env > project/user config file
   // Use Object.assign pattern to avoid assigning `undefined` to optional keys
   // (required by exactOptionalPropertyTypes)
   const resolvedConfig: OrbitConfig = {}
-  const mode = flags.mode ?? fileConfig.mode ?? 'api'
+  const mode = flags.mode ?? mergedFileConfig.mode ?? 'api'
   resolvedConfig.mode = mode
   const apiKeyFromEnvName =
-    fileConfig.apiKeyEnv ? env[fileConfig.apiKeyEnv] : undefined
+    mergedFileConfig.apiKeyEnv ? env[mergedFileConfig.apiKeyEnv] : undefined
   const apiKey =
-    flags.apiKey ?? env['ORBIT_API_KEY'] ?? fileConfig.apiKey ?? apiKeyFromEnvName
+    flags.apiKey ?? env['ORBIT_API_KEY'] ?? mergedFileConfig.apiKey ?? apiKeyFromEnvName
   if (apiKey !== undefined) resolvedConfig.apiKey = apiKey
-  const baseUrl = flags.baseUrl ?? env['ORBIT_BASE_URL'] ?? fileConfig.baseUrl
+  const baseUrl = flags.baseUrl ?? env['ORBIT_BASE_URL'] ?? mergedFileConfig.baseUrl
   if (baseUrl !== undefined) resolvedConfig.baseUrl = baseUrl
-  const orgId = flags.orgId ?? env['ORBIT_ORG_ID'] ?? fileConfig.orgId
+  const orgId = flags.orgId ?? env['ORBIT_ORG_ID'] ?? mergedFileConfig.orgId
   if (orgId !== undefined) resolvedConfig.orgId = orgId
-  const userId = flags.userId ?? env['ORBIT_USER_ID'] ?? fileConfig.userId
+  const userId = flags.userId ?? env['ORBIT_USER_ID'] ?? mergedFileConfig.userId
   if (userId !== undefined) resolvedConfig.userId = userId
-  const adapter = flags.adapter ?? env['ORBIT_ADAPTER'] ?? fileConfig.adapter
+  const adapter = flags.adapter ?? env['ORBIT_ADAPTER'] ?? mergedFileConfig.adapter
   if (adapter !== undefined) resolvedConfig.adapter = adapter
-  const databaseUrl = flags.databaseUrl ?? env['DATABASE_URL'] ?? fileConfig.databaseUrl
+  const databaseUrl = flags.databaseUrl ?? env['DATABASE_URL'] ?? mergedFileConfig.databaseUrl
   if (databaseUrl !== undefined) resolvedConfig.databaseUrl = databaseUrl
 
   if (mode === 'direct') {

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -12,12 +12,15 @@ import { CliValidationError, CliUnsupportedAdapterError } from '../errors.js'
 import { loadConfig, type OrbitConfig } from './files.js'
 import type { GlobalFlags } from '../types.js'
 
-// Direct mode trust boundary — the following middleware protections are NOT active in direct mode:
-// - API key authentication
-// - Rate limiting
-// - Scope enforcement (org isolation is the caller's responsibility)
-// - SSRF protection
-// When using direct mode, ensure the caller is trusted and the database is local.
+/**
+ * Direct-mode trust boundaries — the following middleware protections are NOT active in direct mode:
+ * - API key authentication: no key validation occurs
+ * - Rate limiting: no throttling on operations
+ * - Scope enforcement: org isolation is the caller's responsibility
+ * - SSRF protection: no outbound request filtering
+ *
+ * Direct mode is trusted-caller-only. Ensure the database is local and the caller is authorized.
+ */
 
 const DIRECT_MODE_WARNING =
   'Warning: direct mode bypasses API key authentication, rate limiting, scope enforcement, and SSRF protection. Ensure the caller is trusted and the database is local.\n'

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -58,9 +58,20 @@ function resolveAdapter(flags: GlobalFlags, config: OrbitConfig, cwd: string): S
     if (dbUrl.startsWith('file:')) {
       // Use URL.pathname to correctly handle file:///abs/path and file:/abs/path
       try {
-        dbPath = new URL(dbUrl).pathname
-      } catch {
-        dbPath = dbUrl.slice(5) // fallback for malformed but non-rejectable file: URIs
+        const parsed = new URL(dbUrl)
+        if (parsed.hostname && parsed.hostname !== 'localhost') {
+          throw new CliValidationError(
+            `SQLite file: URI must not specify a remote host. Got hostname: '${parsed.hostname}'`,
+            { code: 'MISSING_REQUIRED_CONFIG', path: 'databaseUrl' },
+          )
+        }
+        dbPath = parsed.pathname
+      } catch (err) {
+        if (err instanceof CliValidationError) throw err
+        throw new CliValidationError(
+          `Malformed file: URI for SQLite database: '${dbUrl}'. Use 'file:///absolute/path' or a bare file path.`,
+          { code: 'INVALID_DATABASE_URL', path: 'databaseUrl' },
+        )
       }
     } else {
       dbPath = dbUrl || path.join(cwd, '.orbit', 'orbit.db')

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -56,7 +56,12 @@ function resolveAdapter(flags: GlobalFlags, config: OrbitConfig, cwd: string): S
     // Resolve actual file path from file: URI or bare path
     let dbPath: string
     if (dbUrl.startsWith('file:')) {
-      dbPath = dbUrl.slice(5)
+      // Use URL.pathname to correctly handle file:///abs/path and file:/abs/path
+      try {
+        dbPath = new URL(dbUrl).pathname
+      } catch {
+        dbPath = dbUrl.slice(5) // fallback for malformed but non-rejectable file: URIs
+      }
     } else {
       dbPath = dbUrl || path.join(cwd, '.orbit', 'orbit.db')
     }
@@ -134,8 +139,10 @@ export function resolveClient(options: ResolveContextOptions): OrbitClient {
   resolvedConfig.mode = mode
   const apiKeyFromEnvName =
     mergedFileConfig.apiKeyEnv ? env[mergedFileConfig.apiKeyEnv] : undefined
+  // Priority: CLI flag > ORBIT_API_KEY env > apiKeyEnv-indirected env > literal key in config file
+  // apiKeyEnv beats the literal apiKey so operators can inject at runtime without storing in the file
   const apiKey =
-    flags.apiKey ?? env['ORBIT_API_KEY'] ?? mergedFileConfig.apiKey ?? apiKeyFromEnvName
+    flags.apiKey ?? env['ORBIT_API_KEY'] ?? apiKeyFromEnvName ?? mergedFileConfig.apiKey
   if (apiKey !== undefined) resolvedConfig.apiKey = apiKey
   const baseUrl = flags.baseUrl ?? env['ORBIT_BASE_URL'] ?? mergedFileConfig.baseUrl
   if (baseUrl !== undefined) resolvedConfig.baseUrl = baseUrl

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -18,13 +18,13 @@ import type { GlobalFlags } from '../types.js'
  * - API key authentication: no key validation occurs
  * - Rate limiting: no throttling on operations
  * - Scope enforcement: org isolation is the caller's responsibility
- * - SSRF protection: no outbound request filtering
+ * - Input validation: database URL / path is not validated beyond scheme and prefix checks
  *
  * Direct mode is trusted-caller-only. Ensure the database is local and the caller is authorized.
  */
 
 const DIRECT_MODE_WARNING =
-  'Warning: direct mode bypasses API key authentication, rate limiting, scope enforcement, and SSRF protection. Ensure the caller is trusted and the database is local.\n'
+  'Warning: direct mode bypasses API key authentication, rate limiting, and scope enforcement. Ensure the caller is trusted and the database is local.\n'
 
 export interface ResolveContextOptions {
   flags: GlobalFlags
@@ -140,7 +140,8 @@ export function resolveClient(options: ResolveContextOptions): OrbitClient {
   const apiKeyFromEnvName =
     mergedFileConfig.apiKeyEnv ? env[mergedFileConfig.apiKeyEnv] : undefined
   // Priority: CLI flag > ORBIT_API_KEY env > apiKeyEnv-indirected env > literal key in config file
-  // apiKeyEnv beats the literal apiKey so operators can inject at runtime without storing in the file
+  // apiKeyEnv lets the config file name a custom env var (e.g. MY_APP_KEY) for environments
+  // where ORBIT_API_KEY is not the standard name.
   const apiKey =
     flags.apiKey ?? env['ORBIT_API_KEY'] ?? apiKeyFromEnvName ?? mergedFileConfig.apiKey
   if (apiKey !== undefined) resolvedConfig.apiKey = apiKey

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -81,15 +81,24 @@ export function resolveClient(options: ResolveContextOptions): OrbitClient {
   const { flags, env = process.env, cwd, overrideHome } = options
 
   // Warn if --api-key appeared in argv (security: key visible in process list)
-  const argvApiKey = process.argv.includes('--api-key')
+  const argvApiKey =
+    process.argv.includes('--api-key') || process.argv.some((a) => a.startsWith('--api-key='))
   if (argvApiKey) {
     process.stderr.write(
-      'Warning: --api-key flag exposes your API key in the process list. Use ORBIT_API_KEY env var instead.\n',
+      'Warning: --api-key is visible in process listings. Prefer ORBIT_API_KEY env var.\n',
     )
-    // Redact from argv
-    const idx = process.argv.indexOf('--api-key')
-    if (idx !== -1 && idx + 1 < process.argv.length) {
-      process.argv[idx + 1] = '[REDACTED]'
+    // Redact from argv — handle both --api-key <value> and --api-key=<value>
+    for (let i = 0; i < process.argv.length; i++) {
+      const arg = process.argv[i] ?? ''
+      if (arg === '--api-key' && i + 1 < process.argv.length) {
+        // Two-token form: --api-key <value>
+        process.argv[i + 1] = '[REDACTED]'
+        break
+      } else if (arg.startsWith('--api-key=')) {
+        // Single-token form: --api-key=<value>
+        process.argv[i] = '--api-key=[REDACTED]'
+        break
+      }
     }
   }
 

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -36,8 +36,15 @@ function resolveAdapter(flags: GlobalFlags, config: OrbitConfig): StorageAdapter
   if (adapterName === 'sqlite') {
     // Validate URL scheme — reject http(s) and anything non-file
     if (dbUrl && /^https?:\/\//i.test(dbUrl)) {
+      let safeUrl = dbUrl
+      try {
+        const parsed = new URL(dbUrl)
+        safeUrl = `${parsed.protocol}//${parsed.hostname}`
+      } catch {
+        safeUrl = '[unparseable]'
+      }
       throw new CliValidationError(
-        `SQLite database URL must be a file path or file: URI, not an HTTP URL: '${dbUrl}'`,
+        `SQLite database URL must be a file path or file: URI, not an HTTP URL. Scheme+host: '${safeUrl}'`,
         { code: 'MISSING_REQUIRED_CONFIG', path: 'databaseUrl' },
       )
     }
@@ -59,9 +66,15 @@ function resolveAdapter(flags: GlobalFlags, config: OrbitConfig): StorageAdapter
 
   if (adapterName === 'postgres') {
     if (!dbUrl || (!dbUrl.startsWith('postgresql://') && !dbUrl.startsWith('postgres://'))) {
+      let safeUrl = dbUrl
+      try {
+        safeUrl = new URL(dbUrl).hostname
+      } catch {
+        safeUrl = '[unparseable]'
+      }
       throw new CliValidationError(
-        `Postgres database URL must start with postgresql:// or postgres://. Got: '${dbUrl}'`,
-        { code: 'MISSING_REQUIRED_CONFIG', path: 'databaseUrl' },
+        `Postgres database URL must use postgresql:// or postgres:// scheme. Host: '${safeUrl}'`,
+        { code: 'INVALID_DATABASE_URL', adapter: 'postgres' },
       )
     }
 
@@ -125,8 +138,8 @@ export function resolveClient(options: ResolveContextOptions): OrbitClient {
   if (databaseUrl !== undefined) resolvedConfig.databaseUrl = databaseUrl
 
   if (mode === 'direct') {
-    // Warn on TTY unless quiet
-    if (process.stdout.isTTY && !flags.quiet) {
+    // Warn unless quiet (emit in all contexts including CI/piped)
+    if (!flags.quiet) {
       process.stderr.write(DIRECT_MODE_WARNING)
     }
 

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -1,0 +1,162 @@
+import { DatabaseSync } from 'node:sqlite'
+import { Pool } from 'pg'
+import {
+  createSqliteStorageAdapter,
+  createPostgresStorageAdapter,
+  SqliteOrbitDatabase,
+  PostgresOrbitDatabase,
+  type StorageAdapter,
+} from '@orbit-ai/core'
+import { OrbitClient } from '@orbit-ai/sdk'
+import { CliValidationError, CliUnsupportedAdapterError } from '../errors.js'
+import { loadConfig, type OrbitConfig } from './files.js'
+import type { GlobalFlags } from '../types.js'
+
+// Direct mode trust boundary — the following middleware protections are NOT active in direct mode:
+// - API key authentication
+// - Rate limiting
+// - Scope enforcement (org isolation is the caller's responsibility)
+// - SSRF protection
+// When using direct mode, ensure the caller is trusted and the database is local.
+
+const DIRECT_MODE_WARNING =
+  'Warning: direct mode bypasses API key authentication, rate limiting, scope enforcement, and SSRF protection. Ensure the caller is trusted and the database is local.\n'
+
+export interface ResolveContextOptions {
+  flags: GlobalFlags
+  env?: NodeJS.ProcessEnv
+  cwd?: string
+  overrideHome?: string
+}
+
+function resolveAdapter(flags: GlobalFlags, config: OrbitConfig): StorageAdapter {
+  const adapterName = flags.adapter ?? config.adapter ?? 'sqlite'
+  const dbUrl = flags.databaseUrl ?? config.databaseUrl ?? ''
+
+  if (adapterName === 'sqlite') {
+    // Validate URL scheme — reject http(s) and anything non-file
+    if (dbUrl && /^https?:\/\//i.test(dbUrl)) {
+      throw new CliValidationError(
+        `SQLite database URL must be a file path or file: URI, not an HTTP URL: '${dbUrl}'`,
+        { code: 'MISSING_REQUIRED_CONFIG', path: 'databaseUrl' },
+      )
+    }
+
+    // Resolve actual file path from file: URI or bare path
+    let dbPath: string
+    if (dbUrl.startsWith('file:')) {
+      dbPath = dbUrl.slice(5)
+    } else {
+      dbPath = dbUrl || ':memory:'
+    }
+
+    const database =
+      dbPath === ':memory:'
+        ? new SqliteOrbitDatabase()
+        : new SqliteOrbitDatabase({ filename: dbPath })
+    return createSqliteStorageAdapter({ database })
+  }
+
+  if (adapterName === 'postgres') {
+    if (!dbUrl || (!dbUrl.startsWith('postgresql://') && !dbUrl.startsWith('postgres://'))) {
+      throw new CliValidationError(
+        `Postgres database URL must start with postgresql:// or postgres://. Got: '${dbUrl}'`,
+        { code: 'MISSING_REQUIRED_CONFIG', path: 'databaseUrl' },
+      )
+    }
+
+    const pool = new Pool({ connectionString: dbUrl })
+    const database = new PostgresOrbitDatabase({ pool })
+    return createPostgresStorageAdapter({ database })
+  }
+
+  if (adapterName === 'supabase' || adapterName === 'neon') {
+    throw new CliUnsupportedAdapterError(adapterName)
+  }
+
+  throw new CliUnsupportedAdapterError(adapterName)
+}
+
+export function resolveClient(options: ResolveContextOptions): OrbitClient {
+  const { flags, env = process.env, cwd, overrideHome } = options
+
+  // Warn if --api-key appeared in argv (security: key visible in process list)
+  const argvApiKey = process.argv.includes('--api-key')
+  if (argvApiKey) {
+    process.stderr.write(
+      'Warning: --api-key flag exposes your API key in the process list. Use ORBIT_API_KEY env var instead.\n',
+    )
+    // Redact from argv
+    const idx = process.argv.indexOf('--api-key')
+    if (idx !== -1 && idx + 1 < process.argv.length) {
+      process.argv[idx + 1] = '[REDACTED]'
+    }
+  }
+
+  // Load config from files
+  const fileConfig = loadConfig(cwd, overrideHome)
+
+  // Resolve effective config: flags > env > project/user config file
+  // Use Object.assign pattern to avoid assigning `undefined` to optional keys
+  // (required by exactOptionalPropertyTypes)
+  const resolvedConfig: OrbitConfig = {}
+  const mode = flags.mode ?? fileConfig.mode ?? 'api'
+  resolvedConfig.mode = mode
+  const apiKey = flags.apiKey ?? env['ORBIT_API_KEY'] ?? fileConfig.apiKey
+  if (apiKey !== undefined) resolvedConfig.apiKey = apiKey
+  const baseUrl = flags.baseUrl ?? env['ORBIT_BASE_URL'] ?? fileConfig.baseUrl
+  if (baseUrl !== undefined) resolvedConfig.baseUrl = baseUrl
+  const orgId = flags.orgId ?? env['ORBIT_ORG_ID'] ?? fileConfig.orgId
+  if (orgId !== undefined) resolvedConfig.orgId = orgId
+  const userId = flags.userId ?? env['ORBIT_USER_ID'] ?? fileConfig.userId
+  if (userId !== undefined) resolvedConfig.userId = userId
+  const adapter = flags.adapter ?? env['ORBIT_ADAPTER'] ?? fileConfig.adapter
+  if (adapter !== undefined) resolvedConfig.adapter = adapter
+  const databaseUrl = flags.databaseUrl ?? env['DATABASE_URL'] ?? fileConfig.databaseUrl
+  if (databaseUrl !== undefined) resolvedConfig.databaseUrl = databaseUrl
+
+  if (mode === 'direct') {
+    // Warn on TTY unless quiet
+    if (process.stdout.isTTY && !flags.quiet) {
+      process.stderr.write(DIRECT_MODE_WARNING)
+    }
+
+    const resolvedOrgId = resolvedConfig.orgId
+    if (!resolvedOrgId) {
+      throw new CliValidationError(
+        'orgId is required in direct mode. Set --org-id or ORBIT_ORG_ID.',
+        { code: 'MISSING_REQUIRED_CONFIG', path: 'context.orgId' },
+      )
+    }
+
+    const resolvedAdapter = resolveAdapter(flags, resolvedConfig)
+
+    return new OrbitClient({
+      adapter: resolvedAdapter,
+      context: {
+        orgId: resolvedOrgId,
+        ...(resolvedConfig.userId ? { userId: resolvedConfig.userId } : {}),
+      },
+    })
+  }
+
+  // API mode
+  const resolvedApiKey = resolvedConfig.apiKey
+  if (!resolvedApiKey) {
+    throw new CliValidationError(
+      'apiKey is required in API mode. Set --api-key or ORBIT_API_KEY.',
+      { code: 'MISSING_REQUIRED_CONFIG', path: 'apiKey' },
+    )
+  }
+
+  const clientOpts: import('@orbit-ai/sdk').OrbitClientOptions = { apiKey: resolvedApiKey }
+  if (baseUrl !== undefined) clientOpts.baseUrl = baseUrl
+  if (resolvedConfig.orgId !== undefined) {
+    const ctxOrgId = resolvedConfig.orgId
+    clientOpts.context = { orgId: ctxOrgId }
+    if (resolvedConfig.userId !== undefined) {
+      clientOpts.context.userId = resolvedConfig.userId
+    }
+  }
+  return new OrbitClient(clientOpts)
+}

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -127,7 +127,10 @@ export function resolveClient(options: ResolveContextOptions): OrbitClient {
   const resolvedConfig: OrbitConfig = {}
   const mode = flags.mode ?? fileConfig.mode ?? 'api'
   resolvedConfig.mode = mode
-  const apiKey = flags.apiKey ?? env['ORBIT_API_KEY'] ?? fileConfig.apiKey
+  const apiKeyFromEnvName =
+    fileConfig.apiKeyEnv ? env[fileConfig.apiKeyEnv] : undefined
+  const apiKey =
+    flags.apiKey ?? env['ORBIT_API_KEY'] ?? fileConfig.apiKey ?? apiKeyFromEnvName
   if (apiKey !== undefined) resolvedConfig.apiKey = apiKey
   const baseUrl = flags.baseUrl ?? env['ORBIT_BASE_URL'] ?? fileConfig.baseUrl
   if (baseUrl !== undefined) resolvedConfig.baseUrl = baseUrl

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,42 @@
+export class CliValidationError extends Error {
+  readonly exitCode = 2
+  constructor(
+    message: string,
+    readonly details?: { code: string; path?: string; [key: string]: unknown },
+  ) {
+    super(message)
+    this.name = 'CliValidationError'
+  }
+}
+
+export class CliConfigError extends Error {
+  readonly exitCode = 3
+  constructor(
+    message: string,
+    readonly details?: { code: string; [key: string]: unknown },
+  ) {
+    super(message)
+    this.name = 'CliConfigError'
+  }
+}
+
+export class CliUnsupportedAdapterError extends CliValidationError {
+  constructor(adapter: string) {
+    super(
+      `Adapter '${adapter}' is not supported. Use 'sqlite' or 'postgres' instead.`,
+      { code: 'UNSUPPORTED_ADAPTER', adapter },
+    )
+    this.name = 'CliUnsupportedAdapterError'
+  }
+}
+
+export class CliNotImplementedError extends Error {
+  readonly exitCode = 2
+  constructor(
+    message: string,
+    readonly details?: { code: string; dependency?: string; [key: string]: unknown },
+  ) {
+    super(message)
+    this.name = 'CliNotImplementedError'
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { run } from './program.js'
+run()

--- a/packages/cli/src/ink/dashboard.tsx
+++ b/packages/cli/src/ink/dashboard.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import { isJsonMode } from '../program.js'
+
+interface DashboardProps {
+  orgName?: string
+  stats?: {
+    contacts: number
+    deals: number
+    openTasks: number
+  }
+}
+
+export function Dashboard({ orgName, stats }: DashboardProps): React.JSX.Element | null {
+  if (isJsonMode() || !process.stdout.isTTY) return null
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold>Orbit AI CRM — {orgName ?? 'Dashboard'}</Text>
+      {stats ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text>Contacts: {stats.contacts}</Text>
+          <Text>Open deals: {stats.deals}</Text>
+          <Text>Open tasks: {stats.openTasks}</Text>
+        </Box>
+      ) : (
+        <Text dimColor>No data</Text>
+      )}
+    </Box>
+  )
+}

--- a/packages/cli/src/ink/pipeline-board.tsx
+++ b/packages/cli/src/ink/pipeline-board.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import { isJsonMode } from '../program.js'
+
+interface Deal {
+  id: string
+  title?: string
+  name?: string
+}
+
+interface Stage {
+  id: string
+  name: string
+  deals: Deal[]
+}
+
+interface PipelineBoardProps {
+  stages: Stage[]
+}
+
+export function PipelineBoard({ stages }: PipelineBoardProps): React.JSX.Element | null {
+  // Guard: do not render in JSON mode or non-TTY
+  if (isJsonMode() || !process.stdout.isTTY) {
+    return null
+  }
+
+  return (
+    <Box flexDirection="row" gap={2}>
+      {stages.map((stage) => (
+        <Box key={stage.id} flexDirection="column" minWidth={20} borderStyle="single">
+          <Text bold>{stage.name}</Text>
+          {stage.deals.length === 0 ? (
+            <Text dimColor>(empty)</Text>
+          ) : (
+            stage.deals.map((deal) => (
+              <Text key={deal.id}>• {deal.title ?? deal.name ?? deal.id}</Text>
+            ))
+          )}
+        </Box>
+      ))}
+    </Box>
+  )
+}

--- a/packages/cli/src/ink/status-panel.tsx
+++ b/packages/cli/src/ink/status-panel.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import { isJsonMode } from '../program.js'
+
+interface StatusCheck {
+  name: string
+  pass: boolean
+  detail?: string
+}
+
+interface StatusPanelProps {
+  checks: StatusCheck[]
+}
+
+export function StatusPanel({ checks }: StatusPanelProps): React.JSX.Element | null {
+  if (isJsonMode() || !process.stdout.isTTY) return null
+
+  return (
+    <Box flexDirection="column">
+      {checks.map((check, i) => (
+        <Box key={i}>
+          <Text color={check.pass ? 'green' : 'red'}>{check.pass ? '✓' : '✗'} </Text>
+          <Text>{check.name}</Text>
+          {check.detail ? <Text dimColor> ({check.detail})</Text> : null}
+        </Box>
+      ))}
+    </Box>
+  )
+}

--- a/packages/cli/src/interactive/autocomplete.ts
+++ b/packages/cli/src/interactive/autocomplete.ts
@@ -1,0 +1,16 @@
+/**
+ * Simple prefix-based fuzzy lookup for interactive mode.
+ * Returns items matching the query prefix (case-insensitive).
+ */
+export function filterByPrefix<T extends { name: string; id: string }>(
+  items: T[],
+  query: string,
+): T[] {
+  const q = query.toLowerCase()
+  return items.filter(
+    (item) =>
+      item.id.toLowerCase().startsWith(q) ||
+      item.name.toLowerCase().startsWith(q) ||
+      item.name.toLowerCase().includes(q),
+  )
+}

--- a/packages/cli/src/interactive/confirm.tsx
+++ b/packages/cli/src/interactive/confirm.tsx
@@ -1,12 +1,21 @@
 import React, { useState } from 'react'
 import { Text, useInput, useApp } from 'ink'
+import { isJsonMode } from '../program.js'
 
 interface ConfirmProps {
   message: string
   onConfirm: (confirmed: boolean) => void
 }
 
-export function Confirm({ message, onConfirm }: ConfirmProps): React.JSX.Element {
+export function Confirm({ message, onConfirm }: ConfirmProps): React.JSX.Element | null {
+  // Guard: skip in JSON mode or non-TTY — must be before any hooks
+  if (isJsonMode() || !process.stdout.isTTY) {
+    return null
+  }
+  return <ConfirmInner message={message} onConfirm={onConfirm} />
+}
+
+function ConfirmInner({ message, onConfirm }: ConfirmProps): React.JSX.Element {
   const [answered, setAnswered] = useState(false)
   const { exit } = useApp()
 

--- a/packages/cli/src/interactive/confirm.tsx
+++ b/packages/cli/src/interactive/confirm.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react'
+import { Text, useInput, useApp } from 'ink'
+
+interface ConfirmProps {
+  message: string
+  onConfirm: (confirmed: boolean) => void
+}
+
+export function Confirm({ message, onConfirm }: ConfirmProps): React.JSX.Element {
+  const [answered, setAnswered] = useState(false)
+  const { exit } = useApp()
+
+  useInput((input, key) => {
+    if (answered) return
+    if (key.return || input.toLowerCase() === 'y') {
+      setAnswered(true)
+      onConfirm(true)
+      exit()
+    } else if (key.escape || input.toLowerCase() === 'n') {
+      setAnswered(true)
+      onConfirm(false)
+      exit()
+    }
+  })
+
+  return <Text>{message} [y/N] </Text>
+}

--- a/packages/cli/src/interactive/prompt.tsx
+++ b/packages/cli/src/interactive/prompt.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Text, Box } from 'ink'
+
+interface PromptProps {
+  label: string
+  onSubmit: (value: string) => void
+  placeholder?: string
+}
+
+// Ink v5 does not include TextInput — display label and hint only.
+// Actual input is collected via readlinePrompt() helper below.
+export function Prompt({ label, placeholder }: PromptProps): React.JSX.Element {
+  return (
+    <Box>
+      <Text>{label}{placeholder ? ` (${placeholder})` : ''}: </Text>
+      {placeholder ? <Text dimColor>{placeholder}</Text> : null}
+    </Box>
+  )
+}
+
+/**
+ * Read a single line from stdin (non-Ink, plain readline).
+ * Only call this in a TTY context.
+ */
+export async function readlinePrompt(question: string): Promise<string> {
+  const { createInterface } = await import('node:readline')
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close()
+      resolve(answer)
+    })
+  })
+}

--- a/packages/cli/src/output/csv.ts
+++ b/packages/cli/src/output/csv.ts
@@ -1,0 +1,75 @@
+/**
+ * CSV formatter (RFC 4180 compliant).
+ * Fields containing commas, double-quotes, or newlines are quoted.
+ * Double-quotes within quoted fields are doubled ("").
+ * TSV: same but tab-delimited. Fields containing literal tabs are stripped
+ * (replaced with a space) since there is no standard tab escape in TSV.
+ */
+
+function csvField(value: unknown, delimiter: string): string {
+  const str =
+    value === null || value === undefined
+      ? ''
+      : typeof value === 'boolean'
+        ? value ? 'yes' : 'no'
+        : typeof value === 'object' && !Array.isArray(value)
+          ? JSON.stringify(value)
+          : Array.isArray(value)
+            ? value.join(', ')
+            : String(value)
+
+  if (delimiter === '\t') {
+    // TSV: strip tab characters (replace with space)
+    const cleaned = str.replace(/\t/g, ' ')
+    // Still quote if contains newlines
+    if (cleaned.includes('\n') || cleaned.includes('"')) {
+      return '"' + cleaned.replace(/"/g, '""') + '"'
+    }
+    return cleaned
+  }
+
+  // CSV: quote if contains delimiter, double-quote, or newline
+  if (str.includes(delimiter) || str.includes('"') || str.includes('\n')) {
+    return '"' + str.replace(/"/g, '""') + '"'
+  }
+  return str
+}
+
+function flattenRecord(record: Record<string, unknown>): Record<string, unknown> {
+  const flat: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(record)) {
+    if (key === 'custom_fields' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      for (const [cfKey, cfValue] of Object.entries(value)) {
+        flat[`custom_fields.${cfKey}`] = cfValue
+      }
+    } else {
+      flat[key] = value
+    }
+  }
+  return flat
+}
+
+function formatDelimited(records: Record<string, unknown>[], delimiter: string): string {
+  if (records.length === 0) return ''
+
+  const flattened = records.map(flattenRecord)
+  const firstRecord = flattened[0]
+  if (firstRecord === undefined) return ''
+  const headers = Object.keys(firstRecord)
+
+  const lines: string[] = []
+  lines.push(headers.map((h) => csvField(h, delimiter)).join(delimiter))
+  for (const record of flattened) {
+    lines.push(headers.map((h) => csvField(record[h], delimiter)).join(delimiter))
+  }
+
+  return lines.join('\r\n') + '\r\n'
+}
+
+export function formatCsv(records: Record<string, unknown>[]): string {
+  return formatDelimited(records, ',')
+}
+
+export function formatTsv(records: Record<string, unknown>[]): string {
+  return formatDelimited(records, '\t')
+}

--- a/packages/cli/src/output/formatter.ts
+++ b/packages/cli/src/output/formatter.ts
@@ -1,0 +1,40 @@
+import { formatJson } from './json.js'
+import { formatTable } from './table.js'
+import { formatCsv, formatTsv } from './csv.js'
+import type { OutputFormat } from './types.js'
+
+export type { OutputFormat }
+
+export function formatOutput(
+  data: unknown,
+  options: { format: OutputFormat },
+): string {
+  const { format } = options
+
+  if (format === 'json') {
+    return formatJson(data)
+  }
+
+  // For table/csv/tsv, extract records from envelope or use as-is
+  const records = extractRecords(data)
+
+  if (format === 'table') return formatTable(records)
+  if (format === 'csv') return formatCsv(records)
+  if (format === 'tsv') return formatTsv(records)
+
+  return formatJson(data)
+}
+
+function extractRecords(data: unknown): Record<string, unknown>[] {
+  if (Array.isArray(data)) return data as Record<string, unknown>[]
+  if (data !== null && typeof data === 'object') {
+    const obj = data as Record<string, unknown>
+    if (Array.isArray(obj.data)) return obj.data as Record<string, unknown>[]
+    // Single record envelope
+    if (obj.data !== undefined && typeof obj.data === 'object') {
+      return [obj.data as Record<string, unknown>]
+    }
+    return [obj]
+  }
+  return []
+}

--- a/packages/cli/src/output/json.ts
+++ b/packages/cli/src/output/json.ts
@@ -1,0 +1,3 @@
+export function formatJson(data: unknown): string {
+  return JSON.stringify(data, null, 2) + '\n'
+}

--- a/packages/cli/src/output/table.ts
+++ b/packages/cli/src/output/table.ts
@@ -1,0 +1,25 @@
+import Table from 'cli-table3'
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'boolean') return value ? 'yes' : 'no'
+  if (Array.isArray(value)) return value.join(', ')
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+export function formatTable(records: Record<string, unknown>[]): string {
+  if (records.length === 0) return '(no records)\n'
+
+  const firstRecord = records[0]
+  if (firstRecord === undefined) return '(no records)\n'
+  const headers = Object.keys(firstRecord)
+  const table = new Table({ head: headers })
+
+  for (const record of records) {
+    table.push(headers.map((h) => formatValue(record[h])))
+  }
+
+  return table.toString() + '\n'
+}

--- a/packages/cli/src/output/types.ts
+++ b/packages/cli/src/output/types.ts
@@ -1,0 +1,5 @@
+export type OutputFormat = 'table' | 'json' | 'csv' | 'tsv'
+
+export interface FormatOptions {
+  format: OutputFormat
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -29,6 +29,8 @@ import { registerSchemaCommand } from './commands/schema.js'
 import { registerFieldsCommand } from './commands/fields.js'
 import { registerReportCommand } from './commands/report.js'
 import { registerDashboardCommand } from './commands/dashboard.js'
+import { registerMcpCommand } from './commands/mcp.js'
+import { registerIntegrationsCommand } from './commands/integrations.js'
 
 let _jsonMode = false
 
@@ -153,16 +155,10 @@ export function createProgram(): Command {
   registerFieldsCommand(program)
   registerReportCommand(program)
   registerDashboardCommand(program)
-  registerStubCommand(program, 'mcp', 'MCP server commands')
-  registerStubCommand(program, 'integrations', 'Integration commands')
+  registerMcpCommand(program)
+  registerIntegrationsCommand(program)
 
   return program
-}
-
-function registerStubCommand(program: Command, name: string, description: string): void {
-  program.command(name).description(description).allowUnknownOption(true).action(() => {
-    // Stub — will be replaced by actual implementation in later slices
-  })
 }
 
 export async function run(): Promise<void> {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -77,6 +77,21 @@ function classifyError(error: unknown): { code: number; payload: Record<string, 
       },
     }
   }
+  // Commander parse/validation errors (exitOverride surfaces these as CommanderError)
+  if (
+    error instanceof Error &&
+    error.constructor.name === 'CommanderError' &&
+    'exitCode' in error
+  ) {
+    const ce = error as { exitCode: number; code?: string; message: string }
+    return {
+      code: ce.exitCode === 0 ? 0 : 2,
+      payload: {
+        code: ce.code ?? 'COMMANDER_ERROR',
+        message: ce.message,
+      },
+    }
+  }
   // OrbitApiError and HTTP errors → exit code 1
   if (
     error instanceof Error &&
@@ -178,6 +193,7 @@ export async function run(): Promise<void> {
 
   try {
     const program = createProgram()
+    program.exitOverride()
     await program.parseAsync(process.argv)
     process.exit(0)
   } catch (error) {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -165,10 +165,16 @@ export function createProgram(): Command {
 }
 
 export async function run(): Promise<void> {
-  // Handle SIGINT
-  process.once('SIGINT', () => {
-    process.exit(130)
-  })
+  process.once('SIGINT', () => { process.exit(130) })
+
+  // Detect JSON mode from argv before preAction hook can fire
+  // (preAction only fires if Commander reaches the command — parse errors fire before it)
+  const argvHasJson =
+    process.argv.includes('--json') ||
+    process.argv.includes('--format=json') ||
+    (process.argv.includes('--format') &&
+      process.argv[process.argv.indexOf('--format') + 1] === 'json')
+  if (argvHasJson) _jsonMode = true
 
   try {
     const program = createProgram()

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -14,6 +14,20 @@ import { registerPipelinesCommand } from './commands/pipelines.js'
 import { registerStagesCommand } from './commands/stages.js'
 import { registerContextCommand } from './commands/context.js'
 import { registerSearchCommand } from './commands/search.js'
+import { registerActivitiesCommand } from './commands/activities.js'
+import { registerTasksCommand } from './commands/tasks.js'
+import { registerNotesCommand } from './commands/notes.js'
+import { registerProductsCommand } from './commands/products.js'
+import { registerPaymentsCommand } from './commands/payments.js'
+import { registerContractsCommand } from './commands/contracts.js'
+import { registerSequencesCommand } from './commands/sequences.js'
+import { registerTagsCommand } from './commands/tags.js'
+import { registerWebhooksCommand } from './commands/webhooks.js'
+import { registerImportsCommand } from './commands/imports.js'
+import { registerLogCommand } from './commands/log.js'
+import { registerSchemaCommand } from './commands/schema.js'
+import { registerFieldsCommand } from './commands/fields.js'
+import { registerReportCommand } from './commands/report.js'
 
 let _jsonMode = false
 
@@ -123,13 +137,20 @@ export function createProgram(): Command {
   registerStagesCommand(program)
   registerContextCommand(program)
   registerSearchCommand(program)
-  registerStubCommand(program, 'log', 'Log an activity (call, email, meeting, note)')
-  registerStubCommand(program, 'tasks', 'Manage tasks')
-  registerStubCommand(program, 'notes', 'Manage notes')
-  registerStubCommand(program, 'sequences', 'Manage and enroll contacts in sequences')
-  registerStubCommand(program, 'fields', 'Manage custom fields')
-  registerStubCommand(program, 'schema', 'Manage CRM schema')
-  registerStubCommand(program, 'report', 'Generate reports')
+  registerActivitiesCommand(program)
+  registerTasksCommand(program)
+  registerNotesCommand(program)
+  registerProductsCommand(program)
+  registerPaymentsCommand(program)
+  registerContractsCommand(program)
+  registerSequencesCommand(program)
+  registerTagsCommand(program)
+  registerWebhooksCommand(program)
+  registerImportsCommand(program)
+  registerLogCommand(program)
+  registerSchemaCommand(program)
+  registerFieldsCommand(program)
+  registerReportCommand(program)
   registerStubCommand(program, 'dashboard', 'Interactive dashboard')
   registerStubCommand(program, 'mcp', 'MCP server commands')
   registerStubCommand(program, 'integrations', 'Integration commands')

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,0 +1,135 @@
+import { Command } from 'commander'
+import { CliValidationError, CliConfigError, CliUnsupportedAdapterError } from './errors.js'
+import type { GlobalFlags } from './types.js'
+
+let _jsonMode = false
+
+export function isJsonMode(): boolean {
+  return _jsonMode
+}
+
+function classifyError(error: unknown): { code: number; payload: Record<string, unknown> } {
+  if (error instanceof CliValidationError || error instanceof CliUnsupportedAdapterError) {
+    return {
+      code: 2,
+      payload: {
+        code: error.details?.code ?? 'VALIDATION_ERROR',
+        message: error.message,
+        ...error.details,
+      },
+    }
+  }
+  if (error instanceof CliConfigError) {
+    return {
+      code: 3,
+      payload: {
+        code: error.details?.code ?? 'CONFIG_ERROR',
+        message: error.message,
+        ...error.details,
+      },
+    }
+  }
+  // OrbitApiError and HTTP errors → exit code 1
+  if (
+    error instanceof Error &&
+    (error.name === 'OrbitApiError' || (error as { statusCode?: number }).statusCode !== undefined)
+  ) {
+    const e = error as { statusCode?: number; code?: string; requestId?: string }
+    return {
+      code: 1,
+      payload: {
+        code: e.code ?? 'API_ERROR',
+        message: error.message,
+        ...(e.requestId ? { request_id: e.requestId } : {}),
+      },
+    }
+  }
+  // Generic error → exit code 1
+  return {
+    code: 1,
+    payload: {
+      code: 'UNKNOWN_ERROR',
+      message: error instanceof Error ? error.message : String(error),
+    },
+  }
+}
+
+function formatErrorForHuman(payload: Record<string, unknown>): string {
+  return `Error [${payload.code}]: ${payload.message}`
+}
+
+export function createProgram(): Command {
+  const program = new Command()
+  program
+    .name('orbit')
+    .description('Orbit AI CRM terminal interface')
+    .version('0.1.0-alpha.0')
+    .option('--json', 'Output as JSON envelope')
+    .option('--format <format>', 'Output format: table|json|csv|tsv', 'table')
+    .option('--api-key <key>', 'Orbit API key (prefer ORBIT_API_KEY env var)')
+    .option('--base-url <url>', 'Orbit API base URL')
+    .option('--org-id <id>', 'Organization ID')
+    .option('--user-id <id>', 'User ID')
+    .option('--database-url <url>', 'Database URL (direct mode)')
+    .option('--adapter <type>', 'Storage adapter: sqlite|postgres (direct mode)')
+    .option('--mode <mode>', 'Client mode: api|direct', 'api')
+    .option('--profile <name>', 'Config profile name')
+    .option('--quiet', 'Suppress warnings')
+    .option('--yes', 'Skip interactive confirmations (bypass for --yes flag)')
+    .hook('preAction', (thisCommand) => {
+      const opts = thisCommand.opts<GlobalFlags & { json?: boolean }>()
+      _jsonMode = opts.json === true || opts.format === 'json'
+    })
+
+  // Register all command groups (stubs — commands will be filled in later slices)
+  registerStubCommand(program, 'init', 'Scaffold .orbit/config.json and .env.example')
+  registerStubCommand(program, 'status', 'Show connection and config status')
+  registerStubCommand(program, 'doctor', 'Run environment diagnostics')
+  registerStubCommand(program, 'seed', 'Seed the database with example data')
+  registerStubCommand(program, 'migrate', 'Run schema migrations')
+  registerStubCommand(program, 'contacts', 'Manage contacts')
+  registerStubCommand(program, 'companies', 'Manage companies')
+  registerStubCommand(program, 'deals', 'Manage deals')
+  registerStubCommand(program, 'context', 'Show full CRM context for a contact')
+  registerStubCommand(program, 'search', 'Search across CRM entities')
+  registerStubCommand(program, 'users', 'Manage users')
+  registerStubCommand(program, 'log', 'Log an activity (call, email, meeting, note)')
+  registerStubCommand(program, 'tasks', 'Manage tasks')
+  registerStubCommand(program, 'notes', 'Manage notes')
+  registerStubCommand(program, 'sequences', 'Manage and enroll contacts in sequences')
+  registerStubCommand(program, 'fields', 'Manage custom fields')
+  registerStubCommand(program, 'schema', 'Manage CRM schema')
+  registerStubCommand(program, 'report', 'Generate reports')
+  registerStubCommand(program, 'dashboard', 'Interactive dashboard')
+  registerStubCommand(program, 'mcp', 'MCP server commands')
+  registerStubCommand(program, 'integrations', 'Integration commands')
+
+  return program
+}
+
+function registerStubCommand(program: Command, name: string, description: string): void {
+  program.command(name).description(description).allowUnknownOption(true).action(() => {
+    // Stub — will be replaced by actual implementation in later slices
+  })
+}
+
+export async function run(): Promise<void> {
+  // Handle SIGINT
+  process.on('SIGINT', () => {
+    process.exit(130)
+  })
+
+  try {
+    const program = createProgram()
+    await program.parseAsync(process.argv)
+    process.exit(0)
+  } catch (error) {
+    const { code, payload } = classifyError(error)
+    if (isJsonMode()) {
+      process.stdout.write(JSON.stringify({ error: payload }) + '\n')
+    } else {
+      process.stderr.write(formatErrorForHuman(payload) + '\n')
+    }
+    process.exit(code)
+  }
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,6 +1,11 @@
 import { Command } from 'commander'
 import { CliValidationError, CliConfigError, CliNotImplementedError } from './errors.js'
 import type { GlobalFlags } from './types.js'
+import { registerInitCommand } from './commands/init.js'
+import { registerStatusCommand } from './commands/status.js'
+import { registerDoctorCommand } from './commands/doctor.js'
+import { registerSeedCommand } from './commands/seed.js'
+import { registerMigrateCommand } from './commands/migrate.js'
 
 let _jsonMode = false
 
@@ -96,12 +101,12 @@ export function createProgram(): Command {
       _jsonMode = opts.json === true || opts.format === 'json'
     })
 
-  // Register all command groups (stubs — commands will be filled in later slices)
-  registerStubCommand(program, 'init', 'Scaffold .orbit/config.json and .env.example')
-  registerStubCommand(program, 'status', 'Show connection and config status')
-  registerStubCommand(program, 'doctor', 'Run environment diagnostics')
-  registerStubCommand(program, 'seed', 'Seed the database with example data')
-  registerStubCommand(program, 'migrate', 'Run schema migrations')
+  // Register all command groups
+  registerInitCommand(program)
+  registerStatusCommand(program)
+  registerDoctorCommand(program)
+  registerSeedCommand(program)
+  registerMigrateCommand(program)
   registerStubCommand(program, 'contacts', 'Manage contacts')
   registerStubCommand(program, 'companies', 'Manage companies')
   registerStubCommand(program, 'deals', 'Manage deals')

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -28,6 +28,7 @@ import { registerLogCommand } from './commands/log.js'
 import { registerSchemaCommand } from './commands/schema.js'
 import { registerFieldsCommand } from './commands/fields.js'
 import { registerReportCommand } from './commands/report.js'
+import { registerDashboardCommand } from './commands/dashboard.js'
 
 let _jsonMode = false
 
@@ -151,7 +152,7 @@ export function createProgram(): Command {
   registerSchemaCommand(program)
   registerFieldsCommand(program)
   registerReportCommand(program)
-  registerStubCommand(program, 'dashboard', 'Interactive dashboard')
+  registerDashboardCommand(program)
   registerStubCommand(program, 'mcp', 'MCP server commands')
   registerStubCommand(program, 'integrations', 'Integration commands')
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -6,6 +6,14 @@ import { registerStatusCommand } from './commands/status.js'
 import { registerDoctorCommand } from './commands/doctor.js'
 import { registerSeedCommand } from './commands/seed.js'
 import { registerMigrateCommand } from './commands/migrate.js'
+import { registerContactsCommand } from './commands/contacts.js'
+import { registerCompaniesCommand } from './commands/companies.js'
+import { registerDealsCommand } from './commands/deals.js'
+import { registerUsersCommand } from './commands/users.js'
+import { registerPipelinesCommand } from './commands/pipelines.js'
+import { registerStagesCommand } from './commands/stages.js'
+import { registerContextCommand } from './commands/context.js'
+import { registerSearchCommand } from './commands/search.js'
 
 let _jsonMode = false
 
@@ -107,12 +115,14 @@ export function createProgram(): Command {
   registerDoctorCommand(program)
   registerSeedCommand(program)
   registerMigrateCommand(program)
-  registerStubCommand(program, 'contacts', 'Manage contacts')
-  registerStubCommand(program, 'companies', 'Manage companies')
-  registerStubCommand(program, 'deals', 'Manage deals')
-  registerStubCommand(program, 'context', 'Show full CRM context for a contact')
-  registerStubCommand(program, 'search', 'Search across CRM entities')
-  registerStubCommand(program, 'users', 'Manage users')
+  registerContactsCommand(program)
+  registerCompaniesCommand(program)
+  registerDealsCommand(program)
+  registerUsersCommand(program)
+  registerPipelinesCommand(program)
+  registerStagesCommand(program)
+  registerContextCommand(program)
+  registerSearchCommand(program)
   registerStubCommand(program, 'log', 'Log an activity (call, email, meeting, note)')
   registerStubCommand(program, 'tasks', 'Manage tasks')
   registerStubCommand(program, 'notes', 'Manage notes')

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -43,6 +43,9 @@ export function _resetJsonMode(): void {
   _jsonMode = false
 }
 
+// test-only export
+export { classifyError as _classifyError }
+
 function classifyError(error: unknown): { code: number; payload: Record<string, unknown> } {
   if (error instanceof CliNotImplementedError) {
     return {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -33,6 +33,7 @@ import { registerMcpCommand } from './commands/mcp.js'
 import { registerIntegrationsCommand } from './commands/integrations.js'
 
 let _jsonMode = false
+let _sigintHandler: (() => void) | null = null
 
 export function isJsonMode(): boolean {
   return _jsonMode
@@ -176,7 +177,9 @@ export function createProgram(): Command {
 
 export async function run(): Promise<void> {
   _jsonMode = false  // reset from any previous invocation
-  process.once('SIGINT', () => { process.exit(130) })
+  if (_sigintHandler) process.removeListener('SIGINT', _sigintHandler)
+  _sigintHandler = () => { process.exit(130) }
+  process.once('SIGINT', _sigintHandler)
 
   // Detect JSON mode from argv before preAction hook can fire
   // (preAction only fires if Commander reaches the command — parse errors fire before it)

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { CliValidationError, CliConfigError, CliUnsupportedAdapterError } from './errors.js'
+import { CliValidationError, CliConfigError, CliNotImplementedError } from './errors.js'
 import type { GlobalFlags } from './types.js'
 
 let _jsonMode = false
@@ -8,8 +8,23 @@ export function isJsonMode(): boolean {
   return _jsonMode
 }
 
+// test-only
+export function _resetJsonMode(): void {
+  _jsonMode = false
+}
+
 function classifyError(error: unknown): { code: number; payload: Record<string, unknown> } {
-  if (error instanceof CliValidationError || error instanceof CliUnsupportedAdapterError) {
+  if (error instanceof CliNotImplementedError) {
+    return {
+      code: 2,
+      payload: {
+        code: error.details?.code ?? 'NOT_IMPLEMENTED',
+        message: error.message,
+        ...error.details,
+      },
+    }
+  }
+  if (error instanceof CliValidationError) {
     return {
       code: 2,
       payload: {
@@ -115,7 +130,7 @@ function registerStubCommand(program: Command, name: string, description: string
 
 export async function run(): Promise<void> {
   // Handle SIGINT
-  process.on('SIGINT', () => {
+  process.once('SIGINT', () => {
     process.exit(130)
   })
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander'
+import { Command, CommanderError } from 'commander'
 import { CliValidationError, CliConfigError, CliNotImplementedError } from './errors.js'
 import type { GlobalFlags } from './types.js'
 import { registerInitCommand } from './commands/init.js'
@@ -78,17 +78,12 @@ function classifyError(error: unknown): { code: number; payload: Record<string, 
     }
   }
   // Commander parse/validation errors (exitOverride surfaces these as CommanderError)
-  if (
-    error instanceof Error &&
-    error.constructor.name === 'CommanderError' &&
-    'exitCode' in error
-  ) {
-    const ce = error as { exitCode: number; code?: string; message: string }
+  if (error instanceof CommanderError) {
     return {
-      code: ce.exitCode === 0 ? 0 : 2,
+      code: error.exitCode === 0 ? 0 : 2,
       payload: {
-        code: ce.code ?? 'COMMANDER_ERROR',
-        message: ce.message,
+        code: error.code ?? 'COMMANDER_ERROR',
+        message: error.message,
       },
     }
   }
@@ -180,6 +175,7 @@ export function createProgram(): Command {
 }
 
 export async function run(): Promise<void> {
+  _jsonMode = false  // reset from any previous invocation
   process.once('SIGINT', () => { process.exit(130) })
 
   // Detect JSON mode from argv before preAction hook can fire

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,16 @@
+export type OutputFormat = 'table' | 'json' | 'csv' | 'tsv'
+
+export interface GlobalFlags {
+  json?: boolean
+  format?: OutputFormat
+  apiKey?: string
+  baseUrl?: string
+  orgId?: string
+  userId?: string
+  databaseUrl?: string
+  adapter?: string
+  mode?: 'api' | 'direct'
+  profile?: string
+  quiet?: boolean
+  yes?: boolean
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,3 +1,5 @@
+import type { OrbitClient } from '@orbit-ai/sdk'
+
 export type OutputFormat = 'table' | 'json' | 'csv' | 'tsv'
 
 export interface GlobalFlags {
@@ -13,4 +15,10 @@ export interface GlobalFlags {
   profile?: string
   quiet?: boolean
   yes?: boolean
+}
+
+export interface ResolvedContext {
+  client: OrbitClient
+  flags: GlobalFlags
+  format: OutputFormat
 }

--- a/packages/cli/src/utils/prompt.ts
+++ b/packages/cli/src/utils/prompt.ts
@@ -1,0 +1,22 @@
+/**
+ * Prompt the user for a yes/no confirmation on stderr.
+ * Returns true for 'y', false for anything else (including stdin EOF).
+ * Cleans up all stdin listeners after resolution to prevent event-listener leaks.
+ */
+export async function confirmAction(prompt: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    process.stderr.write(prompt)
+    process.stdin.setEncoding('utf8')
+    const onData = (data: Buffer | string) => { cleanup(); resolve(data.toString().trim().toLowerCase() === 'y') }
+    const onEnd = () => { cleanup(); resolve(false) }
+    const onError = (err: Error) => { cleanup(); reject(err) }
+    const cleanup = () => {
+      process.stdin.removeListener('data', onData)
+      process.stdin.removeListener('end', onEnd)
+      process.stdin.removeListener('error', onError)
+    }
+    process.stdin.once('data', onData)
+    process.stdin.once('end', onEnd)
+    process.stdin.once('error', onError)
+  })
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
-    exclude: ['src/**/*.smoke.test.ts'],
+    exclude: ['src/**/*.smoke.test.ts', 'src/__tests__/smoke.test.ts'],
     setupFiles: ['src/__tests__/setup.ts'],
     coverage: { enabled: false },
   },

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    exclude: ['src/**/*.smoke.test.ts'],
+    setupFiles: ['src/__tests__/setup.ts'],
+    coverage: { enabled: false },
+  },
+})

--- a/packages/cli/vitest.smoke.config.ts
+++ b/packages/cli/vitest.smoke.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+// Separate config for smoke tests — runs the compiled binary as a subprocess.
+// Usage: pnpm --filter @orbit-ai/cli exec vitest run --config vitest.smoke.config.ts
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/smoke.test.ts'],
+    setupFiles: [],
+    coverage: { enabled: false },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,37 @@ importers:
         specifier: ^4.1.11
         version: 4.3.6
 
+  packages/cli:
+    dependencies:
+      '@orbit-ai/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      cli-table3:
+        specifier: ^0.6.0
+        version: 0.6.5
+      commander:
+        specifier: ^12.0.0
+        version: 12.1.0
+      ink:
+        specifier: ^5.0.0
+        version: 5.2.1(@types/react@18.3.28)(react@18.3.1)
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+    devDependencies:
+      '@types/react':
+        specifier: ^18.0.0
+        version: 18.3.28
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.12.0)(tsx@4.21.0)
+
   packages/core:
     dependencies:
       drizzle-orm:
@@ -87,6 +118,14 @@ importers:
         version: link:../core
 
 packages:
+
+  '@alcalzone/ansi-tokenize@0.1.3':
+    resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
+    engines: {node: '>=14.13.1'}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -417,6 +456,12 @@ packages:
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react@18.3.28':
+    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -446,9 +491,29 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -470,12 +535,47 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -599,6 +699,16 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -614,10 +724,17 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -645,6 +762,10 @@ packages:
 
   functional-red-black-tree@1.0.1:
     resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -679,8 +800,45 @@ packages:
   immutable@4.3.8:
     resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
+  ink@5.2.1:
+    resolution: {integrity: sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
+      react-devtools-core: ^4.19.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  is-in-ci@1.0.0:
+    resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -691,6 +849,10 @@ packages:
 
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -705,6 +867,10 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
@@ -731,6 +897,14 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -845,8 +1019,22 @@ packages:
     resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
     engines: {node: '>=0.12'}
 
+  react-reconciler@0.29.2:
+    resolution: {integrity: sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^18.3.1
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   ret@0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
@@ -857,12 +1045,26 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -872,11 +1074,31 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -911,6 +1133,10 @@ packages:
   turbo@2.9.1:
     resolution: {integrity: sha512-TO9du8MwLTAKoXcGezekh9cPJabJUb0+8KxtpMR6kXdRASrmJ8qXf2GkVbCREgzbMQakzfNcux9cZtxheDY4RQ==}
     hasBin: true
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1002,6 +1228,26 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@5.0.0:
+    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
+    engines: {node: '>=18'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -1009,10 +1255,21 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@alcalzone/ansi-tokenize@0.1.3':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
@@ -1206,6 +1463,13 @@ snapshots:
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react@18.3.28':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1248,7 +1512,19 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
   assertion-error@2.0.1: {}
+
+  auto-bind@5.0.1: {}
 
   cac@6.7.14: {}
 
@@ -1277,9 +1553,38 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk@5.6.2: {}
+
   check-error@2.1.3: {}
 
+  cli-boxes@3.0.0: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
+  cli-truncate@4.0.0:
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
+
+  commander@12.1.0: {}
+
   commander@2.20.3: {}
+
+  convert-to-spaces@2.0.1: {}
+
+  csstype@3.2.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -1311,6 +1616,12 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  environment@1.1.0: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -1320,6 +1631,8 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.45.1: {}
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -1350,6 +1663,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
+  escape-string-regexp@2.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -1366,6 +1681,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   functional-red-black-tree@1.0.1: {}
+
+  get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -1405,7 +1722,54 @@ snapshots:
 
   immutable@4.3.8: {}
 
+  indent-string@5.0.0: {}
+
+  ink@5.2.1(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.1.3
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      cli-cursor: 4.0.0
+      cli-truncate: 4.0.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.45.1
+      indent-string: 5.0.0
+      is-in-ci: 1.0.0
+      patch-console: 2.0.0
+      react: 18.3.1
+      react-reconciler: 0.29.2(react@18.3.1)
+      scheduler: 0.23.2
+      signal-exit: 3.0.7
+      slice-ansi: 7.1.2
+      stack-utils: 2.0.6
+      string-width: 7.2.0
+      type-fest: 4.41.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.2
+      ws: 8.20.0
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@4.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+
+  is-in-ci@1.0.0: {}
+
   isarray@2.0.5: {}
+
+  js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
 
@@ -1419,6 +1783,10 @@ snapshots:
 
   jsonify@0.0.1: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
 
   lru-cache@6.0.0:
@@ -1430,6 +1798,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mimic-fn@2.1.0: {}
 
   moment@2.30.1: {}
 
@@ -1449,6 +1819,12 @@ snapshots:
   object-hash@2.2.0: {}
 
   object-keys@1.1.1: {}
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  patch-console@2.0.0: {}
 
   pathe@2.0.3: {}
 
@@ -1531,7 +1907,22 @@ snapshots:
       discontinuous-range: 1.0.0
       ret: 0.1.15
 
+  react-reconciler@0.29.2(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   resolve-pkg-maps@1.0.0: {}
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   ret@0.1.15: {}
 
@@ -1566,6 +1957,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -1577,13 +1972,49 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
+  slice-ansi@5.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   source-map-js@1.2.1: {}
 
   split2@4.2.0: {}
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-literal@3.1.0:
     dependencies:
@@ -1619,6 +2050,8 @@ snapshots:
       '@turbo/linux-arm64': 2.9.1
       '@turbo/windows-64': 2.9.1
       '@turbo/windows-arm64': 2.9.1
+
+  type-fest@4.41.0: {}
 
   typescript@5.9.3: {}
 
@@ -1706,8 +2139,22 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@5.0.0:
+    dependencies:
+      string-width: 7.2.0
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  ws@8.20.0: {}
+
   xtend@4.0.2: {}
 
   yallist@4.0.0: {}
+
+  yoga-layout@3.2.1: {}
 
   zod@4.3.6: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@orbit-ai/core':
+        specifier: workspace:*
+        version: link:../core
       '@orbit-ai/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -69,10 +72,16 @@ importers:
       ink:
         specifier: ^5.0.0
         version: 5.2.1(@types/react@18.3.28)(react@18.3.1)
+      pg:
+        specifier: ^8.11.0
+        version: 8.20.0
       react:
         specifier: ^18.0.0
         version: 18.3.1
     devDependencies:
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.20.0
       '@types/react':
         specifier: ^18.0.0
         version: 18.3.28


### PR DESCRIPTION
## Summary

Adds `@orbit-ai/cli` (`packages/cli`) — the terminal interface for Orbit AI CRM.

- **30 commands** across all CRM entities (contacts, companies, deals, pipelines, stages, users, activities, tasks, notes, products, payments, contracts, sequences, tags, webhooks, imports, schema, fields, log, search, context, report, dashboard, mcp stub, integrations stub, init, status, doctor, seed, migrate)
- **Dual mode**: API mode (HTTP via `@orbit-ai/sdk`) and direct SQLite mode (local adapter)
- **Structured JSON contract** throughout: `{ error: { code, message } }` on all failure paths, `--json` / `--format json` unified via `isJsonMode()`
- **Config resolution**: project `.orbit/config.json` + user `~/.config/orbit/config.json`, nested-cwd discovery, `--profile` named profiles, `apiKeyEnv` runtime key injection
- **Security**: `--api-key` argv redaction, 0600 config file permissions, `file://` URI hostname rejection, URL scheme allowlist, direct-mode trust-boundary warning
- **Interactive UX**: Ink-based dashboard, TTY confirmation prompts via `utils/prompt.ts` (stdin EOF/error safe), `--yes` flag for CI/non-interactive
- **161 tests** across 17 files — 4 rounds of code review (Codex + 3 agent-panel rounds with 6 reviewers each)

## Key fixes from review rounds

- `exitOverride()` + `instanceof CommanderError` — parse errors flow through JSON contract
- All 20 command files: `flags.json` → `isJsonMode()` — `--format json` activates JSON envelope path
- `_jsonMode` reset at start of `run()` — safe for repeated invocations
- `apiKeyEnv` config field resolved at runtime (priority: flag > `ORBIT_API_KEY` > apiKeyEnv > literal)
- `ancestorRoots` helper — config discovery works from any nested subdirectory
- `ProfileConfig = Omit<OrbitConfig, 'profiles'|'profile'>` — prevents recursive profile nesting
- `file://hostname/` rejection + malformed `file:` URI throws explicit error
- `confirmAction` extracted to `utils/prompt.ts` — stdin EOF/error safe, deduped between migrate + fields
- `migrate --apply` previews first, gates only on `preview.destructive` flag (not regex)
- `migrate` no-flags guard — throws `MISSING_REQUIRED_ARG` instead of silent return
- `seed` count validated (int 1–1000); effective mode from config, not just `flags.mode`
- Synchronous `write + exit` throughout — eliminates callback-race exit code bugs
- `SIGINT` handler deduped across `run()` calls — no `MaxListenersExceededWarning`

## Test plan

- [ ] `pnpm --filter @orbit-ai/cli test` — 161 passing
- [ ] `pnpm --filter @orbit-ai/cli typecheck` — 0 errors
- [ ] `pnpm --filter @orbit-ai/cli build` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)