### PR TITLE
feat: SDK/MCP/CLI prerequisite seams for integrations

### DIFF
--- a/packages/cli/src/__tests__/integrations.test.ts
+++ b/packages/cli/src/__tests__/integrations.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { Command } from 'commander'
+import { registerIntegrationSubcommands, registerIntegrationsCommand } from '../commands/integrations.js'
+import { createProgram } from '../program.js'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('registerIntegrationSubcommands', () => {
+  it('registers two plugins as subcommands under integrations', () => {
+    const program = new Command()
+    const action1 = vi.fn()
+    const action2 = vi.fn()
+
+    registerIntegrationSubcommands(program, [
+      { name: 'gmail', description: 'Gmail integration', action: action1 },
+      { name: 'google-calendar', description: 'Google Calendar integration', action: action2 },
+    ])
+
+    const integrationsCmd = program.commands.find((c) => c.name() === 'integrations')
+    expect(integrationsCmd).toBeDefined()
+
+    const subNames = integrationsCmd!.commands.map((c) => c.name())
+    expect(subNames).toContain('gmail')
+    expect(subNames).toContain('google-calendar')
+  })
+
+  it('registers plugin options on the subcommand', () => {
+    const program = new Command()
+
+    registerIntegrationSubcommands(program, [
+      {
+        name: 'stripe',
+        description: 'Stripe integration',
+        action: vi.fn(),
+        options: [
+          { flags: '--webhook-secret <secret>', description: 'Stripe webhook secret' },
+          { flags: '--live', description: 'Use live mode', defaultValue: false },
+        ],
+      },
+    ])
+
+    const integrationsCmd = program.commands.find((c) => c.name() === 'integrations')
+    const stripeCmd = integrationsCmd?.commands.find((c) => c.name() === 'stripe')
+    expect(stripeCmd).toBeDefined()
+
+    const optionFlags = stripeCmd!.options.map((o) => o.flags)
+    expect(optionFlags).toContain('--webhook-secret <secret>')
+    expect(optionFlags).toContain('--live')
+  })
+
+  it('with empty plugins array registers the parent command with no subcommands', () => {
+    const program = new Command()
+
+    registerIntegrationSubcommands(program, [])
+
+    const integrationsCmd = program.commands.find((c) => c.name() === 'integrations')
+    expect(integrationsCmd).toBeDefined()
+    expect(integrationsCmd!.commands).toHaveLength(0)
+  })
+
+  it('calls the action when a subcommand is parsed', async () => {
+    const program = new Command()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+
+    const action = vi.fn()
+    registerIntegrationSubcommands(program, [
+      { name: 'gmail', description: 'Gmail integration', action },
+    ])
+
+    await program.parseAsync(['node', 'orbit', 'integrations', 'gmail'])
+    expect(action).toHaveBeenCalledOnce()
+  })
+})
+
+describe('registerIntegrationsCommand', () => {
+  it('registers the integrations command without throwing', () => {
+    const program = new Command()
+    expect(() => registerIntegrationsCommand(program)).not.toThrow()
+    const integrationsCmd = program.commands.find((c) => c.name() === 'integrations')
+    expect(integrationsCmd).toBeDefined()
+  })
+
+  it('does not throw when invoked with no plugins (shows help or exits cleanly)', () => {
+    const program = new Command()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    registerIntegrationsCommand(program)
+    // Parsing `integrations` with no subcommand should NOT throw a CliNotImplementedError
+    expect(() =>
+      program.parse(['node', 'orbit', 'integrations']),
+    ).not.toThrow()
+  })
+
+  it('is idempotent — calling twice does not duplicate the command', () => {
+    const program = new Command()
+    registerIntegrationsCommand(program)
+    registerIntegrationsCommand(program)
+    const integrationsCmds = program.commands.filter((c) => c.name() === 'integrations')
+    expect(integrationsCmds).toHaveLength(1)
+  })
+})
+
+describe('top-level calendar alias', () => {
+  it('registers a top-level calendar command on the program', () => {
+    const program = createProgram()
+    const names = program.commands.map((c) => c.name())
+    expect(names).toContain('calendar')
+  })
+
+  it('calendar command has a description referencing google-calendar', () => {
+    const program = createProgram()
+    const calendarCmd = program.commands.find((c) => c.name() === 'calendar')
+    expect(calendarCmd).toBeDefined()
+    expect(calendarCmd!.description()).toContain('google-calendar')
+  })
+})

--- a/packages/cli/src/__tests__/integrations.test.ts
+++ b/packages/cli/src/__tests__/integrations.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { Command } from 'commander'
 import { registerIntegrationSubcommands, registerIntegrationsCommand } from '../commands/integrations.js'
+import { registerCalendarAliasCommand } from '../commands/calendar-alias.js'
 import { createProgram } from '../program.js'
 
 afterEach(() => {
@@ -115,5 +116,26 @@ describe('top-level calendar alias', () => {
     const calendarCmd = program.commands.find((c) => c.name() === 'calendar')
     expect(calendarCmd).toBeDefined()
     expect(calendarCmd!.description()).toContain('google-calendar')
+  })
+
+  it('prints informational message and exits 0 when google-calendar plugin is not registered', async () => {
+    const program = new Command()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    registerCalendarAliasCommand(program)
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: string | number | null) => {
+      throw new Error(`process.exit(${_code})`)
+    })
+
+    await expect(
+      program.parseAsync(['node', 'orbit', 'calendar']),
+    ).rejects.toThrow('process.exit(0)')
+
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Google Calendar integration not enabled'),
+    )
+    expect(exitSpy).toHaveBeenCalledWith(0)
   })
 })

--- a/packages/cli/src/__tests__/program.test.ts
+++ b/packages/cli/src/__tests__/program.test.ts
@@ -6,7 +6,7 @@ describe('program', () => {
     'init', 'status', 'doctor', 'seed', 'migrate',
     'contacts', 'companies', 'deals', 'context', 'search', 'users',
     'log', 'tasks', 'notes', 'sequences', 'fields', 'schema', 'report',
-    'dashboard', 'mcp', 'integrations',
+    'dashboard', 'mcp', 'integrations', 'calendar',
   ]
 
   it('registers all expected commands', () => {

--- a/packages/cli/src/commands/activities.ts
+++ b/packages/cli/src/commands/activities.ts
@@ -51,11 +51,11 @@ export function registerActivitiesCommand(program: Command): void {
     .description('Create a new activity')
     .requiredOption('--type <type>', 'Activity type (call, email, meeting, note, task)')
     .option('--subject <subject>', 'Activity subject')
-    .option('--description <description>', 'Activity description')
+    .option('--body <body>', 'Activity body text')
     .option('--contact-id <id>', 'Contact ID')
     .option('--company-id <id>', 'Company ID')
     .option('--deal-id <id>', 'Deal ID')
-    .option('--user-id <id>', 'User ID')
+    .option('--logged-by-user-id <id>', 'User ID who logged the activity')
     .option('--occurred-at <date>', 'Occurred at (ISO date)')
     .action(async (opts) => {
       const flags = program.opts() as GlobalFlags
@@ -63,11 +63,11 @@ export function registerActivitiesCommand(program: Command): void {
 
       const input: CreateActivityInput = { type: opts.type }
       if (opts.subject) input.subject = opts.subject
-      if (opts.description) input.description = opts.description
+      if (opts.body) input.body = opts.body
       if (opts.contactId) input.contact_id = opts.contactId
       if (opts.companyId) input.company_id = opts.companyId
       if (opts.dealId) input.deal_id = opts.dealId
-      if (opts.userId) input.user_id = opts.userId
+      if (opts.loggedByUserId) input.logged_by_user_id = opts.loggedByUserId
       if (opts.occurredAt) input.occurred_at = opts.occurredAt
 
       if (isJsonMode()) {
@@ -84,11 +84,11 @@ export function registerActivitiesCommand(program: Command): void {
     .description('Update an activity')
     .option('--type <type>', 'Activity type')
     .option('--subject <subject>', 'Activity subject')
-    .option('--description <description>', 'Activity description')
+    .option('--body <body>', 'Activity body text')
     .option('--contact-id <id>', 'Contact ID')
     .option('--company-id <id>', 'Company ID')
     .option('--deal-id <id>', 'Deal ID')
-    .option('--user-id <id>', 'User ID')
+    .option('--logged-by-user-id <id>', 'User ID who logged the activity')
     .option('--occurred-at <date>', 'Occurred at (ISO date)')
     .action(async (id, opts) => {
       const flags = program.opts() as GlobalFlags
@@ -97,11 +97,11 @@ export function registerActivitiesCommand(program: Command): void {
       const input: UpdateActivityInput = {}
       if (opts.type) input.type = opts.type
       if (opts.subject) input.subject = opts.subject
-      if (opts.description) input.description = opts.description
+      if (opts.body) input.body = opts.body
       if (opts.contactId) input.contact_id = opts.contactId
       if (opts.companyId) input.company_id = opts.companyId
       if (opts.dealId) input.deal_id = opts.dealId
-      if (opts.userId) input.user_id = opts.userId
+      if (opts.loggedByUserId) input.logged_by_user_id = opts.loggedByUserId
       if (opts.occurredAt) input.occurred_at = opts.occurredAt
 
       if (isJsonMode()) {

--- a/packages/cli/src/commands/calendar-alias.ts
+++ b/packages/cli/src/commands/calendar-alias.ts
@@ -19,7 +19,7 @@ export function registerCalendarAliasCommand(program: Command): void {
         process.stderr.write(
           'Google Calendar integration not enabled. Install @orbit-ai/integrations and register the google-calendar plugin.\n',
         )
-        process.exit(1)
+        process.exit(0)
         return
       }
 

--- a/packages/cli/src/commands/calendar-alias.ts
+++ b/packages/cli/src/commands/calendar-alias.ts
@@ -1,0 +1,35 @@
+import { Command } from 'commander'
+
+/**
+ * Register a top-level `calendar` alias for `orbit integrations google-calendar`.
+ *
+ * If the google-calendar integration is not loaded (no subcommand registered),
+ * the alias prints an informational message instead of failing.
+ */
+export function registerCalendarAliasCommand(program: Command): void {
+  program
+    .command('calendar', { hidden: false })
+    .description('Alias for `orbit integrations google-calendar`')
+    .allowUnknownOption(true)
+    .action(function (this: Command) {
+      const integrationsCmd = program.commands.find((c) => c.name() === 'integrations')
+      const calendarCmd = integrationsCmd?.commands.find((c) => c.name() === 'google-calendar')
+
+      if (!calendarCmd) {
+        process.stderr.write(
+          'Google Calendar integration not enabled. Install @orbit-ai/integrations and register the google-calendar plugin.\n',
+        )
+        process.exit(1)
+        return
+      }
+
+      // Forward remaining args to the google-calendar subcommand
+      const remaining = this.args
+      calendarCmd.parseAsync(['node', 'orbit'].concat(remaining), { from: 'user' }).catch((err: unknown) => {
+        process.stderr.write(
+          `calendar alias error: ${err instanceof Error ? err.message : String(err)}\n`,
+        )
+        process.exit(1)
+      })
+    })
+}

--- a/packages/cli/src/commands/integrations.ts
+++ b/packages/cli/src/commands/integrations.ts
@@ -1,15 +1,52 @@
 import { Command } from 'commander'
-import { CliNotImplementedError } from '../errors.js'
 
-export function registerIntegrationsCommand(program: Command): void {
-  program
+export interface IntegrationCommand {
+  name: string
+  description: string
+  action: (...args: unknown[]) => void | Promise<void>
+  options?: Array<{ flags: string; description: string; defaultValue?: string | boolean }>
+}
+
+/**
+ * Find or create the 'integrations' parent command on a program.
+ * Returns the existing command if already registered.
+ */
+function findOrCreateIntegrationsParent(program: Command): Command {
+  const existing = program.commands.find((c) => c.name() === 'integrations')
+  if (existing) return existing
+  return program
     .command('integrations')
-    .description('Integration commands (coming soon)')
-    .allowUnknownOption(true)
-    .action(() => {
-      throw new CliNotImplementedError(
-        'orbit integrations requires @orbit-ai/integrations which is not yet available.',
-        { code: 'DEPENDENCY_NOT_AVAILABLE', dependency: '@orbit-ai/integrations' },
-      )
-    })
+    .description('Manage integrations (Gmail, Google Calendar, Stripe)')
+}
+
+/**
+ * Register an array of integration plugins as subcommands under `orbit integrations`.
+ * Safe to call with an empty array — the parent command is still registered with no subcommands.
+ */
+export function registerIntegrationSubcommands(program: Command, plugins: IntegrationCommand[]): void {
+  const parent = findOrCreateIntegrationsParent(program)
+
+  for (const plugin of plugins) {
+    const sub = parent.command(plugin.name).description(plugin.description)
+
+    if (plugin.options) {
+      for (const opt of plugin.options) {
+        if (opt.defaultValue !== undefined) {
+          sub.option(opt.flags, opt.description, String(opt.defaultValue))
+        } else {
+          sub.option(opt.flags, opt.description)
+        }
+      }
+    }
+
+    sub.action(plugin.action)
+  }
+}
+
+/**
+ * Register the `integrations` parent command on the program.
+ * Acts as a thin wrapper; does not throw if no plugins are loaded.
+ */
+export function registerIntegrationsCommand(program: Command): void {
+  findOrCreateIntegrationsParent(program)
 }

--- a/packages/cli/src/commands/log.ts
+++ b/packages/cli/src/commands/log.ts
@@ -23,7 +23,7 @@ export function registerLogCommand(program: Command): void {
       if (opts.contact) body.contact_id = opts.contact
       if (opts.company) body.company_id = opts.company
       if (opts.deal) body.deal_id = opts.deal
-      if (opts.note) body.description = opts.note
+      if (opts.note) body.body = opts.note
       if (opts.subject) body.subject = opts.subject
       if (opts.occurredAt) body.occurred_at = opts.occurredAt
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -31,6 +31,7 @@ import { registerReportCommand } from './commands/report.js'
 import { registerDashboardCommand } from './commands/dashboard.js'
 import { registerMcpCommand } from './commands/mcp.js'
 import { registerIntegrationsCommand } from './commands/integrations.js'
+import { registerCalendarAliasCommand } from './commands/calendar-alias.js'
 
 let _jsonMode = false
 let _sigintHandler: (() => void) | null = null
@@ -171,6 +172,7 @@ export function createProgram(): Command {
   registerDashboardCommand(program)
   registerMcpCommand(program)
   registerIntegrationsCommand(program)
+  registerCalendarAliasCommand(program)
 
   return program
 }

--- a/packages/core/src/entities/payments/service.test.ts
+++ b/packages/core/src/entities/payments/service.test.ts
@@ -4,6 +4,7 @@ import { createNoopTransactionScope } from '../../adapters/noop-transaction-scop
 import { generateId } from '../../ids/generate-id.js'
 import { createInMemoryPaymentRepository, type PaymentRepository } from './repository.js'
 import { createPaymentService } from './service.js'
+import { paymentCreateInputSchema, paymentUpdateInputSchema } from './validators.js'
 import { createInMemoryCompanyRepository } from '../companies/repository.js'
 import { createCompanyService } from '../companies/service.js'
 import { createInMemoryContactRepository } from '../contacts/repository.js'
@@ -343,5 +344,54 @@ describe('payment service', () => {
       await paymentService.create(ctx, { amount: '5.00', status: 'pending' })
       expect(withDatabaseSpy).toHaveBeenCalledTimes(1)
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// payment_method → method transform (MEDIUM-3 fix)
+// ---------------------------------------------------------------------------
+
+describe('paymentCreateInputSchema payment_method transform', () => {
+  it('maps payment_method to method when method is absent', () => {
+    const result = paymentCreateInputSchema.parse({
+      amount: '100.00',
+      currency: 'USD',
+      status: 'pending',
+      payment_method: 'stripe',
+    })
+    expect((result as Record<string, unknown>).method).toBe('stripe')
+    expect((result as Record<string, unknown>).payment_method).toBeUndefined()
+  })
+
+  it('preserves explicit method when both payment_method and method are provided', () => {
+    const result = paymentCreateInputSchema.parse({
+      amount: '100.00',
+      currency: 'USD',
+      status: 'pending',
+      method: 'manual',
+      payment_method: 'stripe',
+    })
+    // method takes precedence over payment_method when both present
+    expect((result as Record<string, unknown>).method).toBe('manual')
+    expect((result as Record<string, unknown>).payment_method).toBeUndefined()
+  })
+
+  it('strips payment_method when no method is provided', () => {
+    const result = paymentCreateInputSchema.parse({
+      amount: '100.00',
+      currency: 'USD',
+      status: 'pending',
+    })
+    expect((result as Record<string, unknown>).payment_method).toBeUndefined()
+  })
+})
+
+describe('paymentUpdateInputSchema payment_method transform', () => {
+  it('maps payment_method to method for updates', () => {
+    const result = paymentUpdateInputSchema.parse({
+      payment_method: 'ideal',
+    })
+    expect((result as Record<string, unknown>).method).toBe('ideal')
+    expect((result as Record<string, unknown>).payment_method).toBeUndefined()
   })
 })

--- a/packages/core/src/entities/payments/validators.ts
+++ b/packages/core/src/entities/payments/validators.ts
@@ -5,18 +5,36 @@ import { paymentInsertSchema, paymentSelectSchema, paymentUpdateSchema } from '.
 export const paymentRecordSchema = paymentSelectSchema
 export type PaymentRecord = z.infer<typeof paymentRecordSchema>
 
-export const paymentCreateInputSchema = paymentInsertSchema.omit({
-  id: true,
-  organizationId: true,
-  createdAt: true,
-  updatedAt: true,
-})
+export const paymentCreateInputSchema = paymentInsertSchema
+  .omit({
+    id: true,
+    organizationId: true,
+    createdAt: true,
+    updatedAt: true,
+  })
+  .transform((data) => {
+    if (data.payment_method !== undefined && data.method === undefined) {
+      const { payment_method, ...rest } = data
+      return { ...rest, method: payment_method }
+    }
+    const { payment_method: _pm, ...rest } = data
+    return rest
+  })
 export type PaymentCreateInput = z.input<typeof paymentCreateInputSchema>
 
-export const paymentUpdateInputSchema = paymentUpdateSchema.omit({
-  id: true,
-  organizationId: true,
-  createdAt: true,
-  updatedAt: true,
-})
+export const paymentUpdateInputSchema = paymentUpdateSchema
+  .omit({
+    id: true,
+    organizationId: true,
+    createdAt: true,
+    updatedAt: true,
+  })
+  .transform((data) => {
+    if (data.payment_method !== undefined && data.method === undefined) {
+      const { payment_method, ...rest } = data
+      return { ...rest, method: payment_method }
+    }
+    const { payment_method: _pm, ...rest } = data
+    return rest
+  })
 export type PaymentUpdateInput = z.input<typeof paymentUpdateInputSchema>

--- a/packages/core/src/schema/zod.ts
+++ b/packages/core/src/schema/zod.ts
@@ -357,13 +357,13 @@ export const paymentInsertSchema = createInsertSchema(payments, {
   dealId: orbitId('deal').optional().nullable(),
   contactId: orbitId('contact').optional().nullable(),
   currency: z.string().length(3).transform((value) => value.toUpperCase()).optional(),
-})
+}).extend({ payment_method: z.string().optional() })
 export const paymentUpdateSchema = createUpdateSchema(payments, {
   organizationId: orbitId('organization').optional(),
   dealId: orbitId('deal').optional().nullable(),
   contactId: orbitId('contact').optional().nullable(),
   currency: z.string().length(3).transform((value) => value.toUpperCase()).optional(),
-})
+}).extend({ payment_method: z.string().optional() })
 
 export const contractSelectSchema = createSelectSchema(contracts, {
   id: orbitId('contract'),

--- a/packages/mcp/src/__tests__/extension.test.ts
+++ b/packages/mcp/src/__tests__/extension.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { registerExtensionTools } from '../extension.js'
+import type { ExtensionTool } from '../extension.js'
+
+function makeMcpServer(): McpServer {
+  return new McpServer(
+    { name: '@orbit-ai/mcp-test', version: '0.0.0' },
+    { capabilities: { tools: {} } },
+  )
+}
+
+function makeValidTool(overrides: Partial<ExtensionTool> = {}): ExtensionTool {
+  return {
+    name: 'integrations.gmail.send_email',
+    description: 'Send an email via Gmail',
+    inputSchema: z.object({ to: z.string(), subject: z.string(), body: z.string() }),
+    execute: vi.fn(async () => ({ ok: true })),
+    ...overrides,
+  }
+}
+
+describe('registerExtensionTools', () => {
+  it('registers valid tools with the integrations. prefix successfully', () => {
+    const server = makeMcpServer()
+    const toolA = makeValidTool({ name: 'integrations.gmail.send_email' })
+    const toolB = makeValidTool({ name: 'integrations.calendar.create_event', description: 'Create a calendar event' })
+
+    expect(() => registerExtensionTools(server, [toolA, toolB])).not.toThrow()
+  })
+
+  it('throws when a tool name lacks the integrations. prefix', () => {
+    const server = makeMcpServer()
+    const badTool = makeValidTool({ name: 'gmail.send_email' })
+
+    expect(() => registerExtensionTools(server, [badTool])).toThrow(
+      /must start with the 'integrations\.' prefix/,
+    )
+  })
+
+  it('includes the offending tool name in the prefix error message', () => {
+    const server = makeMcpServer()
+    const badTool = makeValidTool({ name: 'send_email' })
+
+    expect(() => registerExtensionTools(server, [badTool])).toThrow(/send_email/)
+  })
+
+  it('throws when two extension tools share the same name', () => {
+    const server = makeMcpServer()
+    const toolA = makeValidTool({ name: 'integrations.gmail.send_email' })
+    const toolB = makeValidTool({ name: 'integrations.gmail.send_email', description: 'Another send tool' })
+
+    expect(() => registerExtensionTools(server, [toolA, toolB])).toThrow(/Duplicate extension tool name/)
+  })
+
+  it('includes the duplicate name in the duplicate error message', () => {
+    const server = makeMcpServer()
+    const toolA = makeValidTool({ name: 'integrations.gmail.send_email' })
+    const toolB = makeValidTool({ name: 'integrations.gmail.send_email', description: 'Duplicate' })
+
+    expect(() => registerExtensionTools(server, [toolA, toolB])).toThrow(/integrations\.gmail\.send_email/)
+  })
+
+  it('writes a stderr warning before throwing on prefix violation', () => {
+    const server = makeMcpServer()
+    const badTool = makeValidTool({ name: 'no_prefix_here' })
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+
+    expect(() => registerExtensionTools(server, [badTool])).toThrow()
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('no_prefix_here'))
+
+    stderrSpy.mockRestore()
+  })
+
+  it('writes a stderr warning before throwing on duplicate name', () => {
+    const server = makeMcpServer()
+    const toolA = makeValidTool({ name: 'integrations.duplicate.tool' })
+    const toolB = makeValidTool({ name: 'integrations.duplicate.tool', description: 'Dup' })
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+
+    expect(() => registerExtensionTools(server, [toolA, toolB])).toThrow()
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('integrations.duplicate.tool'))
+
+    stderrSpy.mockRestore()
+  })
+
+  it('accepts an empty tools array without throwing', () => {
+    const server = makeMcpServer()
+    expect(() => registerExtensionTools(server, [])).not.toThrow()
+  })
+
+  it('does not register any tools from the first violating tool onward when a prefix error occurs mid-list', () => {
+    const server = makeMcpServer()
+    const validTool = makeValidTool({ name: 'integrations.valid.tool' })
+    const invalidTool = makeValidTool({ name: 'no_prefix' })
+
+    // Calling with [valid, invalid] — valid is registered before we reach invalid,
+    // but the function throws and the caller is notified of the violation.
+    expect(() => registerExtensionTools(server, [validTool, invalidTool])).toThrow(
+      /must start with the 'integrations\.' prefix/,
+    )
+  })
+})

--- a/packages/mcp/src/__tests__/extension.test.ts
+++ b/packages/mcp/src/__tests__/extension.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+// Must be hoisted before the module under test is imported so the mock is in
+// place when extension.ts evaluates CORE_TOOL_NAMES at module scope.
+vi.mock('../tools/registry.js', () => ({
+  buildTools: vi.fn(() => []),
+}))
+
 import { registerExtensionTools } from '../extension.js'
 import type { ExtensionTool } from '../extension.js'
+import { buildTools } from '../tools/registry.js'
 
 function makeMcpServer(): McpServer {
   return new McpServer(
@@ -100,5 +108,42 @@ describe('registerExtensionTools', () => {
     expect(() => registerExtensionTools(server, [validTool, invalidTool])).toThrow(
       /must start with the 'integrations\.' prefix/,
     )
+  })
+
+})
+
+/**
+ * Isolated module test for the shadow guard.
+ *
+ * CORE_TOOL_NAMES is built once at extension.ts module scope, so we need a fresh
+ * module import (via vi.resetModules + dynamic import) with the registry mock
+ * pre-configured to return a tool whose name starts with 'integrations.' —
+ * which can never happen in production but lets us exercise the shadow-check branch.
+ */
+describe('registerExtensionTools — shadow guard (isolated module)', () => {
+  it('throws when an extension tool name conflicts with a core tool name', async () => {
+    // Reset module registry so extension.ts will re-execute its module scope.
+    vi.resetModules()
+
+    // Override the registry mock before re-importing extension.ts.
+    vi.doMock('../tools/registry.js', () => ({
+      buildTools: vi.fn(() => [{ name: 'integrations.conflict.test' }]),
+    }))
+
+    // Dynamically import extension so CORE_TOOL_NAMES is built with the mock active.
+    const { registerExtensionTools: freshRegister } = await import('../extension.js')
+
+    const server = new McpServer(
+      { name: '@orbit-ai/mcp-test', version: '0.0.0' },
+      { capabilities: { tools: {} } },
+    )
+    const conflictingTool: ExtensionTool = {
+      name: 'integrations.conflict.test',
+      description: 'Tool whose name shadows a core tool',
+      inputSchema: z.object({}),
+      execute: vi.fn(async () => ({ ok: true })),
+    }
+
+    expect(() => freshRegister(server, [conflictingTool])).toThrow(/conflicts with a core tool/)
   })
 })

--- a/packages/mcp/src/extension.ts
+++ b/packages/mcp/src/extension.ts
@@ -1,0 +1,88 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { ZodTypeAny } from 'zod'
+import { buildTools } from './tools/registry.js'
+import { writeStderrWarning } from './server.js'
+
+/**
+ * Minimal shape expected from integration tool plugins.
+ * Tool names MUST start with the 'integrations.' prefix.
+ */
+export interface ExtensionTool {
+  /** Must start with 'integrations.' prefix, e.g. 'integrations.gmail.send_email' */
+  name: string
+  title?: string
+  description: string
+  inputSchema: ZodTypeAny
+  execute: (args: Record<string, unknown>) => Promise<unknown>
+}
+
+const INTEGRATION_PREFIX = 'integrations.'
+
+/**
+ * Registers a set of integration extension tools on an existing McpServer.
+ *
+ * Validation rules:
+ * - Every tool name must start with 'integrations.'
+ * - No tool name may duplicate a core tool name
+ * - No two extension tools may share the same name
+ *
+ * @throws Error if any validation rule is violated
+ */
+export function registerExtensionTools(server: McpServer, tools: ExtensionTool[]): void {
+  const coreToolNames = new Set(buildTools().map((t) => t.name))
+  const seen = new Set<string>()
+
+  for (const tool of tools) {
+    if (!tool.name.startsWith(INTEGRATION_PREFIX)) {
+      const msg = `Extension tool name "${tool.name}" must start with the '${INTEGRATION_PREFIX}' prefix.`
+      writeStderrWarning(msg)
+      throw new Error(msg)
+    }
+
+    if (coreToolNames.has(tool.name)) {
+      const msg = `Extension tool name "${tool.name}" conflicts with a core tool name.`
+      writeStderrWarning(msg)
+      throw new Error(msg)
+    }
+
+    if (seen.has(tool.name)) {
+      const msg = `Duplicate extension tool name detected: "${tool.name}". Each tool name must be unique.`
+      writeStderrWarning(msg)
+      throw new Error(msg)
+    }
+
+    seen.add(tool.name)
+
+    const toolConfig: {
+      description: string
+      inputSchema: ZodTypeAny
+      title?: string
+    } = {
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    }
+    if (tool.title !== undefined) {
+      toolConfig.title = tool.title
+    }
+
+    server.registerTool(
+      tool.name,
+      toolConfig,
+      async (args) => {
+        try {
+          const result = await tool.execute(args as Record<string, unknown>)
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          writeStderrWarning(`Extension tool "${tool.name}" execution failed: ${message}`)
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error: message }) }],
+            isError: true,
+          }
+        }
+      },
+    )
+  }
+}

--- a/packages/mcp/src/extension.ts
+++ b/packages/mcp/src/extension.ts
@@ -19,6 +19,12 @@ export interface ExtensionTool {
 const INTEGRATION_PREFIX = 'integrations.'
 
 /**
+ * Set of core tool names, computed once at module load to avoid redundant
+ * registry traversals on every registerExtensionTools call.
+ */
+const CORE_TOOL_NAMES = new Set(buildTools().map((t) => t.name))
+
+/**
  * Registers a set of integration extension tools on an existing McpServer.
  *
  * Validation rules:
@@ -29,7 +35,7 @@ const INTEGRATION_PREFIX = 'integrations.'
  * @throws Error if any validation rule is violated
  */
 export function registerExtensionTools(server: McpServer, tools: ExtensionTool[]): void {
-  const coreToolNames = new Set(buildTools().map((t) => t.name))
+  const coreToolNames = CORE_TOOL_NAMES
   const seen = new Set<string>()
 
   for (const tool of tools) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,2 +1,4 @@
 export { startMcpServer } from './server.js'
 export type { StartMcpServerOptions } from './server.js'
+export { registerExtensionTools } from './extension.js'
+export type { ExtensionTool } from './extension.js'

--- a/packages/sdk/src/__tests__/resources-wave2.test.ts
+++ b/packages/sdk/src/__tests__/resources-wave2.test.ts
@@ -99,6 +99,45 @@ describe('ActivityResource', () => {
       body: { type: 'call' },
     })
   })
+
+  it('create() passes body, direction, and metadata through transport', async () => {
+    const input = {
+      type: 'email_sent',
+      body: 'Hey there',
+      direction: 'outbound',
+      metadata: { campaign_id: 'camp_1' },
+      logged_by_user_id: 'user_123',
+    }
+    transport.request.mockResolvedValue(makeEnvelope({ id: 'act_3', ...input }))
+
+    await activities.create(input)
+
+    expect(transport.request).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/v1/activities',
+      body: input,
+    })
+  })
+
+  it('ActivityRecord wire format uses logged_by_user_id, not user_id', () => {
+    // Type-level check: CreateActivityInput must accept logged_by_user_id
+    // and must not accept user_id (this is enforced by TypeScript, tested here
+    // by verifying the transport receives the correct field name at runtime)
+    const input = {
+      type: 'call',
+      logged_by_user_id: 'user_abc',
+      occurred_at: '2026-04-10T09:00:00.000Z',
+    }
+    transport.request.mockResolvedValue(makeEnvelope({ id: 'act_4', ...input }))
+
+    activities.create(input)
+
+    expect(transport.request).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/v1/activities',
+      body: input,
+    })
+  })
 })
 
 describe('TaskResource', () => {
@@ -157,6 +196,47 @@ describe('PaymentResource', () => {
     expect(transport.request).toHaveBeenCalledWith({
       method: 'GET',
       path: '/v1/payments/pay_1',
+    })
+  })
+
+  it('create() passes external_id and metadata through transport', async () => {
+    const transport = createMockTransport()
+    const payments = new PaymentResource(transport)
+    const input = {
+      amount: 9999,
+      currency: 'EUR',
+      status: 'paid',
+      external_id: 'stripe_ch_abc123',
+      metadata: { invoice_id: 'inv_1' },
+    }
+    transport.request.mockResolvedValue(makeEnvelope({ id: 'pay_2', ...input }))
+
+    await payments.create(input)
+
+    expect(transport.request).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/v1/payments',
+      body: input,
+    })
+  })
+
+  it('create() passes payment_method alias through transport', async () => {
+    const transport = createMockTransport()
+    const payments = new PaymentResource(transport)
+    const input = {
+      amount: 500,
+      currency: 'USD',
+      status: 'paid',
+      payment_method: 'ideal',
+    }
+    transport.request.mockResolvedValue(makeEnvelope({ id: 'pay_3', method: 'ideal' }))
+
+    await payments.create(input)
+
+    expect(transport.request).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/v1/payments',
+      body: input,
     })
   })
 })

--- a/packages/sdk/src/resources/activities.ts
+++ b/packages/sdk/src/resources/activities.ts
@@ -8,6 +8,11 @@ export interface ActivityRecord {
   type: string
   subject: string | null
   description: string | null
+  body?: string | null
+  direction?: string | null
+  duration_minutes?: number | null
+  metadata?: Record<string, unknown> | null
+  outcome?: string | null
   contact_id: string | null
   company_id: string | null
   deal_id: string | null
@@ -22,6 +27,11 @@ export interface CreateActivityInput {
   type: string
   subject?: string
   description?: string
+  body?: string
+  direction?: string
+  duration_minutes?: number
+  metadata?: Record<string, unknown>
+  outcome?: string
   contact_id?: string
   company_id?: string
   deal_id?: string

--- a/packages/sdk/src/resources/activities.ts
+++ b/packages/sdk/src/resources/activities.ts
@@ -7,7 +7,6 @@ export interface ActivityRecord {
   organization_id: string
   type: string
   subject: string | null
-  description: string | null
   body?: string | null
   direction?: string | null
   duration_minutes?: number | null
@@ -16,8 +15,8 @@ export interface ActivityRecord {
   contact_id: string | null
   company_id: string | null
   deal_id: string | null
-  user_id: string | null
-  occurred_at: string | null
+  logged_by_user_id: string | null
+  occurred_at: string
   custom_fields: Record<string, unknown>
   created_at: string
   updated_at: string
@@ -26,7 +25,6 @@ export interface ActivityRecord {
 export interface CreateActivityInput {
   type: string
   subject?: string
-  description?: string
   body?: string
   direction?: string
   duration_minutes?: number
@@ -35,7 +33,7 @@ export interface CreateActivityInput {
   contact_id?: string
   company_id?: string
   deal_id?: string
-  user_id?: string
+  logged_by_user_id?: string
   occurred_at?: string
   custom_fields?: Record<string, unknown>
 }

--- a/packages/sdk/src/resources/payments.ts
+++ b/packages/sdk/src/resources/payments.ts
@@ -10,7 +10,7 @@ export interface PaymentRecord {
   status: string
   deal_id: string | null
   contact_id: string | null
-  payment_method: string | null
+  method: string | null
   external_id?: string | null
   metadata?: Record<string, unknown> | null
   paid_at: string | null

--- a/packages/sdk/src/resources/payments.ts
+++ b/packages/sdk/src/resources/payments.ts
@@ -11,6 +11,8 @@ export interface PaymentRecord {
   deal_id: string | null
   contact_id: string | null
   payment_method: string | null
+  external_id?: string | null
+  metadata?: Record<string, unknown> | null
   paid_at: string | null
   custom_fields: Record<string, unknown>
   created_at: string
@@ -24,6 +26,8 @@ export interface CreatePaymentInput {
   deal_id?: string
   contact_id?: string
   payment_method?: string
+  external_id?: string
+  metadata?: Record<string, unknown>
   paid_at?: string
   custom_fields?: Record<string, unknown>
 }


### PR DESCRIPTION
## Summary
- **SDK**: Add missing activity fields (`body`, `direction`, `duration_minutes`, `metadata`, `outcome`) and payment fields (`external_id`, `metadata`). Fix `payment_method`→`method` naming with Zod transform.
- **MCP**: Add `registerExtensionTools()` seam for integration plugins with `integrations.*` prefix enforcement
- **CLI**: Replace integrations stub with dynamic `registerIntegrationSubcommands()` loader. Add `orbit calendar` top-level alias.

## Test plan
- [ ] `pnpm -r build && pnpm -r typecheck && pnpm -r test && pnpm -r lint` — all pass
- [ ] SDK: `CreateActivityInput` accepts `body`, `direction`, `metadata` fields
- [ ] SDK: `CreatePaymentInput.payment_method` correctly maps to `method` column via Zod transform
- [ ] MCP: Extension tools without `integrations.` prefix are rejected
- [ ] CLI: `orbit calendar` prints informational message when plugin not loaded (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)