### PR TITLE
fix(integrations,cli,sdk): runtime fixes — booleans, await, retry, redaction, Stripe CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### @orbit-ai/integrations — Review Fixes (18 issues from PRs #29–#34)
+
+#### Security
+- **Fixed**: `findOrCreateContactFromEmail` now passes `organization_id` in contact and company list filters (cross-org bleed prevention)
+- **Fixed**: MIME header injection prevented via `sanitizeMimeHeader()` — strips CR/LF from To/Subject/Cc
+- **Fixed**: Email and orgId validation guards added to shared contact helper
+
+#### Data Integrity
+- **Fixed**: Gmail polling cursor used as `pageToken` only (not `after:` query); `stoppedEarly` tracks `lastCompletedPageToken` correctly
+- **Fixed**: `userId` threaded through OAuth credential read/write path (getValidAccessToken → getGmailClient/getCalendarClient → all operations)
+- **Fixed**: Schema migration policies use `DROP IF EXISTS` before `CREATE`; `connection_id` FK added with `ON DELETE CASCADE`
+- **Fixed**: Idempotency keys use length-prefixed encoding; filter narrowed to include `method`+`path`
+- **Fixed**: Stripe sync metadata uses conditional spreads to avoid `undefined` values
+
+#### Runtime
+- **Fixed**: Boolean CLI option defaults preserved (not stringified via `String(false)`)
+- **Fixed**: `maxAttempts` validated as positive integer >= 1 in retry helper
+- **Fixed**: `sanitizeIntegrationMetadata` recurses into arrays and nested arrays
+- **Fixed**: Stripe CLI `--amount` validated (NaN/negative/zero rejected)
+- **Fixed**: `commander` moved from `devDependencies` to `dependencies`
+- **Fixed**: `api_key` and `client_secret` added to `SENSITIVE_KEY_PATTERN` (snake_case coverage)
+
+### @orbit-ai/mcp
+- **Fixed**: Activities tool fields renamed `description`→`body`, `user_id`→`logged_by_user_id`; `.parse()`→`.safeParse()`
+
+### @orbit-ai/sdk
+- **Fixed**: Missing `await` in wave2 activity test
+
+### @orbit-ai/cli
+- **Fixed**: Boolean option defaults preserved in integration CLI commands
+
 ### @orbit-ai/integrations
 - **Added**: Package scaffold with plugin contract and error model
 - **Added**: Integration tables (integration_connections, integration_sync_state) with RLS

--- a/packages/cli/src/__tests__/integrations.test.ts
+++ b/packages/cli/src/__tests__/integrations.test.ts
@@ -51,6 +51,72 @@ describe('registerIntegrationSubcommands', () => {
     expect(optionFlags).toContain('--live')
   })
 
+  it('preserves boolean false default without stringifying it', () => {
+    const program = new Command()
+
+    registerIntegrationSubcommands(program, [
+      {
+        name: 'stripe',
+        description: 'Stripe integration',
+        action: vi.fn(),
+        options: [
+          { flags: '--live', description: 'Use live mode', defaultValue: false },
+        ],
+      },
+    ])
+
+    const integrationsCmd = program.commands.find((c) => c.name() === 'integrations')
+    const stripeCmd = integrationsCmd?.commands.find((c) => c.name() === 'stripe')
+    const liveOption = stripeCmd!.options.find((o) => o.flags === '--live')
+    expect(liveOption).toBeDefined()
+    // Must be boolean false, NOT the string 'false' (which is truthy)
+    expect(liveOption!.defaultValue).toBe(false)
+    expect(liveOption!.defaultValue).not.toBe('false')
+  })
+
+  it('preserves boolean true default without stringifying it', () => {
+    const program = new Command()
+
+    registerIntegrationSubcommands(program, [
+      {
+        name: 'gmail',
+        description: 'Gmail integration',
+        action: vi.fn(),
+        options: [
+          { flags: '--auto-sync', description: 'Enable auto sync', defaultValue: true },
+        ],
+      },
+    ])
+
+    const integrationsCmd = program.commands.find((c) => c.name() === 'integrations')
+    const gmailCmd = integrationsCmd?.commands.find((c) => c.name() === 'gmail')
+    const autoSyncOption = gmailCmd!.options.find((o) => o.flags === '--auto-sync')
+    expect(autoSyncOption).toBeDefined()
+    expect(autoSyncOption!.defaultValue).toBe(true)
+    expect(autoSyncOption!.defaultValue).not.toBe('true')
+  })
+
+  it('still stringifies non-boolean defaults', () => {
+    const program = new Command()
+
+    registerIntegrationSubcommands(program, [
+      {
+        name: 'stripe',
+        description: 'Stripe integration',
+        action: vi.fn(),
+        options: [
+          { flags: '--timeout <ms>', description: 'Timeout in ms', defaultValue: '5000' },
+        ],
+      },
+    ])
+
+    const integrationsCmd = program.commands.find((c) => c.name() === 'integrations')
+    const stripeCmd = integrationsCmd?.commands.find((c) => c.name() === 'stripe')
+    const timeoutOption = stripeCmd!.options.find((o) => o.flags === '--timeout <ms>')
+    expect(timeoutOption).toBeDefined()
+    expect(timeoutOption!.defaultValue).toBe('5000')
+  })
+
   it('with empty plugins array registers the parent command with no subcommands', () => {
     const program = new Command()
 

--- a/packages/cli/src/commands/integrations.ts
+++ b/packages/cli/src/commands/integrations.ts
@@ -32,7 +32,11 @@ export function registerIntegrationSubcommands(program: Command, plugins: Integr
     if (plugin.options) {
       for (const opt of plugin.options) {
         if (opt.defaultValue !== undefined) {
-          sub.option(opt.flags, opt.description, String(opt.defaultValue))
+          sub.option(
+            opt.flags,
+            opt.description,
+            typeof opt.defaultValue === 'boolean' ? opt.defaultValue : String(opt.defaultValue),
+          )
         } else {
           sub.option(opt.flags, opt.description)
         }

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@orbit-ai/core": "workspace:*",
     "@orbit-ai/sdk": "workspace:*",
+    "commander": "^12.0.0",
     "drizzle-orm": "^0.44.5",
     "google-auth-library": "^9.0.0",
     "googleapis": "^144.0.0",
@@ -28,7 +29,6 @@
     "zod": "^4.1.11"
   },
   "devDependencies": {
-    "commander": "^12.0.0",
     "vitest": "^3.2.4"
   },
   "files": [

--- a/packages/integrations/src/cli.test.ts
+++ b/packages/integrations/src/cli.test.ts
@@ -164,4 +164,65 @@ describe('registerIntegrationCommands', () => {
   it('is a function (shape check)', () => {
     expect(typeof registerIntegrationCommands).toBe('function')
   })
+
+  it('preserves boolean false default — does not stringify to "false"', () => {
+    const { Command } = require('commander') as typeof import('commander')
+    const program = new Command()
+    program.command('integrations').description('Manage integrations')
+
+    const boolCmd: IntegrationCommand = {
+      name: 'stripe',
+      description: 'Stripe integration',
+      action: vi.fn(),
+      options: [
+        { flags: '--live', description: 'Use live mode', defaultValue: false },
+      ],
+    }
+    const plugin = makePlugin('stripe', { commands: [boolCmd] })
+    const registry = new IntegrationRegistry()
+    registry.register(plugin)
+
+    const config = { integrations: { stripe: { enabled: true, config: {} } } }
+    registerIntegrationCommands(program, registry, config)
+
+    const intCmd = program.commands.find((c: { name: () => string }) => c.name() === 'integrations')
+    const stripeCmd = intCmd?.commands.find((c: { name: () => string }) => c.name() === 'stripe')
+    expect(stripeCmd).toBeDefined()
+
+    const liveOption = stripeCmd!.options.find((o: { flags: string }) => o.flags === '--live')
+    expect(liveOption).toBeDefined()
+    // Must be boolean false, NOT the string 'false' (which is truthy)
+    expect(liveOption!.defaultValue).toBe(false)
+    expect(liveOption!.defaultValue).not.toBe('false')
+  })
+
+  it('preserves boolean true default — does not stringify to "true"', () => {
+    const { Command } = require('commander') as typeof import('commander')
+    const program = new Command()
+    program.command('integrations').description('Manage integrations')
+
+    const boolCmd: IntegrationCommand = {
+      name: 'gmail',
+      description: 'Gmail integration',
+      action: vi.fn(),
+      options: [
+        { flags: '--auto-sync', description: 'Enable auto sync', defaultValue: true },
+      ],
+    }
+    const plugin = makePlugin('gmail', { commands: [boolCmd] })
+    const registry = new IntegrationRegistry()
+    registry.register(plugin)
+
+    const config = { integrations: { gmail: { enabled: true, config: {} } } }
+    registerIntegrationCommands(program, registry, config)
+
+    const intCmd = program.commands.find((c: { name: () => string }) => c.name() === 'integrations')
+    const gmailCmd = intCmd?.commands.find((c: { name: () => string }) => c.name() === 'gmail')
+    expect(gmailCmd).toBeDefined()
+
+    const autoSyncOption = gmailCmd!.options.find((o: { flags: string }) => o.flags === '--auto-sync')
+    expect(autoSyncOption).toBeDefined()
+    expect(autoSyncOption!.defaultValue).toBe(true)
+    expect(autoSyncOption!.defaultValue).not.toBe('true')
+  })
 })

--- a/packages/integrations/src/cli.ts
+++ b/packages/integrations/src/cli.ts
@@ -78,7 +78,11 @@ export function registerIntegrationCommands(
     if (cmd.options) {
       for (const opt of cmd.options) {
         if (opt.defaultValue != null) {
-          sub.option(opt.flags, opt.description, String(opt.defaultValue))
+          sub.option(
+            opt.flags,
+            opt.description,
+            typeof opt.defaultValue === 'boolean' ? opt.defaultValue : String(opt.defaultValue),
+          )
         } else {
           sub.option(opt.flags, opt.description)
         }

--- a/packages/integrations/src/redaction.test.ts
+++ b/packages/integrations/src/redaction.test.ts
@@ -16,6 +16,8 @@ describe('isSensitiveIntegrationKey', () => {
     'private_key',
     'signature',
     'credential',
+    'api_key',
+    'client_secret',
   ])('"%s" → true (exact match)', (key) => {
     expect(isSensitiveIntegrationKey(key)).toBe(true)
   })
@@ -129,11 +131,35 @@ describe('sanitizeIntegrationMetadata', () => {
     expect(result['created_at']).toBe('2026-01-01T00:00:00Z')
   })
 
-  it('preserves arrays as-is (does not recurse into array elements)', () => {
+  it('preserves primitive arrays unchanged', () => {
     const obj = { scopes: ['read', 'write'], count: 2 }
     const result = sanitizeIntegrationMetadata(obj)
     expect(result['scopes']).toEqual(['read', 'write'])
     expect(result['count']).toBe(2)
+  })
+
+  it('sanitizes sensitive keys inside array elements', () => {
+    const obj = {
+      connections: [
+        { name: 'gmail', accessToken: 'ya29.secret', status: 'active' },
+        { name: 'stripe', apiKey: 'sk_live_abc', status: 'active' },
+      ],
+    }
+    const result = sanitizeIntegrationMetadata(obj)
+    const connections = result['connections'] as Array<Record<string, unknown>>
+    expect(connections[0]!['accessToken']).toBe('[REDACTED]')
+    expect(connections[1]!['apiKey']).toBe('[REDACTED]')
+    expect(connections[0]!['name']).toBe('gmail')
+  })
+
+  it('sanitizes sensitive keys inside nested arrays (arrays within arrays)', () => {
+    const obj = {
+      data: [[{ token: 'secret_value', name: 'test' }]],
+    }
+    const result = sanitizeIntegrationMetadata(obj)
+    const inner = (result['data'] as unknown[][])[0]! as Array<Record<string, unknown>>
+    expect(inner[0]!['token']).toBe('[REDACTED]')
+    expect(inner[0]!['name']).toBe('test')
   })
 
   it('returns empty object when depth exceeds 10 (cycle protection)', () => {

--- a/packages/integrations/src/redaction.ts
+++ b/packages/integrations/src/redaction.ts
@@ -5,7 +5,7 @@
 
 // Sensitive key patterns — exact boundary match using word boundaries
 // Keys like 'authorized_at', 'auth_provider', 'authorization_type' must NOT be redacted
-const SENSITIVE_KEY_PATTERN = /^(token|secret|signature|credential|password|private_key|refresh_token|access_token)$/i
+const SENSITIVE_KEY_PATTERN = /^(token|secret|signature|credential|password|private_key|refresh_token|access_token|api_key|client_secret)$/i
 
 /**
  * Check if an object key should be redacted.
@@ -36,6 +36,16 @@ export function redactProviderError(message: string): string {
     .replace(/\b(token|secret|key|password)=[^\s&"']+/gi, '$1=[REDACTED]')
 }
 
+function sanitizeMetadataValue(value: unknown, depth: number): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeMetadataValue(item, depth))
+  }
+  if (value !== null && typeof value === 'object') {
+    return sanitizeIntegrationMetadata(value as Record<string, unknown>, depth + 1)
+  }
+  return value
+}
+
 /**
  * Recursively sanitize a metadata object, redacting sensitive keys.
  * Must be applied recursively — top-level-only sanitization leaks nested secrets.
@@ -49,7 +59,9 @@ export function sanitizeIntegrationMetadata(
   for (const [key, value] of Object.entries(obj)) {
     if (isSensitiveIntegrationKey(key)) {
       result[key] = '[REDACTED]'
-    } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    } else if (Array.isArray(value)) {
+      result[key] = value.map((item) => sanitizeMetadataValue(item, depth))
+    } else if (value !== null && typeof value === 'object') {
       result[key] = sanitizeIntegrationMetadata(value as Record<string, unknown>, depth + 1)
     } else {
       result[key] = value

--- a/packages/integrations/src/retry.test.ts
+++ b/packages/integrations/src/retry.test.ts
@@ -83,6 +83,24 @@ describe('withBoundedRetry', () => {
     ).rejects.toThrow('Bad Gateway')
     expect(fn).toHaveBeenCalledTimes(5)
   })
+
+  it('throws immediately when maxAttempts is 0', async () => {
+    await expect(
+      withBoundedRetry(() => Promise.resolve('ok'), { maxAttempts: 0, baseDelayMs: 0, jitter: false }),
+    ).rejects.toThrow('maxAttempts must be a positive integer >= 1')
+  })
+
+  it('throws immediately when maxAttempts is negative', async () => {
+    await expect(
+      withBoundedRetry(() => Promise.resolve('ok'), { maxAttempts: -1, baseDelayMs: 0, jitter: false }),
+    ).rejects.toThrow('maxAttempts must be a positive integer >= 1')
+  })
+
+  it('throws immediately when maxAttempts is fractional', async () => {
+    await expect(
+      withBoundedRetry(() => Promise.resolve('ok'), { maxAttempts: 0.5, baseDelayMs: 0, jitter: false }),
+    ).rejects.toThrow('maxAttempts must be a positive integer >= 1')
+  })
 })
 
 describe('isRetryableError', () => {

--- a/packages/integrations/src/retry.ts
+++ b/packages/integrations/src/retry.ts
@@ -18,6 +18,10 @@ export async function withBoundedRetry<T>(
   const maxDelayMs = options.maxDelayMs ?? 10_000
   const jitter = options.jitter ?? true
 
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new Error('maxAttempts must be a positive integer >= 1')
+  }
+
   let lastError: unknown
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {

--- a/packages/integrations/src/stripe/mcp-tools.test.ts
+++ b/packages/integrations/src/stripe/mcp-tools.test.ts
@@ -190,4 +190,18 @@ describe('buildStripeCommands', () => {
     expect(errorSpy).toHaveBeenCalledWith('--session-id is required')
     errorSpy.mockRestore()
   })
+
+  it('link-create prints error and returns when amount is missing/NaN', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const commands = buildStripeCommands(makeContext())
+    const linkCreate = commands.find((c) => c.name === 'link-create')!
+
+    // Simulate Commander passing opts with missing amount
+    await linkCreate.action({ currency: 'usd' })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('--amount must be a positive number'),
+    )
+    consoleSpy.mockRestore()
+  })
 })

--- a/packages/integrations/src/stripe/mcp-tools.ts
+++ b/packages/integrations/src/stripe/mcp-tools.ts
@@ -72,10 +72,15 @@ export function buildStripeCommands(context: StripeToolContext): IntegrationComm
       ],
       async action(...args: unknown[]) {
         const opts = args[args.length - 1] as Record<string, string>
+        const amount = Number(opts['amount'])
+        if (!Number.isFinite(amount) || amount <= 0) {
+          console.error('Error: --amount must be a positive number (in cents)')
+          return
+        }
         try {
           const description = opts['description'] as string | undefined
           const result = await createPaymentLink(context.config, {
-            amount: Number(opts['amount']),
+            amount,
             currency: opts['currency'] ?? 'usd',
             ...(description !== undefined ? { description } : {}),
           })

--- a/packages/sdk/src/__tests__/resources-wave2.test.ts
+++ b/packages/sdk/src/__tests__/resources-wave2.test.ts
@@ -119,7 +119,7 @@ describe('ActivityResource', () => {
     })
   })
 
-  it('ActivityRecord wire format uses logged_by_user_id, not user_id', () => {
+  it('ActivityRecord wire format uses logged_by_user_id, not user_id', async () => {
     // Type-level check: CreateActivityInput must accept logged_by_user_id
     // and must not accept user_id (this is enforced by TypeScript, tested here
     // by verifying the transport receives the correct field name at runtime)
@@ -130,7 +130,7 @@ describe('ActivityResource', () => {
     }
     transport.request.mockResolvedValue(makeEnvelope({ id: 'act_4', ...input }))
 
-    activities.create(input)
+    await activities.create(input)
 
     expect(transport.request).toHaveBeenCalledWith({
       method: 'POST',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@orbit-ai/sdk':
         specifier: workspace:*
         version: link:../sdk
+      commander:
+        specifier: ^12.0.0
+        version: 12.1.0
       drizzle-orm:
         specifier: ^0.44.5
         version: 0.44.7(@types/pg@8.20.0)(pg@8.20.0)
@@ -144,9 +147,6 @@ importers:
         specifier: ^4.1.11
         version: 4.3.6
     devDependencies:
-      commander:
-        specifier: ^12.0.0
-        version: 12.1.0
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.12.0)(tsx@4.21.0)


### PR DESCRIPTION
## Summary
- **#12**: Boolean CLI option defaults preserved (not stringified via `String(false)`)
- **#13**: Missing `await` added in SDK wave2 activity test
- **#14**: `maxAttempts` validated as positive integer >= 1 in retry helper
- **#15**: `sanitizeIntegrationMetadata` recurses into arrays and nested arrays
- **#17**: Stripe CLI `--amount` validated (NaN/negative/zero rejected)
- **#18**: `commander` moved from `devDependencies` to `dependencies`
- `api_key` and `client_secret` added to `SENSITIVE_KEY_PATTERN` (snake_case coverage gap)
- CHANGELOG.md updated with all 18 review fixes

## Test plan
- [x] 400 integrations tests passing (+8 new)
- [x] 183 CLI tests passing (+3 new)
- [x] 198 SDK tests passing (+1 fixed)
- [x] Full monorepo build/typecheck/lint clean
- [x] orbit-tenant-safety-review: Task 12 — all checks PASS (after api_key/client_secret fix)
- [x] Spec compliance + code quality reviews completed per task

🤖 Generated with [Claude Code](https://claude.com/claude-code)