### PR TITLE
fix(integrations,mcp): data integrity fixes — polling, OAuth, schema, idempotency, Stripe, MCP

### DIFF
--- a/packages/integrations/src/gmail/auth.test.ts
+++ b/packages/integrations/src/gmail/auth.test.ts
@@ -181,5 +181,18 @@ describe('Gmail OAuth helpers', () => {
       expect(mockSetCredentials).toHaveBeenCalledWith({ refresh_token: '1//gmail-refresh' })
       expect(mockRefreshAccessToken).toHaveBeenCalled()
     })
+
+    it('retrieves user-scoped credentials when userId is provided', async () => {
+      const { getGmailClient } = await loadAuth()
+      const store = new InMemoryCredentialStore()
+      await store.saveCredentials('org_1', 'gmail', 'user_alice', {
+        accessToken: 'alice-token',
+        refreshToken: 'alice-refresh',
+        expiresAt: Date.now() + 3600000,
+      })
+
+      const result = await getGmailClient(TEST_CONFIG, store, 'org_1', 'user_alice')
+      expect(result.accessToken).toBe('alice-token')
+    })
   })
 })

--- a/packages/integrations/src/gmail/auth.ts
+++ b/packages/integrations/src/gmail/auth.ts
@@ -55,8 +55,9 @@ export async function getGmailClient(
   config: GmailConnectorConfig,
   credentialStore: CredentialStore,
   orgId: string,
+  userId?: string,
 ): Promise<{ accessToken: string }> {
   const helper = createGmailOAuthHelper(config)
-  const accessToken = await helper.getValidAccessToken(orgId, GMAIL_SLUG, credentialStore)
+  const accessToken = await helper.getValidAccessToken(orgId, GMAIL_SLUG, credentialStore, undefined, userId)
   return { accessToken }
 }

--- a/packages/integrations/src/gmail/operations.ts
+++ b/packages/integrations/src/gmail/operations.ts
@@ -12,8 +12,9 @@ async function getGmailApi(
   config: GmailConnectorConfig,
   credentialStore: CredentialStore,
   orgId: string,
+  userId?: string,
 ): Promise<gmail_v1.Gmail> {
-  const { accessToken } = await getGmailClient(config, credentialStore, orgId)
+  const { accessToken } = await getGmailClient(config, credentialStore, orgId, userId)
   const auth = new google.auth.OAuth2()
   auth.setCredentials({ access_token: accessToken })
   return google.gmail({ version: 'v1', auth })
@@ -27,9 +28,10 @@ export async function listMessages(
   credentialStore: CredentialStore,
   orgId: string,
   options?: { maxResults?: number; query?: string; pageToken?: string },
+  userId?: string,
 ): Promise<IntegrationResult<{ messages: Array<{ id: string; threadId: string }>; nextPageToken?: string }>> {
   try {
-    const gmail = await getGmailApi(config, credentialStore, orgId)
+    const gmail = await getGmailApi(config, credentialStore, orgId, userId)
 
     const listParams: Record<string, unknown> = {
       userId: 'me',
@@ -72,9 +74,10 @@ export async function getMessage(
   credentialStore: CredentialStore,
   orgId: string,
   messageId: string,
+  userId?: string,
 ): Promise<IntegrationResult<GmailMessage>> {
   try {
-    const gmail = await getGmailApi(config, credentialStore, orgId)
+    const gmail = await getGmailApi(config, credentialStore, orgId, userId)
     const response = await gmail.users.messages.get({
       userId: 'me',
       id: messageId,
@@ -120,9 +123,10 @@ export async function sendMessage(
   credentialStore: CredentialStore,
   orgId: string,
   input: GmailSendInput,
+  userId?: string,
 ): Promise<IntegrationResult<{ id: string; threadId: string }>> {
   try {
-    const gmail = await getGmailApi(config, credentialStore, orgId)
+    const gmail = await getGmailApi(config, credentialStore, orgId, userId)
 
     // Build RFC 2822 MIME message
     const mimeLines: string[] = [

--- a/packages/integrations/src/gmail/polling.test.ts
+++ b/packages/integrations/src/gmail/polling.test.ts
@@ -244,6 +244,63 @@ describe('pollGmailInbox', () => {
     expect(mockSyncGmailMessage).toHaveBeenCalledWith(syncContext, makeGmailMessage('msg-2'))
   })
 
+  it('uses cursor as pageToken only — not as after: query parameter', async () => {
+    mockListMessages.mockResolvedValueOnce({
+      data: { messages: [], nextPageToken: undefined },
+      provider: 'gmail',
+    })
+
+    await pollGmailInbox(config, credentialStore, 'org_1', syncContext, 'cursor_abc')
+
+    const listCall = mockListMessages.mock.calls[0]![3] as Record<string, unknown>
+    expect(listCall['pageToken']).toBe('cursor_abc')
+    expect(listCall['query']).toBeUndefined()
+  })
+
+  it('returns last fully-processed page cursor when stopped early', async () => {
+    // First page: 2 messages, has next page
+    mockListMessages.mockResolvedValueOnce({
+      data: { messages: [{ id: 'm1', threadId: 't1' }, { id: 'm2', threadId: 't2' }], nextPageToken: 'page2' },
+      provider: 'gmail',
+    })
+    // getMessage mocks
+    mockGetMessage.mockResolvedValue({ data: makeGmailMessage('m1'), provider: 'gmail' })
+    mockSyncGmailMessage.mockResolvedValue({ activity: makeActivity('m1'), contactId: 'c_1', created: false })
+
+    const result = await pollGmailInbox(config, credentialStore, 'org_1', syncContext, undefined, { maxMessages: 2 })
+
+    // All allowed messages are exactly consumed with the page fully processed.
+    // newCursor should be 'page2' (the cursor for the NEXT unprocessed page)
+    expect(result.newCursor).toBe('page2')
+  })
+
+  it('returns current page cursor when maxMessages interrupts mid-page', async () => {
+    // Page has 3 messages but maxMessages=1 — we stop after first message
+    mockListMessages.mockResolvedValueOnce({
+      data: {
+        messages: [
+          { id: 'm1', threadId: 't1' },
+          { id: 'm2', threadId: 't2' },
+          { id: 'm3', threadId: 't3' },
+        ],
+        nextPageToken: 'page2',
+      },
+      provider: 'gmail',
+    })
+    mockGetMessage.mockResolvedValue({ data: makeGmailMessage('m1'), provider: 'gmail' })
+    mockSyncGmailMessage.mockResolvedValue({ activity: makeActivity('m1'), contactId: 'c_1', created: false })
+
+    const result = await pollGmailInbox(
+      config, credentialStore, 'org_1', syncContext, 'page1', { maxMessages: 1 },
+    )
+
+    expect(result.stoppedEarly).toBe(true)
+    expect(result.synced).toBe(1)
+    // Page was NOT fully processed — cursor should be 'page1' (where we started),
+    // not 'page2' (which would skip unprocessed messages m2/m3)
+    expect(result.newCursor).toBe('page1')
+  })
+
   it('wraps errors with toIntegrationError', async () => {
     mockListMessages.mockRejectedValueOnce(new Error('API rate limit exceeded 429'))
 

--- a/packages/integrations/src/gmail/polling.ts
+++ b/packages/integrations/src/gmail/polling.ts
@@ -35,6 +35,9 @@ export async function pollGmailInbox(
   const activities: ActivityInput[] = []
   let pageToken = cursor
   let stoppedEarly = false
+  // Tracks the last page token for which we fully processed all messages.
+  // Starts as the incoming cursor (so on mid-page interruption we can resume from there).
+  let lastCompletedPageToken = cursor
 
   try {
     let messagesProcessed = 0
@@ -46,23 +49,26 @@ export async function pollGmailInbox(
         break
       }
 
+      const currentPageToken = pageToken
       const batchSize = Math.min(20, maxMessages - messagesProcessed)
-      const listOpts: { maxResults: number; pageToken?: string; query?: string } = {
+      const listOpts: { maxResults: number; pageToken?: string } = {
         maxResults: batchSize,
       }
-      if (pageToken !== undefined) listOpts.pageToken = pageToken
-      if (cursor !== undefined) listOpts.query = `after:${cursor}`
+      if (currentPageToken !== undefined) listOpts.pageToken = currentPageToken
       const listResult = await listMessages(config, credentialStore, orgId, listOpts)
 
       if (listResult.data.messages.length === 0) break
 
+      let pageFullyProcessed = true
       for (const msgSummary of listResult.data.messages) {
         if (messagesProcessed >= maxMessages) {
           stoppedEarly = true
+          pageFullyProcessed = false
           break
         }
         if (Date.now() - startTime > maxDurationMs) {
           stoppedEarly = true
+          pageFullyProcessed = false
           break
         }
 
@@ -73,6 +79,11 @@ export async function pollGmailInbox(
       }
 
       pageToken = listResult.data.nextPageToken
+      if (pageFullyProcessed) {
+        // Only advance the completed cursor when the page was fully processed.
+        // This means newCursor points to the next unprocessed page.
+        lastCompletedPageToken = pageToken
+      }
       if (!pageToken) break
     }
 
@@ -81,7 +92,7 @@ export async function pollGmailInbox(
       activities,
       stoppedEarly,
     }
-    if (pageToken !== undefined) result.newCursor = pageToken
+    if (lastCompletedPageToken !== undefined) result.newCursor = lastCompletedPageToken
     return result
   } catch (err) {
     throw toIntegrationError(err, 'gmail')

--- a/packages/integrations/src/google-calendar/auth.test.ts
+++ b/packages/integrations/src/google-calendar/auth.test.ts
@@ -179,5 +179,18 @@ describe('Google Calendar OAuth helpers', () => {
       expect(mockSetCredentials).toHaveBeenCalledWith({ refresh_token: '1//calendar-refresh' })
       expect(mockRefreshAccessToken).toHaveBeenCalled()
     })
+
+    it('retrieves user-scoped credentials when userId is provided', async () => {
+      const { getCalendarClient } = await loadAuth()
+      const store = new InMemoryCredentialStore()
+      await store.saveCredentials('org_1', 'google-calendar', 'user_bob', {
+        accessToken: 'bob-token',
+        refreshToken: 'bob-refresh',
+        expiresAt: Date.now() + 3600000,
+      })
+
+      const result = await getCalendarClient(TEST_CONFIG, store, 'org_1', 'user_bob')
+      expect(result.accessToken).toBe('bob-token')
+    })
   })
 })

--- a/packages/integrations/src/google-calendar/auth.ts
+++ b/packages/integrations/src/google-calendar/auth.ts
@@ -54,8 +54,9 @@ export async function getCalendarClient(
   config: CalendarConnectorConfig,
   credentialStore: CredentialStore,
   orgId: string,
+  userId?: string,
 ): Promise<{ accessToken: string }> {
   const helper = createCalendarOAuthHelper(config)
-  const accessToken = await helper.getValidAccessToken(orgId, CALENDAR_SLUG, credentialStore)
+  const accessToken = await helper.getValidAccessToken(orgId, CALENDAR_SLUG, credentialStore, undefined, userId)
   return { accessToken }
 }

--- a/packages/integrations/src/google-calendar/operations.ts
+++ b/packages/integrations/src/google-calendar/operations.ts
@@ -12,8 +12,9 @@ async function getCalendarApi(
   config: CalendarConnectorConfig,
   credentialStore: CredentialStore,
   orgId: string,
+  userId?: string,
 ): Promise<calendar_v3.Calendar> {
-  const { accessToken } = await getCalendarClient(config, credentialStore, orgId)
+  const { accessToken } = await getCalendarClient(config, credentialStore, orgId, userId)
   const auth = new google.auth.OAuth2()
   auth.setCredentials({ access_token: accessToken })
   return google.calendar({ version: 'v3', auth })
@@ -66,9 +67,10 @@ export async function listEvents(
     pageToken?: string
     calendarId?: string
   },
+  userId?: string,
 ): Promise<IntegrationResult<{ events: CalendarEvent[]; nextPageToken?: string }>> {
   try {
-    const calendar = await getCalendarApi(config, credentialStore, orgId)
+    const calendar = await getCalendarApi(config, credentialStore, orgId, userId)
     const calendarId = options?.calendarId ?? 'primary'
 
     const params: calendar_v3.Params$Resource$Events$List = {
@@ -110,9 +112,10 @@ export async function createEvent(
   orgId: string,
   input: CalendarEventInput,
   calendarId?: string,
+  userId?: string,
 ): Promise<IntegrationResult<CalendarEvent>> {
   try {
-    const calendar = await getCalendarApi(config, credentialStore, orgId)
+    const calendar = await getCalendarApi(config, credentialStore, orgId, userId)
 
     const requestBody: calendar_v3.Schema$Event = {
       summary: input.summary,
@@ -150,9 +153,10 @@ export async function updateEvent(
   eventId: string,
   input: Partial<CalendarEventInput>,
   calendarId?: string,
+  userId?: string,
 ): Promise<IntegrationResult<CalendarEvent>> {
   try {
-    const calendar = await getCalendarApi(config, credentialStore, orgId)
+    const calendar = await getCalendarApi(config, credentialStore, orgId, userId)
 
     const requestBody: calendar_v3.Schema$Event = {}
     if (input.summary !== undefined) requestBody.summary = input.summary
@@ -189,9 +193,10 @@ export async function deleteEvent(
   orgId: string,
   eventId: string,
   calendarId?: string,
+  userId?: string,
 ): Promise<IntegrationResult<{ deleted: true }>> {
   try {
-    const calendar = await getCalendarApi(config, credentialStore, orgId)
+    const calendar = await getCalendarApi(config, credentialStore, orgId, userId)
 
     await calendar.events.delete({
       calendarId: calendarId ?? 'primary',
@@ -215,9 +220,10 @@ export async function checkAvailability(
   credentialStore: CredentialStore,
   orgId: string,
   options: { timeMin: string; timeMax: string; emails: string[] },
+  userId?: string,
 ): Promise<IntegrationResult<Array<{ email: string; busy: Array<{ start: string; end: string }> }>>> {
   try {
-    const calendar = await getCalendarApi(config, credentialStore, orgId)
+    const calendar = await getCalendarApi(config, credentialStore, orgId, userId)
 
     const response = await calendar.freebusy.query({
       requestBody: {

--- a/packages/integrations/src/idempotency.test.ts
+++ b/packages/integrations/src/idempotency.test.ts
@@ -36,6 +36,12 @@ describe('generateIdempotencyKey', () => {
     const key = generateIdempotencyKey(['only-one'])
     expect(key).toHaveLength(32)
   })
+
+  it('generates different keys for inputs that would collide with :: separator', () => {
+    const key1 = generateIdempotencyKey(['a', 'b::c'])
+    const key2 = generateIdempotencyKey(['a::b', 'c'])
+    expect(key1).not.toBe(key2)
+  })
 })
 
 describe('IdempotencyHelper', () => {

--- a/packages/integrations/src/idempotency.ts
+++ b/packages/integrations/src/idempotency.ts
@@ -11,8 +11,13 @@ export interface IdempotencyCheckResult {
  * Generate a deterministic idempotency key from provider-specific inputs.
  * Uses SHA-256 to create a stable key from the inputs.
  */
+const INTEGRATION_METHOD = 'INTEGRATION' as const
+const INTEGRATION_PATH = '/integration/dedup' as const
+
 export function generateIdempotencyKey(parts: string[]): string {
-  return createHash('sha256').update(parts.join('::')).digest('hex').slice(0, 32)
+  // Length-prefix each part to prevent ambiguity: "3:abc5:hello" not "abc::hello"
+  const encoded = parts.map(p => `${p.length}:${p}`).join('')
+  return createHash('sha256').update(encoded).digest('hex').slice(0, 32)
 }
 
 /**
@@ -53,7 +58,7 @@ export class IdempotencyHelper {
     try {
       const ctx: OrbitAuthContext = { orgId: this.organizationId }
       const result = await this.repository.list(ctx, {
-        filter: { key },
+        filter: { key, method: INTEGRATION_METHOD, path: INTEGRATION_PATH },
         limit: 1,
       })
       return { isDuplicate: result.data.length > 0, key }
@@ -79,8 +84,8 @@ export class IdempotencyHelper {
         id: generateId('idempotencyKey'),
         organizationId: this.organizationId,
         key,
-        method: 'INTEGRATION',
-        path: '/integration/dedup',
+        method: INTEGRATION_METHOD,
+        path: INTEGRATION_PATH,
         requestHash: key,
         responseCode: null,
         responseBody: null,

--- a/packages/integrations/src/oauth.ts
+++ b/packages/integrations/src/oauth.ts
@@ -73,8 +73,9 @@ export class GoogleOAuthHelper {
     provider: string,
     credentialStore: CredentialStore,
     connectionTracker?: ConnectionStatusTracker,
+    userId?: string,
   ): Promise<string> {
-    const creds = await credentialStore.getCredentials(orgId, provider)
+    const creds = await credentialStore.getCredentials(orgId, provider, userId)
     if (!creds) {
       throw createIntegrationError('AUTH_EXPIRED', `No credentials found for ${provider}`, { provider })
     }
@@ -96,8 +97,8 @@ export class GoogleOAuthHelper {
         accessToken: credentials.access_token ?? '',
         ...(credentials.expiry_date != null ? { expiresAt: credentials.expiry_date } : {}),
       }
-      // Save refreshed credentials (userId not known here — use default)
-      await credentialStore.saveCredentials(orgId, provider, '__default__', updated)
+      // Preserve the userId slot when saving refreshed credentials
+      await credentialStore.saveCredentials(orgId, provider, userId ?? '__default__', updated)
 
       if (connectionTracker) {
         await connectionTracker.recordSuccess(orgId, provider)
@@ -123,8 +124,9 @@ export class GoogleOAuthHelper {
     orgId: string,
     provider: string,
     credentialStore: CredentialStore,
+    userId?: string,
   ): Promise<void> {
-    const creds = await credentialStore.getCredentials(orgId, provider)
+    const creds = await credentialStore.getCredentials(orgId, provider, userId)
     if (creds?.refreshToken) {
       try {
         await this.oauth2Client.revokeToken(creds.refreshToken)
@@ -133,7 +135,7 @@ export class GoogleOAuthHelper {
         // Continue to delete local credentials even if revocation fails
       }
     }
-    await credentialStore.deleteCredentials(orgId, provider)
+    await credentialStore.deleteCredentials(orgId, provider, userId)
   }
 }
 

--- a/packages/integrations/src/schema-extension.test.ts
+++ b/packages/integrations/src/schema-extension.test.ts
@@ -98,4 +98,35 @@ describe('integrationSchemaExtension', () => {
     const createStatement = migration.up.find((sql) => sql.includes('CREATE TABLE'))
     expect(createStatement).toContain("DEFAULT '[]'::jsonb")
   })
+
+  it('migration 001 drops policy before creating (idempotent)', () => {
+    const migration = integrationSchemaExtension.migrations[0]!
+    const dropIdx = migration.up.findIndex((sql) =>
+      sql.includes('DROP POLICY IF EXISTS ic_tenant_isolation'),
+    )
+    const createIdx = migration.up.findIndex((sql) =>
+      sql.includes('CREATE POLICY ic_tenant_isolation'),
+    )
+    expect(dropIdx).toBeGreaterThanOrEqual(0)
+    expect(createIdx).toBeGreaterThan(dropIdx)
+  })
+
+  it('migration 002 includes FK constraint on connection_id with cascade', () => {
+    const migration = integrationSchemaExtension.migrations[1]!
+    const createSql = migration.up.find((sql) => sql.includes('CREATE TABLE'))
+    expect(createSql).toContain('REFERENCES integration_connections(id)')
+    expect(createSql).toContain('ON DELETE CASCADE')
+  })
+
+  it('migration 002 drops policy before creating (idempotent)', () => {
+    const migration = integrationSchemaExtension.migrations[1]!
+    const dropIdx = migration.up.findIndex((sql) =>
+      sql.includes('DROP POLICY IF EXISTS iss_tenant_isolation'),
+    )
+    const createIdx = migration.up.findIndex((sql) =>
+      sql.includes('CREATE POLICY iss_tenant_isolation'),
+    )
+    expect(dropIdx).toBeGreaterThanOrEqual(0)
+    expect(createIdx).toBeGreaterThan(dropIdx)
+  })
 })

--- a/packages/integrations/src/schema-extension.ts
+++ b/packages/integrations/src/schema-extension.ts
@@ -35,6 +35,7 @@ export const integrationSchemaExtension: PluginSchemaExtension = {
         `CREATE INDEX IF NOT EXISTS ic_org_status_idx
           ON integration_connections(organization_id, status)`,
         `ALTER TABLE integration_connections ENABLE ROW LEVEL SECURITY`,
+        `DROP POLICY IF EXISTS ic_tenant_isolation ON integration_connections`,
         `CREATE POLICY ic_tenant_isolation ON integration_connections
           USING (organization_id = current_setting('app.current_org_id', TRUE))`,
       ],
@@ -47,7 +48,7 @@ export const integrationSchemaExtension: PluginSchemaExtension = {
       up: [
         `CREATE TABLE IF NOT EXISTS integration_sync_state (
           id TEXT PRIMARY KEY,
-          connection_id TEXT NOT NULL,
+          connection_id TEXT NOT NULL REFERENCES integration_connections(id) ON DELETE CASCADE,
           stream TEXT NOT NULL,
           cursor TEXT,
           processed_event_ids JSONB DEFAULT '[]'::jsonb,
@@ -59,6 +60,7 @@ export const integrationSchemaExtension: PluginSchemaExtension = {
         `CREATE INDEX IF NOT EXISTS iss_connection_stream_idx
           ON integration_sync_state(connection_id, stream)`,
         `ALTER TABLE integration_sync_state ENABLE ROW LEVEL SECURITY`,
+        `DROP POLICY IF EXISTS iss_tenant_isolation ON integration_sync_state`,
         `CREATE POLICY iss_tenant_isolation ON integration_sync_state
           USING (
             connection_id IN (

--- a/packages/integrations/src/stripe/sync.test.ts
+++ b/packages/integrations/src/stripe/sync.test.ts
@@ -134,6 +134,24 @@ describe('Stripe sync', () => {
       expect(result.data.session.paymentIntentId).toBeUndefined()
     })
 
+    it('does not include undefined values in payment metadata', async () => {
+      const { syncStripeCheckoutSession } = await loadSync()
+      // Session with no payment_intent and no customer_details
+      mockCheckoutSessionsRetrieve.mockResolvedValue({
+        id: 'cs_1',
+        payment_status: 'paid',
+        amount_total: 1000,
+        currency: 'usd',
+        payment_intent: null,
+        customer_details: null,
+        metadata: null,
+      })
+
+      const result = await syncStripeCheckoutSession(TEST_CONFIG, 'cs_1')
+      const values = Object.values(result.data.payment.metadata ?? {})
+      expect(values.every(v => v !== undefined)).toBe(true)
+    })
+
     it('maps errors to IntegrationError', async () => {
       const { syncStripeCheckoutSession } = await loadSync()
       mockCheckoutSessionsRetrieve.mockRejectedValue(new Error('Session not found'))

--- a/packages/integrations/src/stripe/sync.ts
+++ b/packages/integrations/src/stripe/sync.ts
@@ -48,8 +48,8 @@ export async function syncStripeCheckoutSession(
       external_id: session.id,
       metadata: {
         stripe_session_id: session.id,
-        stripe_payment_intent: checkoutSync.paymentIntentId,
-        stripe_customer_email: checkoutSync.customerEmail,
+        ...(checkoutSync.paymentIntentId != null ? { stripe_payment_intent: checkoutSync.paymentIntentId } : {}),
+        ...(checkoutSync.customerEmail != null ? { stripe_customer_email: checkoutSync.customerEmail } : {}),
       },
     }
 

--- a/packages/mcp/src/__tests__/activities.test.ts
+++ b/packages/mcp/src/__tests__/activities.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { handleLogActivity } from '../tools/activities.js'
+
+describe('handleLogActivity', () => {
+  it('passes body field (not description) to SDK', async () => {
+    const mockLog = vi.fn().mockResolvedValue({ id: 'act_1', type: 'call', body: 'notes' })
+    const client = { activities: { log: mockLog } } as unknown
+
+    await handleLogActivity(client as never, {
+      type: 'call',
+      body: 'notes from the call',
+      occurred_at: '2026-04-10T10:00:00Z',
+    })
+
+    const callArg = mockLog.mock.calls[0]![0]
+    expect(callArg).toHaveProperty('body')
+    expect(callArg).not.toHaveProperty('description')
+  })
+
+  it('passes logged_by_user_id field (not user_id) to SDK', async () => {
+    const mockLog = vi.fn().mockResolvedValue({ id: 'act_2', type: 'call' })
+    const client = { activities: { log: mockLog } } as unknown
+
+    await handleLogActivity(client as never, {
+      type: 'call',
+      logged_by_user_id: 'usr_abc',
+      occurred_at: '2026-04-10T10:00:00Z',
+    })
+
+    const callArg = mockLog.mock.calls[0]![0]
+    expect(callArg).toHaveProperty('logged_by_user_id')
+    expect(callArg).not.toHaveProperty('user_id')
+  })
+
+  it('returns error result for invalid input (safeParse)', async () => {
+    const mockLog = vi.fn()
+    const client = { activities: { log: mockLog } } as unknown
+
+    const result = await handleLogActivity(client as never, { occurred_at: '2026-04-10T10:00:00Z' })
+
+    expect(mockLog).not.toHaveBeenCalled()
+    const text = (result as { content: Array<{ text: string }> }).content[0]?.text ?? ''
+    const parsed = JSON.parse(text) as { ok: boolean; data: { error: string } }
+    expect(parsed.data).toHaveProperty('error', 'Invalid input')
+    const details = (parsed.data as { details?: string }).details
+    expect(typeof details).toBe('string')
+    expect(details).not.toMatch(/^\[{/) // must not be a raw JSON-encoded array
+  })
+})

--- a/packages/mcp/src/__tests__/workflows.test.ts
+++ b/packages/mcp/src/__tests__/workflows.test.ts
@@ -65,7 +65,7 @@ describe('workflow tools', () => {
       contact_id: 'contact_01',
       company_id: 'company_01',
       deal_id: 'deal_01',
-      user_id: 'user_01',
+      logged_by_user_id: 'user_01',
       type: 'email',
       limit: 5,
     })
@@ -73,7 +73,7 @@ describe('workflow tools', () => {
       contact_id: 'contact_01',
       company_id: 'company_01',
       deal_id: 'deal_01',
-      user_id: 'user_01',
+      logged_by_user_id: 'user_01',
       type: 'email',
       limit: 5,
     })

--- a/packages/mcp/src/tools/activities.ts
+++ b/packages/mcp/src/tools/activities.ts
@@ -8,11 +8,11 @@ import { sanitizeStringInput, truncateUnknownStringsWithMeta } from '../output/t
 const LogActivityInput = z.object({
   type: z.string(),
   subject: z.string().optional(),
-  description: z.string().optional(),
+  body: z.string().optional(),
   contact_id: z.string().optional(),
   company_id: z.string().optional(),
   deal_id: z.string().optional(),
-  user_id: z.string().optional(),
+  logged_by_user_id: z.string().optional(),
   occurred_at: z.string(),
   custom_fields: z.record(z.string(), z.unknown()).optional(),
 })
@@ -21,7 +21,7 @@ const ListActivitiesInput = z.object({
   contact_id: z.string().optional(),
   company_id: z.string().optional(),
   deal_id: z.string().optional(),
-  user_id: z.string().optional(),
+  logged_by_user_id: z.string().optional(),
   type: z.string().optional(),
   limit: LimitSchema,
   cursor: z.string().optional(),
@@ -46,18 +46,22 @@ export const listActivitiesTool = defineTool({
 })
 
 export async function handleLogActivity(client: OrbitClient, rawArgs: unknown) {
-  const args = LogActivityInput.parse(rawArgs)
+  const parsed = LogActivityInput.safeParse(rawArgs)
+  if (!parsed.success) {
+    return toToolSuccess({ error: 'Invalid input', details: parsed.error.issues.map((i) => i.message).join('; ') })
+  }
+  const args = parsed.data
   return toToolSuccess(
     sanitizeObjectDeep(
       await client.activities.log({
         type: args.type,
         occurred_at: args.occurred_at,
         ...(args.subject ? { subject: sanitizeStringInput(args.subject) } : {}),
-        ...(args.description ? { description: sanitizeStringInput(args.description) } : {}),
+        ...(args.body ? { body: sanitizeStringInput(args.body) } : {}),
         ...(args.contact_id ? { contact_id: args.contact_id } : {}),
         ...(args.company_id ? { company_id: args.company_id } : {}),
         ...(args.deal_id ? { deal_id: args.deal_id } : {}),
-        ...(args.user_id ? { user_id: args.user_id } : {}),
+        ...(args.logged_by_user_id ? { logged_by_user_id: args.logged_by_user_id } : {}),
         ...(args.custom_fields ? { custom_fields: args.custom_fields } : {}),
       }),
     ),
@@ -65,12 +69,16 @@ export async function handleLogActivity(client: OrbitClient, rawArgs: unknown) {
 }
 
 export async function handleListActivities(client: OrbitClient, rawArgs: unknown) {
-  const args = ListActivitiesInput.parse(rawArgs)
+  const parsed = ListActivitiesInput.safeParse(rawArgs)
+  if (!parsed.success) {
+    return toToolSuccess({ error: 'Invalid input', details: parsed.error.issues.map((i) => i.message).join('; ') })
+  }
+  const args = parsed.data
   const raw = await client.activities.list({
     ...(args.contact_id ? { contact_id: args.contact_id } : {}),
     ...(args.company_id ? { company_id: args.company_id } : {}),
     ...(args.deal_id ? { deal_id: args.deal_id } : {}),
-    ...(args.user_id ? { user_id: args.user_id } : {}),
+    ...(args.logged_by_user_id ? { logged_by_user_id: args.logged_by_user_id } : {}),
     ...(args.type ? { type: sanitizeStringInput(args.type) } : {}),
     ...(args.limit !== undefined ? { limit: args.limit } : {}),
     ...(args.cursor ? { cursor: args.cursor } : {}),


### PR DESCRIPTION
## Summary
- **#3/#4**: Gmail polling cursor used as `pageToken` only (not `after:` query); `stoppedEarly` tracks `lastCompletedPageToken` correctly
- **#5**: `userId` threaded through OAuth credential read/write path (getValidAccessToken → getGmailClient/getCalendarClient → all operations)
- **#6/#7**: Schema migration policies use `DROP IF EXISTS` before `CREATE`; `connection_id` FK with `ON DELETE CASCADE`
- **#8/#9**: Idempotency keys use length-prefixed encoding; filter narrowed to `method`+`path`
- **#10**: Stripe sync metadata uses conditional spreads to avoid `undefined` values
- **#11**: MCP activities tool fields renamed `description`→`body`, `user_id`→`logged_by_user_id`; `.parse()`→`.safeParse()`

## Test plan
- [x] 400 integrations tests passing (+10 new)
- [x] 186 MCP tests passing (+3 new)
- [x] Full monorepo build/typecheck/lint clean
- [x] orbit-tenant-safety-review: Tasks 4, 5 — all checks PASS
- [x] Spec compliance + code quality reviews completed per task

🤖 Generated with [Claude Code](https://claude.com/claude-code)