### PR TITLE
fix(integrations): security fixes — org-scoped lookups + MIME injection

### DIFF
--- a/packages/integrations/src/gmail/operations.test.ts
+++ b/packages/integrations/src/gmail/operations.test.ts
@@ -257,6 +257,26 @@ describe('Gmail operations', () => {
       expect(decoded).toContain('Cc: b@b.com, c@c.com')
     })
 
+    it('strips CR/LF from MIME header fields to prevent injection', async () => {
+      const { sendMessage } = await loadOps()
+      mockMessagesSend.mockResolvedValue({ data: { id: 'msg_1', threadId: 'th_1' } })
+
+      await sendMessage(TEST_CONFIG, {} as never, ORG_ID, {
+        to: 'user@example.com',
+        subject: 'Hello\r\nBcc: attacker@evil.com',
+        body: 'test body',
+      })
+
+      const call = mockMessagesSend.mock.calls[0]![0] as Record<string, unknown>
+      const raw = (call['requestBody'] as Record<string, string>)['raw']
+      const decoded = Buffer.from(raw, 'base64url').toString('utf-8')
+
+      // The injected Bcc header must NOT appear as a separate header line
+      expect(decoded).not.toMatch(/^Bcc:/m)
+      // Subject should be on a single line (CR/LF stripped)
+      expect(decoded).toMatch(/^Subject: Hello Bcc: attacker@evil\.com$/m)
+    })
+
     it('includes threadId for replies', async () => {
       const { sendMessage } = await loadOps()
       mockMessagesSend.mockResolvedValue({

--- a/packages/integrations/src/gmail/operations.ts
+++ b/packages/integrations/src/gmail/operations.ts
@@ -112,6 +112,13 @@ export async function getMessage(
 }
 
 /**
+ * Strip CR/LF characters from MIME header values to prevent header injection.
+ */
+function sanitizeMimeHeader(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ').trim()
+}
+
+/**
  * Send a Gmail message.
  * Constructs an RFC 2822 MIME message and base64url-encodes it per Gmail API spec.
  */
@@ -126,13 +133,13 @@ export async function sendMessage(
 
     // Build RFC 2822 MIME message
     const mimeLines: string[] = [
-      `To: ${input.to}`,
-      `Subject: ${input.subject}`,
+      `To: ${sanitizeMimeHeader(input.to)}`,
+      `Subject: ${sanitizeMimeHeader(input.subject)}`,
       'Content-Type: text/plain; charset=utf-8',
       'MIME-Version: 1.0',
     ]
     if (input.cc && input.cc.length > 0) {
-      mimeLines.push(`Cc: ${input.cc.join(', ')}`)
+      mimeLines.push(`Cc: ${input.cc.map(sanitizeMimeHeader).join(', ')}`)
     }
     mimeLines.push('', input.body)
     const mimeString = mimeLines.join('\r\n')

--- a/packages/integrations/src/shared/contacts.test.ts
+++ b/packages/integrations/src/shared/contacts.test.ts
@@ -138,10 +138,62 @@ describe('findOrCreateContactFromEmail', () => {
 
     expect(result.contactId).toBe('c-upper')
     expect(result.created).toBe(false)
-    // Verify the filter used the normalized email
+    // Verify the filter used the normalized email and included organization_id
     expect(contactClient.list).toHaveBeenCalledWith({
-      filter: { email: 'alice@example.com' },
+      filter: { email: 'alice@example.com', organization_id: 'org-1' },
     })
+  })
+
+  it('passes organization_id in contact lookup filter', async () => {
+    const contactClient: ContactLookupClient = {
+      list: vi.fn().mockResolvedValue({ data: [{ id: 'c_1', email: 'a@b.com' }] }),
+      create: vi.fn(),
+    }
+    const companyClient: CompanyLookupClient = {
+      list: vi.fn().mockResolvedValue({ data: [] }),
+      create: vi.fn(),
+    }
+
+    await findOrCreateContactFromEmail(contactClient, companyClient, 'org_abc', 'a@b.com')
+
+    expect(contactClient.list).toHaveBeenCalledWith({
+      filter: { email: 'a@b.com', organization_id: 'org_abc' },
+    })
+  })
+
+  it('passes organization_id in company lookup filter', async () => {
+    const contactClient: ContactLookupClient = {
+      list: vi.fn().mockResolvedValue({ data: [] }),
+      create: vi.fn().mockResolvedValue({ id: 'c_new' }),
+    }
+    const companyClient: CompanyLookupClient = {
+      list: vi.fn().mockResolvedValue({ data: [{ id: 'co_1', domain: 'b.com' }] }),
+      create: vi.fn(),
+    }
+
+    await findOrCreateContactFromEmail(contactClient, companyClient, 'org_abc', 'a@b.com')
+
+    expect(companyClient.list).toHaveBeenCalledWith({
+      filter: { domain: 'b.com', organization_id: 'org_abc' },
+    })
+  })
+
+  it('throws INVALID_INPUT for empty email', async () => {
+    const contactClient: ContactLookupClient = { list: vi.fn(), create: vi.fn() }
+    const companyClient: CompanyLookupClient = { list: vi.fn(), create: vi.fn() }
+
+    await expect(
+      findOrCreateContactFromEmail(contactClient, companyClient, 'org_1', ''),
+    ).rejects.toMatchObject({ code: 'INVALID_INPUT' })
+  })
+
+  it('throws INVALID_INPUT when orgId is empty string', async () => {
+    const contactClient: ContactLookupClient = { list: vi.fn(), create: vi.fn() }
+    const companyClient: CompanyLookupClient = { list: vi.fn(), create: vi.fn() }
+
+    await expect(
+      findOrCreateContactFromEmail(contactClient, companyClient, '', 'a@b.com'),
+    ).rejects.toMatchObject({ code: 'INVALID_INPUT' })
   })
 
   it('cross-org isolation — same email in different orgs gets separate lookup calls', async () => {
@@ -174,12 +226,12 @@ describe('findOrCreateContactFromEmail', () => {
     expect(resultB.created).toBe(true)
     expect(resultB.contactId).toBe('new-contact-shared@example.com')
 
-    // Each client received exactly one list call with the same filter
+    // Each client received exactly one list call scoped to their respective org
     expect(orgAContactClient.list).toHaveBeenCalledWith({
-      filter: { email: 'shared@example.com' },
+      filter: { email: 'shared@example.com', organization_id: 'org-a' },
     })
     expect(orgBContactClient.list).toHaveBeenCalledWith({
-      filter: { email: 'shared@example.com' },
+      filter: { email: 'shared@example.com', organization_id: 'org-b' },
     })
 
     // Org A never called create, Org B did

--- a/packages/integrations/src/shared/contacts.ts
+++ b/packages/integrations/src/shared/contacts.ts
@@ -27,11 +27,27 @@ export async function findOrCreateContactFromEmail(
   email: string,
   options?: { autoCreate?: boolean },
 ): Promise<{ contactId: string; created: boolean }> {
+  if (!orgId || typeof orgId !== 'string') {
+    throw createIntegrationError(
+      'INVALID_INPUT',
+      'orgId must be a non-empty string',
+      { provider: 'integrations' },
+    )
+  }
+
   const normalizedEmail = email.toLowerCase().trim()
+
+  if (!normalizedEmail || !normalizedEmail.includes('@')) {
+    throw createIntegrationError(
+      'INVALID_INPUT',
+      `Invalid email address: '${email}'`,
+      { provider: 'integrations' },
+    )
+  }
 
   // Step 1: Exact email match within org
   const existing = await contactClient.list({
-    filter: { email: normalizedEmail },
+    filter: { email: normalizedEmail, organization_id: orgId },
   })
   if (existing.data.length > 0) {
     return { contactId: existing.data[0]!.id, created: false }
@@ -41,7 +57,7 @@ export async function findOrCreateContactFromEmail(
     throw createIntegrationError(
       'NOT_FOUND',
       `Contact not found for email ${normalizedEmail} and auto_create is disabled`,
-      { provider: 'gmail' },
+      { provider: 'integrations' },
     )
   }
 
@@ -50,7 +66,7 @@ export async function findOrCreateContactFromEmail(
   let companyId: string | undefined
   if (domain) {
     const companies = await companyClient.list({
-      filter: { domain },
+      filter: { domain, organization_id: orgId },
     })
     if (companies.data.length > 0) {
       companyId = companies.data[0]!.id


### PR DESCRIPTION
## Summary
- **#1/#16**: `findOrCreateContactFromEmail` now passes `organization_id` in both contact and company list filters, preventing cross-org contact bleed. Email and orgId validation guards added.
- **#2**: MIME headers sanitized via `sanitizeMimeHeader()` to strip CR/LF characters, preventing header injection in Gmail `sendMessage`.
- Hardcoded `provider: 'gmail'` fixed to `provider: 'integrations'` in shared helper.

## Test plan
- [x] 395 integrations tests passing (+5 new)
- [x] Full monorepo build/typecheck/lint clean
- [x] orbit-tenant-safety-review: all 4 checks PASS
- [x] Spec compliance + code quality reviews completed per task

🤖 Generated with [Claude Code](https://claude.com/claude-code)