### PR TITLE
docs: public launch prep — READMEs, AGENTS.MD, llms.txt, security docs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "WebSearch",
       "Skill(hookify:help)",
       "Skill(hookify:list)",
-      "Skill(pr-review-toolkit:review-pr)"
+      "Skill(pr-review-toolkit:review-pr)",
+      "Skill(codex:rescue)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,9 @@ temp/
 .claude/worktrees/
 
 # Internal planning docs — kept locally, not tracked in the public repo
-docs/
-# Re-allow public security documentation
-!docs/security/
+# (docs/* + negations used instead of docs/ so git can apply per-file exceptions)
+docs/*
+!docs/security
+docs/security/*
 !docs/security/security-architecture.md
 !docs/security/database-hardening-checklist.md

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,281 +1,202 @@
-# AGENTS.MD — Orbit AI
+# AGENTS.md — Orbit AI
 
-This file is machine-readable documentation for AI agents (Claude Code, Cursor, Copilot, and others). It describes what this project is, how it is structured, and how to contribute correctly.
+Orbit AI is CRM infrastructure for AI agents and developers: type-safe entities, a REST API, TypeScript SDK, CLI, MCP server, and Gmail/Calendar/Stripe connectors. It is not a hosted product — it is a set of packages you deploy alongside your application.
 
----
-
-## What Is This Project
-
-Orbit AI is CRM infrastructure for AI agents and developers. It is NOT a CRM application. It provides the schema, CLI, SDK, REST API, and MCP server that let agents and developers build, manage, and extend their own CRM programmatically.
-
-Analogy: Resend is to email what Orbit AI is to CRM.
-
-The project is a TypeScript monorepo using Turborepo and pnpm workspaces. It is in pre-alpha. No packages are published yet.
+**Status:** `0.1.0-alpha`. API is stable within the alpha series. Not yet on npm — install from source.
 
 ---
 
-## Repository Structure
+## Surface Selection
 
-```
-orbit-ai/
-├── packages/
-│   ├── core/          # @orbit-ai/core — schema engine, entities, adapters
-│   ├── sdk/           # @orbit-ai/sdk — TypeScript client SDK
-│   ├── api/           # @orbit-ai/api — Hono REST API server
-│   ├── mcp/           # @orbit-ai/mcp — MCP server (20+ tools)
-│   └── cli/           # orbit CLI tool
-├── apps/
-│   └── docs/          # Documentation site
-├── examples/
-│   ├── nextjs-crm/    # Reference Next.js app built with @orbit-ai/sdk
-│   └── agent-workflow/ # Agent-driven CRM automation example
-├── docs/
-│   ├── strategy/
-│   │   ├── orbit-ai-prd.md   # Product Requirements Document
-│   │   └── orbit-ai-ard.md   # Architecture Research Document
-│   └── research/
-│       └── competitive-analysis.md
-├── AGENTS.MD          # This file
-├── README.md
-├── LICENSE            # MIT
-├── turbo.json
-└── pnpm-workspace.yaml
-```
+Choose one surface. They share the same entity model and auth contract.
+
+| Surface | When to use |
+|---|---|
+| **MCP** (`@orbit-ai/mcp`) | You are running inside Claude, Cursor, Copilot, or another MCP host. Use the 23 built-in tools. |
+| **SDK** (`@orbit-ai/sdk`) | You are writing TypeScript server-side code. HTTP mode (against a running API) or DirectTransport (in-process, no network, trusted contexts only). |
+| **API** (`@orbit-ai/api`) | You are calling from any language over HTTP. REST, JSON, standard auth header. |
+| **CLI** (`@orbit-ai/cli`) | You are automating from a shell script or terminal. `orbit <entity> <verb>`. |
 
 ---
 
-## Tech Stack
+## Authentication
 
-| Layer | Technology | Notes |
-|-------|------------|-------|
-| Language | TypeScript (strict) | All packages |
-| Monorepo | Turborepo + pnpm workspaces | `turbo.json` at root |
-| ORM | Drizzle ORM | 7.4KB, Edge-compatible, programmatic migration API |
-| API framework | Hono | 14KB, runs on Node/Bun/Deno/Edge |
-| CLI framework | Commander.js + Ink | Ink for TUI rendering via json-render |
-| MCP | @modelcontextprotocol/sdk | stdio transport (local) + HTTP transport (hosted) |
-| Validation | Zod | Used throughout for schema validation |
-| Test runner | Vitest | |
-| Storage adapters | Supabase (MVP), Neon (MVP), SQLite (MVP) | |
+**API / SDK (HTTP mode)**
+
+```
+Authorization: Bearer <api-key>
+Orbit-Version: 2026-04-01
+```
+
+API keys are per-organization. Scopes: `*` (all), or specific entity scopes like `contacts:read`.
+
+**MCP (HTTP transport)**
+
+Same Bearer token in the `Authorization` header. Auth is enforced per request.
+
+**MCP (stdio transport)**
+
+Pass `ORBIT_API_KEY` as an environment variable when starting the server. The server holds one identity for the lifetime of the process.
+
+**CLI**
+
+```bash
+export ORBIT_API_KEY=orb_...
+export ORBIT_API_BASE_URL=https://api.yourapp.com
+```
+
+Or set `apiKey` and `baseUrl` in `~/.config/orbit/config.json`.
+
+**SDK (DirectTransport)**
+
+No API key. Pass `adapter` and `context: { orgId }` directly. Only for trusted server-side code — bypasses auth, rate limiting, and scope enforcement.
 
 ---
 
-## Key Concepts
+## Entity Inventory
 
-### Schema Engine
+All entities share the same ID prefix convention (`cnt_`, `cmp_`, etc.) and support CRUD + cursor-based list pagination.
 
-The core differentiator. Allows safe, agent-driven schema evolution.
+| Entity | ID prefix | What it is |
+|---|---|---|
+| `contacts` | `cnt_` | People — leads, customers, prospects |
+| `companies` | `cmp_` | Organizations that contacts belong to |
+| `deals` | `deal_` | Sales opportunities moving through a pipeline |
+| `pipelines` | `pip_` | Named pipelines containing ordered stages |
+| `stages` | `stg_` | Stages within a pipeline (ordered by `position`) |
+| `users` | `usr_` | Team members with access to the org |
+| `activities` | `act_` | Logged interactions: calls, emails, meetings, notes |
+| `tasks` | `tsk_` | To-do items assigned to users |
+| `notes` | `nte_` | Free-text notes attached to any record |
+| `products` | `prd_` | Product or service catalog items |
+| `payments` | `pay_` | Payment records (often synced from Stripe) |
+| `contracts` | `ctr_` | Contract records |
+| `sequences` | `seq_` | Automated contact engagement sequences |
+| `tags` | `tag_` | Labels attached to any record |
+| `webhooks` | `whk_` | Outbound webhook subscriptions |
+| `imports` | `imp_` | Bulk import jobs |
 
-When `orbit schema add-field contacts wedding_date date --nullable` runs:
-1. Validates field name, type compatibility, no conflicts
-2. Generates migration SQL via `drizzle-kit/api` — `generateMigration()`
-3. Updates RLS policies to cover the new field
-4. Regenerates TypeScript types for the `Contact` type
-5. Updates REST API, SDK, and MCP server to expose the new field
-6. Previews the diff before applying (dry-run by default for agents)
-7. Applies migration in a transaction
-8. Records the migration for rollback
+---
 
-**Agent safety**: Agents can ADD columns/tables. They cannot DROP or rename without explicit `--destructive` flag. On Neon, branch-before-migrate is automatic.
+## Common Patterns
 
-### Core Data Model
-
-Orbit uses one project-scoped database. Inside that database, the developer may run:
-
-- single-organization mode
-- multi-organization mode
-
-The canonical object model is larger than the original CRM surface. Core first-party types include:
-
-```
-organizations, organization_memberships, users, api_keys,
-contacts, companies, deals, pipelines, stages, activities, tasks,
-notes, products, payments, contracts, sequences, sequence_steps,
-sequence_enrollments, sequence_events, tags, entity_tags,
-custom_field_definitions, webhooks, webhook_deliveries, imports,
-schema_migrations, audit_logs, idempotency_keys
-```
-
-Entity IDs are text columns using type-prefixed ULIDs such as `org_`, `contact_`, and `deal_`.
-
-Tenant-scoped tables include:
-- `id`
-- `organization_id`
-- `created_at`
-- `updated_at`
-
-Some entity types also include `custom_fields jsonb` when the spec marks them extensible.
-
-### Multi-Tenancy
-
-Orbit AI does not own the auth layer. The embedding app or hosted runtime provides trusted context.
-
-All tenant data is scoped by `organization_id`. The SDK accepts `context: { userId, orgId }` from the developer's auth provider (Supabase Auth, Clerk, NextAuth, custom).
+### Create a contact and log an activity (SDK)
 
 ```typescript
-const crm = new OrbitClient({
-  apiKey: process.env.ORBIT_API_KEY,
-  context: { userId: 'user_01ABC...', orgId: 'org_01ABC...' }
+const contact = await client.contacts.create({
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+})
+
+await client.activities.create({
+  contactId: contact.id,
+  type: 'email',
+  subject: 'Introduction',
+  body: 'Sent intro email.',
 })
 ```
 
-RLS policies are auto-generated per entity. The pattern:
-```sql
-CREATE POLICY "org_members_only" ON contacts
-  USING (organization_id = orbit.current_org_id());
+### Move a deal through pipeline stages (SDK)
+
+```typescript
+// 1. Find the target stage
+const pipelines = await client.pipelines.list()
+const stage = pipelines.data[0].stages.find(s => s.name === 'Proposal Sent')
+
+// 2. Update the deal
+await client.deals.update(dealId, { stageId: stage.id })
 ```
 
-Important rules:
-- `organizations` is bootstrap-scoped and intentionally does not have `organization_id`
-- tenant-scoped Postgres-family work must run inside `withTenantContext(...)`
-- repositories still filter on `organization_id` even when RLS is enabled
-- request paths may not use privileged migration or bypass credentials
+### Move a deal via MCP
 
-### Agent-Safe Migrations
+```
+Tool: move_deal_stage
+Args: { "deal_id": "deal_01JXXXX", "stage_id": "stg_01JXXXX" }
+```
 
-Non-destructive by default. The `--destructive` flag is required for DROP and RENAME operations. This prevents agents from accidentally destroying production data.
+### Add a custom field to contacts (SDK)
 
-Rollback: Every migration stores its reverse migration. `orbit migrate --rollback` or `crm.schema.rollback()` applies the reverse.
+```typescript
+await client.schema.createCustomField('contacts', {
+  name: 'linkedin_url',
+  label: 'LinkedIn URL',
+  fieldType: 'text',
+})
+```
 
-Branch-before-migrate (Neon): When using the Neon adapter, the schema engine automatically creates a database branch, runs the migration there, validates, then merges. This gives a safe preview on real data.
+### Paginate all contacts (SDK)
 
-### MCP Server
+```typescript
+for await (const contact of client.contacts.pages({ limit: 100 }).autoPaginate()) {
+  console.log(contact.id, contact.name)
+}
+```
 
-The `@orbit-ai/mcp` package exposes 23 core tools across 8 tiers.
-
-The default pattern is Attio-style universal tools with `object_type` parameters rather than one dedicated tool per entity. Example core tools include:
-- `search_records`
-- `get_record`
-- `create_record`
-- `update_record`
-- `delete_record`
-- `list_tasks`
-- `create_note`
-- `get_schema`
-- `create_custom_field`
-- `import_records`
-
-Connector packages may register namespaced extension tools in composite runtimes, but they do not change the 23-tool core contract.
-
-Transport: stdio (local agents) and HTTP (hosted, `mcp.orbit-ai.dev/your-project`).
-
-### CLI Output Modes
-
-Every CLI command supports `--json` for structured output. Agents should always use `--json` mode.
-
-CLI JSON must follow the reconciled shared-envelope rules from the specs. It may not invent metadata separately from the SDK/API contract.
+### Search across entities (CLI)
 
 ```bash
-orbit --json contacts list
-# Returns a structured envelope or first-page JSON contract aligned with the SDK/API specs
-
-orbit --json schema describe
-# Returns: { "entities": { "contacts": { "fields": [...], "relationships": [...] } } }
-
-orbit --json migrate --preview
-# Returns: { "sql": "ALTER TABLE ...", "affected_rows_estimate": 0, "reversible": true }
+orbit search "ada lovelace" --entity contacts --format json
 ```
 
 ---
 
-## How to Contribute
+## Error Codes
 
-### Prerequisites
+All surfaces return structured errors with a `code` field.
 
-- Node.js 20+
-- pnpm 9+
-- A Supabase, Neon, or local Postgres instance (for integration tests)
+| Code | HTTP status | Meaning | Action |
+|---|---|---|---|
+| `RESOURCE_NOT_FOUND` | 404 | Record does not exist or is outside the org scope | Check the ID and org context |
+| `VALIDATION_FAILED` | 422 | Request body failed schema validation | Fix the `details` array in the error |
+| `AUTH_INVALID_API_KEY` | 401 | API key missing, malformed, revoked, or expired | Check `ORBIT_API_KEY` |
+| `AUTH_INSUFFICIENT_SCOPE` | 403 | API key lacks scope for this operation | Use a key with wider scope or `*` |
+| `AUTH_CONTEXT_REQUIRED` | 401 | No org context could be resolved | Pass `orgId` or use a key tied to an org |
+| `RATE_LIMITED` | 429 | Too many requests from this API key | Back off and retry; rate limit is per-key sliding window |
+| `IDEMPOTENCY_CONFLICT` | 409 | Same `Idempotency-Key` used with different payload | Use a new key for a genuinely new request |
+| `PAYLOAD_TOO_LARGE` | 413 | Request body exceeds 1 MB | Split the payload |
+| `INTERNAL_ERROR` | 500 | Server-side error | Retry with exponential backoff; report `request_id` |
 
-Package-specific floor:
+SDK wraps these as `OrbitApiError`:
 
-- `@orbit-ai/mcp` currently requires Node.js 22+ even though the broader repository baseline is Node.js 20+.
+```typescript
+import { OrbitApiError } from '@orbit-ai/sdk'
 
-### Setup
-
-```bash
-git clone https://github.com/sharonsciammas/orbit-ai
-cd orbit-ai
-pnpm install
-pnpm run build
+try {
+  await client.contacts.get('cnt_bad')
+} catch (err) {
+  if (err instanceof OrbitApiError) {
+    console.error(err.code)       // 'RESOURCE_NOT_FOUND'
+    console.error(err.status)     // 404
+    console.error(err.retryable)  // false
+    console.error(err.request_id) // 'req_01JXXXX'
+  }
+}
 ```
 
-### Package Scripts
+---
 
-```bash
-pnpm run build        # Build all packages (via turbo)
-pnpm run dev          # Watch mode for all packages
-pnpm run test         # Run all tests
-pnpm run lint         # Lint all packages
-pnpm run typecheck    # TypeScript type checking
+## Known Alpha Limitations
+
+- **Idempotency store is in-memory** — single-instance only. For multi-instance deployments, implement `IdempotencyStore` and pass via `CreateApiOptions.idempotencyStore`.
+- **Rate limiter is in-memory** — same constraint. A pluggable `RateLimitStore` interface is planned.
+- **API keys are SHA-256 hashed** — HMAC-SHA256 + server pepper is planned for v1 GA.
+- **SQLite has no RLS** — tenant isolation is application-layer only. Do not use SQLite in multi-tenant production.
+- **Packages are not yet on npm** — install from source: `pnpm install && pnpm -r build`.
+- **Batch mutations** — route types exist but batch write implementation is not complete.
+
+---
+
+## Key Files
+
 ```
-
-### Package Organization Rules
-
-1. All packages under `packages/` are internal libraries (`@orbit-ai/*`)
-2. All apps under `apps/` are deployable applications
-3. All examples under `examples/` are standalone demos
-4. Never import across package boundaries using relative paths — always use the package name
-5. Every new tenant-scoped table MUST include `organization_id text NOT NULL`; bootstrap tables are explicitly exempt
-6. Postgres-family tenant tables must receive generated RLS coverage; SQLite relies on app-layer tenant enforcement and is not a production isolation boundary
-
-### Adding a New Entity
-
-1. Update `packages/core/src/schema/tables.ts` and `packages/core/src/schema/relations.ts`
-2. Register the ID prefix in `packages/core/src/ids/prefixes.ts`
-3. Add the object type to `packages/core/src/types/entities.ts`
-4. Add entity repository, service, and validators under `packages/core/src/entities/<entity>/`
-5. Update generated Zod/types and any required search or serializer registration
-6. Add REST route coverage in `packages/api` if the entity is part of the public API surface
-7. Confirm MCP coverage through the 23 core tools or add an allowed extension/semantic tool only if the spec requires it
-8. Add CLI coverage where the command surface requires it
-9. Add `packages/core/src/entities/<entity>/AGENTS.MD`
-
-### Adding a New Storage Adapter
-
-1. Create `packages/core/src/adapters/<name>/index.ts`
-2. Implement the `StorageAdapter` interface from `packages/core/src/adapters/interface.ts`
-3. Export from `packages/core/src/adapters/index.ts`
-4. Document in README.md adapter table
-
-### Migration Guidelines
-
-- Prefer Drizzle definitions and builders as the source of truth; handwritten SQL should be limited to explicitly documented cases such as generated Postgres RLS statements
-- All migrations are transaction-wrapped
-- Every migration MUST have a reverse migration
-- Migration files are stored in `packages/core/src/migrations/`
-- Test migrations on SQLite adapter before Postgres adapters
-
----
-
-## Environment Variables
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `ORBIT_API_KEY` | Yes (hosted) | API key for hosted Orbit AI |
-| `DATABASE_URL` | Yes (self-hosted) | Postgres connection string |
-| `ORBIT_ORG_ID` | No | Default organization ID (can be passed per-request) |
-| `ORBIT_ADAPTER` | No | Storage adapter override (`supabase`, `neon`, `sqlite`) |
-
----
-
-## Current Status
-
-This repository is pre-alpha. No packages are published to npm. The planning, security, and execution baseline now exists. Active implementation starts with `packages/core` slice 1.
-
-See:
-- `docs/KB.md` for the current working hub
-- `docs/strategy/orbit-ai-prd.md` for the product plan
-- `docs/strategy/orbit-ai-ard.md` for technical architecture decisions
-- `docs/execution/core-implementation-plan.md` for the active core execution order
-
----
-
-## Agent Notes
-
-- This is NOT the `smb-sale-crm-app` repository. That is a separate Next.js CRM application. This repository is the Orbit AI infrastructure project.
-- All schema definitions use Drizzle ORM syntax — not Prisma, not MikroORM, not raw SQL strings.
-- The `--json` flag is available on every CLI command. Use it in agent context.
-- Prefer the canonical docs over this file if they conflict, and then update this file.
-- MCP uses the 23-tool core model with universal `object_type` parameters plus optional namespaced extensions.
-- IDs are type-prefixed ULIDs stored in text columns, not UUID columns.
-- License is MIT. The packages are safe to embed in commercial SaaS products.
+README.md                        — quickstart, architecture, dev setup
+AGENTS.md                        — this file
+llms.txt                         — compact machine-readable index
+packages/core/README.md          — schema engine, adapters, migrations
+packages/api/README.md           — REST routes, auth, config reference
+packages/sdk/README.md           — client usage, DirectTransport, pagination
+packages/cli/README.md           — command reference, global flags, config file
+packages/mcp/README.md           — tool reference, server setup, transports
+packages/integrations/README.md  — Gmail, Calendar, Stripe setup guides
+examples/nodejs-quickstart/      — runnable end-to-end example
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,7 @@ pnpm -r lint
 | After each task, during execution | `superpowers:requesting-code-review` | Plan compliance + code quality per task |
 | End of all tasks, before PR | `pr-review-toolkit:review-pr` | 6 specialist agents, confidence ≥80 threshold |
 | After PR is open on GitHub | `code-review:code-review` | Posts structured comment to the PR |
+| Implementer is stuck / needs Codex cross-check | `codex:rescue` | Delegates investigation or a targeted fix to Codex via the shared runtime; use when sub-agent is BLOCKED or a second opinion is needed |
 
 Do not substitute one for another — they serve different points in the pipeline.
 

--- a/README.md
+++ b/README.md
@@ -3,24 +3,18 @@
 > **CRM infrastructure for AI agents and developers.** Packages, not a product.
 > (Think: "Resend for CRM" — type-safe primitives, not a UI.)
 
-**Status**: pre-alpha. First npm release (`0.1.0-alpha`) targets `@orbit-ai/core`,
-`@orbit-ai/api`, and `@orbit-ai/sdk`. CLI, MCP server, and integrations (Gmail,
-Google Calendar, Stripe) are next.
+**Status**: `0.1.0-alpha`. All six packages are implemented and tested. Not yet published to npm — install from source (see [Development](#development)).
 
-## What's in this repo today
+## Packages
 
 | Package | Status | Purpose |
 |---|---|---|
 | [`@orbit-ai/core`](packages/core) | ✅ alpha | Schema engine, entities, storage adapters (SQLite, Postgres, Supabase, Neon), tenant context, migrations |
 | [`@orbit-ai/api`](packages/api) | ✅ alpha | Hono-based REST API with auth, scope enforcement, idempotency, rate limiting, sanitization |
 | [`@orbit-ai/sdk`](packages/sdk) | ✅ alpha | TypeScript client with HTTP and direct-core transports, auto-pagination, type-safe resources |
-
-## What's coming next (not in this release)
-
-- `@orbit-ai/cli` — `orbit init`, CRUD commands, `--json` mode, schema tooling
-- `@orbit-ai/integrations` — Gmail, Google Calendar, Stripe connectors
-- `@orbit-ai/mcp` — Model Context Protocol server with 23 core tools
-- A reference web app built on the SDK
+| [`@orbit-ai/cli`](packages/cli) | ✅ alpha | Terminal interface — `orbit init`, CRUD commands, schema tooling, `--json` mode, direct and API mode |
+| [`@orbit-ai/mcp`](packages/mcp) | ✅ alpha | Model Context Protocol server with 23 core tools, stdio and HTTP transports |
+| [`@orbit-ai/integrations`](packages/integrations) | ✅ alpha | Gmail, Google Calendar, and Stripe connectors with OAuth lifecycle and webhook support |
 
 ## Quick look
 
@@ -64,21 +58,28 @@ pnpm add @orbit-ai/core @orbit-ai/api
 
 ## Architecture
 
-Orbit AI is a monorepo (pnpm + Turborepo) with three layered packages:
+Orbit AI is a monorepo (pnpm + Turborepo) with six layered packages:
 
 ```
-┌─────────────────┐   ┌─────────────────┐
-│  @orbit-ai/api  │   │  @orbit-ai/sdk  │
-│   (REST server) │   │ (client lib)    │
-└────────┬────────┘   └────────┬────────┘
-         │                     │
-         │   depends on        │
-         └──────────┬──────────┘
-                    │
-           ┌────────▼─────────┐
-           │  @orbit-ai/core  │
-           │  (schema + adp.) │
-           └──────────────────┘
+┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
+│  @orbit-ai/api   │  │  @orbit-ai/sdk   │  │  @orbit-ai/cli   │
+│  (REST server)   │  │  (client lib)    │  │  (terminal)      │
+└────────┬─────────┘  └────────┬─────────┘  └────────┬─────────┘
+         │                     │                      │
+         └─────────────────────┼──────────────────────┘
+                               │  depends on
+                    ┌──────────▼──────────┐
+                    │   @orbit-ai/core    │
+                    │  (schema + adpts.)  │
+                    └──────────┬──────────┘
+                               │
+          ┌────────────────────┼────────────────────┐
+          │                                         │
+┌─────────▼──────────┐              ┌───────────────▼──────┐
+│  @orbit-ai/mcp     │              │ @orbit-ai/integrations│
+│  (MCP server,      │              │ (Gmail, Calendar,     │
+│   23 tools)        │              │  Stripe)              │
+└────────────────────┘              └──────────────────────┘
 ```
 
 - **core** is the source of truth for schema, entities, storage adapters, tenant
@@ -88,6 +89,11 @@ Orbit AI is a monorepo (pnpm + Turborepo) with three layered packages:
 - **sdk** is a TypeScript client that can talk to an api server over HTTP, or run
   in-process directly against a core adapter (DirectTransport) for tests and trusted
   server-side use.
+- **cli** is a terminal interface built on Commander.js with interactive prompts,
+  `--json` mode for scripting, and support for both API and direct modes.
+- **mcp** is a Model Context Protocol server exposing 23 tools over stdio or HTTP.
+- **integrations** provides Gmail, Google Calendar, and Stripe connectors with full
+  OAuth lifecycle management and webhook support.
 
 ## Development
 
@@ -135,8 +141,7 @@ checklist.
 - Idempotency and rate limiting are **in-memory by default** — single-instance deployments
   only. For multi-instance, implement the `IdempotencyStore` interface and pass it via
   `CreateApiOptions`.
-- The full list of known alpha gaps lives in
-  [`docs/review/2026-04-08-post-stack-audit.md`](docs/review/2026-04-08-post-stack-audit.md).
+- The full list of known alpha gaps is documented in [`AGENTS.md`](AGENTS.md#known-alpha-limitations).
 
 ## Contributing
 
@@ -146,10 +151,9 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 MIT — see [`LICENSE`](LICENSE).
 
-## Key planning docs
+## What's next
 
-- [`docs/META-PLAN.md`](docs/META-PLAN.md) — master plan
-- [`docs/IMPLEMENTATION-PLAN.md`](docs/IMPLEMENTATION-PLAN.md) — execution baseline
-- [`docs/product/release-definition-v1.md`](docs/product/release-definition-v1.md) — what v1 GA requires
-- [`docs/specs/01-core.md`](docs/specs/01-core.md) through [`06-integrations.md`](docs/specs/06-integrations.md) — per-component specs
-- [`docs/review/2026-04-08-post-stack-audit.md`](docs/review/2026-04-08-post-stack-audit.md) — post-stack audit (alpha readiness)
+- **npm publish** — `0.1.0-alpha.1` will be the first public npm release. Until then, install from source: `pnpm install && pnpm -r build`.
+- **Hosted tier** — a managed Orbit AI API endpoint (beta) is planned alongside the npm release.
+- **E2E test suite** — cross-surface journey tests and multi-tenant denial tests are in progress.
+- **Documentation site** — a full docs site is planned post-publish.

--- a/docs/security/database-hardening-checklist.md
+++ b/docs/security/database-hardening-checklist.md
@@ -1,0 +1,255 @@
+# Orbit AI Database Hardening Checklist
+
+Date: 2026-03-31
+Status: Draft
+Applies to:
+- Supabase
+- Neon
+- raw Postgres
+- SQLite for local development and adapter compatibility work only
+
+Use this checklist before exposing a new table, route, connector, or environment.
+
+## 1. Role and Privilege Hardening
+
+### 1.1 Required
+
+- [ ] separate `migration_role` from `app_role`
+- [ ] ensure runtime roles cannot `ALTER`, `CREATE POLICY`, `DROP`, or install extensions
+- [ ] revoke unnecessary default privileges from `public`
+- [ ] pin `search_path` for runtime roles
+- [ ] keep bootstrap or platform-admin database access separate from tenant runtime access
+
+### 1.2 Release Blockers
+
+- [ ] no request-serving path uses Supabase `service_role`
+- [ ] no shared admin credential is reused for ordinary tenant CRUD
+- [ ] no environment stores production migration credentials where runtime code can access them
+
+## 2. Tenant Isolation and RLS
+
+### 2.1 Table-Level Rules
+
+- [ ] every tenant table has `organization_id not null`
+- [ ] `organizations` is treated as bootstrap-scoped, not as a tenant table
+- [ ] plugin and connector tenant tables are registered as tenant-scoped
+
+### 2.2 Enforcement Rules
+
+- [ ] RLS is enabled on every tenant table for Postgres-family adapters
+- [ ] `select`, `insert`, `update`, and `delete` policies exist for each tenant table
+- [ ] repositories still include explicit org filters even with RLS enabled
+- [ ] direct-core and API paths both route tenant work through `withTenantContext(...)`
+
+### 2.3 Release Blockers
+
+- [ ] no tenant route can access data without tenant context
+- [ ] no table is exposed publicly before RLS and app-layer filtering are both in place
+- [ ] at least one cross-tenant deny test exists for each major entity group
+
+## 3. Tenant Context Safety
+
+### 3.1 Postgres-Family Adapters
+
+- [ ] tenant context is set inside a transaction
+- [ ] transaction-local settings are used, not connection-global settings
+- [ ] tenant context cleanup is guaranteed on success and failure
+
+### 3.2 Pooling Safety
+
+- [ ] behavior is tested under pooled connections
+- [ ] pgbouncer or Supabase pooler behavior is verified for transaction-bound context
+
+### 3.3 Release Blockers
+
+- [ ] no code path relies on connection-global session state for tenant isolation
+- [ ] no shared transaction wrapper can leak `app.current_org_id` across requests
+
+## 4. Schema and Migration Controls
+
+### 4.1 Required
+
+- [ ] migrations run only under `migration_role`
+- [ ] migration execution is serialized with advisory lock or equivalent
+- [ ] rollback metadata is recorded
+- [ ] destructive changes require explicit approval and stronger environment guards
+- [ ] plugin extension tables are registered before migration execution
+
+### 4.2 Pre-Production Checks
+
+- [ ] backup, branch, or snapshot exists before destructive migration
+- [ ] preview output is reviewed before apply
+- [ ] migration audit trail records actor, environment, and result
+
+### 4.3 Release Blockers
+
+- [ ] runtime app credentials cannot run schema migrations
+- [ ] destructive migrations cannot run silently in production
+
+## 5. API Key Storage and Access
+
+### 5.1 Required
+
+- [ ] only hashed API keys are stored
+- [ ] visible prefix is stored separately for lookup and support
+- [ ] scopes, expiry, revoked timestamp, and last-used metadata are recorded
+- [ ] API key actions are audited
+
+### 5.2 Release Blockers
+
+- [ ] no plaintext API key storage
+- [ ] no key material in logs, audit rows, MCP output, or CLI JSON
+- [ ] key rotation and revocation are tested
+
+## 6. Secret Storage and Encryption
+
+### 6.1 Required
+
+- [ ] webhook secrets are encrypted at rest
+- [ ] connector access and refresh tokens are encrypted at rest
+- [ ] provider webhook secrets are encrypted or sourced from external secret management
+- [ ] decryption is limited to the process that needs the secret
+
+### 6.2 Redaction Rules
+
+- [ ] secrets are excluded from logs
+- [ ] secrets are excluded from error payloads
+- [ ] secrets are excluded from audit snapshots
+- [ ] secrets are excluded from support diagnostics by default
+
+### 6.3 Release Blockers
+
+- [ ] no secret values committed to repo or migration files
+- [ ] no undefined or ad hoc secret encryption model in production
+
+## 7. Webhook Hardening
+
+### 7.1 Outbound Customer Webhooks
+
+- [ ] each delivery has event ID, idempotency key, attempt count, and next attempt timestamp
+- [ ] signature format is documented
+- [ ] replay window is documented and tested
+- [ ] retry schedule is bounded
+- [ ] terminal failures move to dead-letter or explicit failed state
+
+### 7.2 Inbound Provider Webhooks
+
+- [ ] provider signature verification is implemented before processing
+- [ ] replay handling is implemented where supported
+- [ ] inbound provider events do not reuse customer outbound delivery pipeline
+
+### 7.3 Release Blockers
+
+- [ ] no webhook endpoint is exposed without verification and retry policy
+- [ ] no customer payload is delivered unsigned
+
+## 8. Connector Credential Hardening
+
+### 8.1 Required
+
+- [ ] `integration_connections` and `integration_sync_state` are tenant-scoped
+- [ ] ownership model is defined per connector
+- [ ] minimal OAuth scopes are documented
+- [ ] token expiry and refresh failure state are tracked
+- [ ] provider webhook IDs and sync cursors are tracked where needed
+
+### 8.2 Operational Controls
+
+- [ ] repeated refresh failure disables the connector in a controlled way
+- [ ] provider metadata storage is limited to required fields
+- [ ] connector actions with side effects are auditable
+
+### 8.3 Release Blockers
+
+- [ ] no connector persists tokens unencrypted
+- [ ] no connector runs with undocumented broad scopes
+
+## 9. Audit Logging
+
+### 9.1 Required
+
+- [ ] audit logs are append-only to runtime roles
+- [ ] access to audit tables is restricted
+- [ ] migration actions are audited
+- [ ] API key actions are audited
+- [ ] webhook configuration changes are audited
+- [ ] connector credential changes are audited
+- [ ] destructive schema actions are audited
+
+### 9.2 Release Blockers
+
+- [ ] runtime roles cannot silently alter or delete audit history
+- [ ] high-sensitivity fields are redacted before write
+
+## 10. Environment-Specific Controls
+
+### 10.1 Supabase
+
+- [ ] service role is isolated from request paths
+- [ ] RLS is tested under the relevant auth contexts
+- [ ] PostgREST or edge-function usage does not bypass intended policies
+- [ ] Vault or secret-storage approach is documented if used
+- [ ] auth sync into Orbit `users` is constrained and validated
+
+### 10.2 Neon
+
+- [ ] branch-before-migrate is used for destructive or high-risk changes where supported
+- [ ] branch lifecycle and cleanup are documented
+- [ ] runtime and migration credentials are separated
+
+### 10.3 Raw Postgres
+
+- [ ] pooler behavior is validated for transaction-bound tenant context
+- [ ] role grants and schema permissions are codified and repeatable
+- [ ] backup and PITR strategy is defined
+
+### 10.4 SQLite
+
+- [ ] SQLite is documented as application-enforced isolation only
+- [ ] SQLite is not presented as equivalent to Postgres multi-tenant security
+- [ ] tenant-sensitive production hosting does not rely on SQLite
+
+## 11. Validation and Testing
+
+### 11.1 Required Test Coverage
+
+- [ ] cross-tenant read deny tests
+- [ ] cross-tenant write deny tests
+- [ ] migration safety tests
+- [ ] webhook signature tests
+- [ ] replay-protection tests
+- [ ] secret redaction tests
+- [ ] connector token handling tests
+
+### 11.2 Release Blockers
+
+- [ ] security tests are required before exposing a new tenant table or mutating route
+- [ ] there is no untested major entity group in tenant-scoped runtime
+
+## 12. Operational Readiness
+
+### 12.1 Required
+
+- [ ] backups are enabled and restore-tested
+- [ ] key rotation runbooks exist
+- [ ] incident owner is assigned
+- [ ] alerts exist for auth failures, webhook failures, migration failures, and connector auth failures
+- [ ] break-glass admin access is documented and controlled
+
+### 12.2 Release Blockers
+
+- [ ] no production environment without backup and restore verification
+- [ ] no production environment without key rotation and incident runbooks
+
+## 13. Minimum Standard Before Public Beta
+
+Orbit AI should not expose a multitenant beta until all blocker items in this checklist pass.
+
+If an item is deferred, the deferral must include:
+
+- owner
+- rationale
+- compensating control
+- date for closure
+
+Unchecked blockers are not documentation gaps. They are release blockers.

--- a/docs/security/security-architecture.md
+++ b/docs/security/security-architecture.md
@@ -1,0 +1,410 @@
+# Orbit AI Security Architecture
+
+Date: 2026-03-31
+Status: Draft
+Primary inputs:
+- [01-core.md](/Users/sharonsciammas/orbit-ai/docs/specs/01-core.md)
+- [02-api.md](/Users/sharonsciammas/orbit-ai/docs/specs/02-api.md)
+- [05-mcp.md](/Users/sharonsciammas/orbit-ai/docs/specs/05-mcp.md)
+- [06-integrations.md](/Users/sharonsciammas/orbit-ai/docs/specs/06-integrations.md)
+- [orbit-ai-prd.md](/Users/sharonsciammas/orbit-ai/docs/strategy/orbit-ai-prd.md)
+- [orbit-ai-ard.md](/Users/sharonsciammas/orbit-ai/docs/strategy/orbit-ai-ard.md)
+
+## 1. Purpose
+
+This document defines the security model for Orbit AI across:
+
+- core services and adapters
+- REST API
+- SDK direct-DB mode
+- CLI
+- MCP runtime
+- migration engine
+- webhook delivery
+- Gmail, Google Calendar, and Stripe connectors
+
+The primary security invariant is tenant isolation. Every other control supports that goal.
+
+## 2. Security Principles
+
+Orbit AI should be implemented and operated according to these principles:
+
+1. Tenant isolation over convenience.
+2. Least privilege for database roles, API keys, workers, and connectors.
+3. Secure-by-default interfaces with explicit escape hatches rather than permissive defaults.
+4. Separation of bootstrap/platform authority from normal tenant authority.
+5. No secrets in logs, envelopes, audit snapshots, CLI output, or MCP responses.
+6. Mutation flows must be attributable, auditable, and replay-resistant.
+7. Schema evolution is a privileged operation, not a normal runtime capability.
+
+## 3. Trust Boundaries
+
+Orbit AI crosses several trust boundaries. They must be treated explicitly in implementation and review.
+
+### 3.1 Public Interface Boundary
+
+This includes:
+
+- HTTP requests to `@orbit-ai/api`
+- CLI invocations in hosted mode
+- MCP requests over stdio or HTTP
+- inbound provider webhooks
+
+Everything crossing this boundary is untrusted until validated.
+
+### 3.2 Tenant Runtime Boundary
+
+This is the normal tenant-scoped application path:
+
+- authenticated API key or trusted direct-core context
+- tenant-scoped service calls
+- repository and adapter operations
+
+This boundary exists to ensure one organization cannot observe or mutate another organization's data.
+
+### 3.3 Platform / Bootstrap Boundary
+
+This includes:
+
+- organization bootstrap
+- platform admin routes
+- API key issuance and revocation
+- migration execution
+- hosted operational controls
+
+This boundary must be distinct from ordinary tenant CRUD.
+
+### 3.4 Database Boundary
+
+For Postgres-family adapters, the database is an active security control through:
+
+- roles and privileges
+- RLS policies
+- transaction-local tenant context
+
+For SQLite, the database is not an isolation boundary. Isolation is enforced only in application code.
+
+### 3.5 Connector / Provider Boundary
+
+Every integration introduces a new external trust boundary:
+
+- Gmail APIs and OAuth tokens
+- Google Calendar APIs and sync state
+- Stripe APIs, outbound actions, and inbound webhook verification
+
+Connector credentials must be treated as highly sensitive tenant data.
+
+## 4. Tenant Isolation Model
+
+Orbit AI's data isolation model is based on tenant-scoped tables plus adapter enforcement.
+
+### 4.1 Table Classification
+
+- `organizations` is bootstrap-scoped and is not treated as a tenant table.
+- Every tenant table must include `organization_id`.
+- Plugin and connector tables that hold tenant data must register as tenant-scoped tables.
+
+### 4.2 Runtime Enforcement
+
+Tenant reads and writes must be protected by both:
+
+- explicit service-layer filtering on `organization_id`
+- RLS enforcement on Postgres-family adapters
+
+The service layer must never trust caller-provided `organization_id` for public operations. It injects tenant scope from trusted runtime context.
+
+### 4.3 Transaction-Bound Tenant Context
+
+For Postgres-family adapters, all tenant-scoped work must execute inside `withTenantContext(...)` using transaction-local settings.
+
+Required rules:
+
+- tenant context is set inside a transaction
+- the transaction uses `set_config(..., true)` or equivalent transaction-local semantics
+- no tenant route can bypass `withTenantContext(...)`
+- bootstrap routes never enter tenant context
+
+This is mandatory because pooled Postgres connections can leak session state if tenant context is not transaction-bound.
+
+### 4.4 SQLite Caveat
+
+SQLite is valid for local development and for adapter compatibility work where application-level tenant enforcement is acceptable. It is not equivalent to Postgres-family isolation because it has no RLS boundary, and it should not be treated as a tenant-sensitive production security model. The product must document this clearly.
+
+## 5. Postgres and Supabase Role Model
+
+Orbit AI should operate with distinct database roles. The exact final role model still needs to be frozen before production implementation; the role set below is the baseline target model this project should converge on.
+
+### 5.1 Required Roles
+
+- `migration_role`
+  Owns schema changes, policies, and extension-level DDL.
+- `app_role`
+  Executes normal runtime reads and writes.
+- `readonly_role`
+  Optional operational or reporting role with restricted permissions.
+- `platform_admin_role`
+  Limited to hosted control-plane and bootstrap workflows where required.
+
+### 5.2 Required Restrictions
+
+- normal request paths must never use Supabase `service_role`
+- `app_role` must not create or alter schema, policies, or extensions
+- default privileges on `public` must be revoked or tightly controlled
+- runtime roles should use pinned `search_path`
+
+The security review should treat any service-role usage on a request path as a release blocker.
+
+## 6. RLS Architecture
+
+RLS is a required control for all tenant-scoped Postgres-family tables.
+
+### 6.1 Policy Expectations
+
+Each tenant table must have policies for:
+
+- `select`
+- `insert`
+- `update`
+- `delete`
+
+Each policy must enforce tenant equality against the transaction-local org context.
+
+### 6.2 Defense In Depth
+
+RLS is necessary but not sufficient. Repositories and services must still include explicit tenant filters.
+
+Reason:
+
+- direct mode must remain auditable and understandable
+- application-layer checks catch mistakes earlier
+- SQLite requires application enforcement
+
+### 6.3 Extension Tables
+
+Plugin and integration tables are not exempt. If a connector creates tenant-scoped state, that table must be:
+
+- registered with the core plugin schema extension contract
+- included in RLS generation for Postgres-family adapters
+- included in application-layer tenant filtering
+
+## 7. Authentication and Authorization
+
+### 7.1 v1 Authentication Model
+
+v1 uses API keys for service-to-service authentication. Orbit AI does not own end-user auth.
+
+For user context:
+
+- the developer's auth provider remains the source of truth
+- SDK and direct-core modes may accept trusted `userId` and `orgId` context
+- Supabase-native auth integration is adapter-specific and optional
+
+### 7.2 API Key Requirements
+
+API keys must be:
+
+- hashed at rest
+- scoped
+- revocable
+- expirable
+- auditable
+
+The user-visible key prefix may be stored for support and diagnostics. Full plaintext keys must never be retrievable after creation.
+
+### 7.3 Authorization Model
+
+Authorization must distinguish:
+
+- bootstrap/platform actions
+- admin/system actions
+- ordinary tenant CRUD
+- read-only versus mutating routes
+- connector-managed side effects
+
+This separation must exist in code and route structure, not only in prose.
+
+## 8. Secret and Credential Handling
+
+Orbit AI stores and operates on several secret classes:
+
+- API keys
+- webhook secrets
+- connector access tokens
+- connector refresh tokens
+- provider webhook secrets
+
+### 8.1 Baseline Rules
+
+- secrets must not be logged
+- secrets must not appear in MCP outputs
+- secrets must not appear in CLI JSON output
+- secrets must not appear in audit before/after snapshots
+- decryption must be limited to the process that needs the value
+
+### 8.2 Encryption Model
+
+Before production release, Orbit AI must freeze one encryption and key-management model for secret-at-rest fields such as:
+
+- `webhooks.secret_encrypted`
+- `integration_connections.access_token_encrypted`
+- `integration_connections.refresh_token_encrypted`
+
+Allowed implementation choices can vary by deployment, but the model must still define:
+
+- where master keys live
+- how envelope encryption or vault lookup works
+- who can rotate keys
+- how re-encryption is performed
+
+## 9. Webhook Security Model
+
+Orbit AI has three distinct event paths:
+
+- internal domain events
+- outbound customer webhooks
+- inbound provider webhooks and polling
+
+These paths must remain separate.
+
+### 9.1 Outbound Customer Webhooks
+
+Requirements:
+
+- signed payloads
+- timestamped delivery
+- replay-resistant verification contract
+- bounded retry schedule
+- idempotency and event identifiers
+- dead-letter or terminal failure state
+
+### 9.2 Inbound Provider Webhooks
+
+Requirements:
+
+- provider-specific signature verification
+- replay checks where the provider supports them
+- no mixing with customer webhook delivery infrastructure
+- minimal processing before verification succeeds
+
+### 9.3 Internal Domain Events
+
+Internal events are for Orbit-owned workflows such as:
+
+- audit fanout
+- connector sync triggers
+- internal state transitions
+
+They are not an external delivery channel and must not be treated as one.
+
+## 10. Migration and Schema Security
+
+The schema engine is one of the highest-risk surfaces in the product.
+
+### 10.1 Privileged Operation
+
+Schema changes must run under `migration_role` or equivalent elevated authority, not under ordinary runtime credentials.
+
+### 10.2 Safe Defaults
+
+The migration engine must preserve these rules:
+
+- preview first
+- rollback metadata recorded
+- destructive actions explicitly gated
+- production controls stronger than local development controls
+
+### 10.3 Operational Controls
+
+Required controls before production use:
+
+- advisory locking or equivalent serialization
+- auditable migration execution
+- environment-aware guards
+- backup, branch, or snapshot requirements before destructive changes
+
+Plugin and connector schema extensions must pass through the same registry and control flow as first-party migrations.
+
+## 11. Connector Security Model
+
+Gmail, Google Calendar, and Stripe are the first external connectors and should be treated as privileged extensions.
+
+### 11.1 Ownership and Scope
+
+For each connector, Orbit AI must define:
+
+- whether credentials are org-owned, user-owned, or both
+- the minimal OAuth scopes or API scopes required
+- whether data creation side effects are automatic or approval-gated
+
+### 11.2 Token Lifecycle
+
+Connector token handling must define:
+
+- expiry tracking
+- refresh policy
+- failure thresholds
+- controlled disablement on repeated auth failure
+
+### 11.3 Data Retention
+
+Only required provider metadata should be stored. Provider payloads should not be persisted wholesale by default.
+
+## 12. Audit Logging and Observability
+
+Every sensitive mutation path must be attributable.
+
+### 12.1 Audit Logging Requirements
+
+At minimum, audit coverage must include:
+
+- create, update, and delete operations on tenant records
+- schema changes
+- API key creation and revocation
+- webhook endpoint changes
+- connector credential and configuration changes
+- privileged admin actions
+
+### 12.2 Redaction
+
+Audit payloads must redact:
+
+- API keys
+- webhook secrets
+- connector tokens
+- provider secrets
+- any fields later classified as high-sensitivity
+
+### 12.3 Operational Visibility
+
+Operators need visibility into:
+
+- auth failures
+- cross-tenant access denials
+- webhook failure rates
+- migration failures
+- token refresh failures
+
+## 13. Required Security Decisions Before Broad Implementation
+
+The following decisions should be frozen before implementation spreads across packages:
+
+1. final secret-at-rest encryption model
+2. final Postgres/Supabase role model
+3. RLS test strategy and minimum per-entity coverage
+4. webhook signature format and replay window
+5. connector credential ownership model
+6. production migration authority and approval workflow
+7. hosted isolation model for managed offering
+
+## 14. Security Readiness Standard
+
+Orbit AI is not ready for tenant-sensitive production release until:
+
+- tenant context is transaction-bound everywhere it needs to be
+- RLS and application filters agree
+- request paths do not use elevated service credentials
+- secrets are redacted and encrypted consistently
+- webhook verification and replay handling are implemented
+- migration authority is isolated and auditable
+
+This document is the baseline that implementation and later threat modeling should be measured against.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,59 @@
+# Orbit AI
+> CRM infrastructure for AI agents and developers. Packages, not a product.
+
+Orbit AI is a TypeScript monorepo providing type-safe CRM primitives: a schema engine,
+REST API, client SDK, CLI, MCP server, and Gmail/Calendar/Stripe connectors.
+Not yet published to npm. Alpha status. MIT license.
+
+## Packages
+
+- @orbit-ai/core    — schema engine, Drizzle ORM entities, storage adapters (SQLite/Postgres/Supabase/Neon), migrations, tenant isolation
+- @orbit-ai/api     — Hono REST server, /v1/* routes, API-key auth, idempotency, rate limiting
+- @orbit-ai/sdk     — TypeScript client, HTTP transport, DirectTransport (in-process)
+- @orbit-ai/cli     — terminal interface, orbit <entity> <verb>, --mode api|direct
+- @orbit-ai/mcp     — Model Context Protocol server, 23 tools, stdio and HTTP transports
+- @orbit-ai/integrations — Gmail, Google Calendar, Stripe connectors with OAuth lifecycle
+
+## Entities
+
+contacts (cnt_), companies (cmp_), deals (deal_), pipelines (pip_), stages (stg_),
+users (usr_), activities (act_), tasks (tsk_), notes (nte_), products (prd_),
+payments (pay_), contracts (ctr_), sequences (seq_), tags (tag_),
+webhooks (whk_), imports (imp_)
+
+All entities: CRUD + cursor-based list pagination + orgId tenant scoping.
+
+## MCP Tools (23)
+
+search_records, get_record, create_record, update_record, delete_record,
+relate_records, list_related_records, bulk_operation,
+get_pipelines, move_deal_stage, get_pipeline_stats,
+log_activity, list_activities,
+get_schema, create_custom_field, update_custom_field,
+import_records, export_records,
+enroll_in_sequence, unenroll_from_sequence,
+run_report, get_dashboard_summary, assign_record
+
+## API Error Codes
+
+RESOURCE_NOT_FOUND (404), VALIDATION_FAILED (422), AUTH_INVALID_API_KEY (401),
+AUTH_INSUFFICIENT_SCOPE (403), AUTH_CONTEXT_REQUIRED (401),
+RATE_LIMITED (429), IDEMPOTENCY_CONFLICT (409),
+PAYLOAD_TOO_LARGE (413), INTERNAL_ERROR (500)
+
+## Key Docs
+
+- README.md — quickstart, architecture, dev setup
+- AGENTS.md — surface selection, auth, entity inventory, common patterns, error codes
+- packages/*/README.md — per-package reference
+- examples/nodejs-quickstart — runnable end-to-end example
+
+## Auth
+
+API/SDK/MCP-HTTP: Authorization: Bearer <api-key>
+CLI: ORBIT_API_KEY env var or ~/.config/orbit/config.json
+SDK DirectTransport: no key — pass adapter + context.orgId directly (trusted server-side only)
+
+## Tech Stack
+
+TypeScript (strict), Drizzle ORM, Hono, Zod v4, Vitest, Turborepo, pnpm, Node.js 22+

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,26 +2,209 @@
 
 Terminal interface for Orbit AI CRM.
 
+**Status**: `0.1.0-alpha`.
+
+## Installation
+
+```bash
+pnpm add -g @orbit-ai/cli
+# or
+npm install -g @orbit-ai/cli
+```
+
+Requires **Node.js 22+**.
+
 ## Quick Start
 
 ```bash
-# API mode (default)
-export ORBIT_API_KEY=your-key-here
+# API mode (default) — requires a running @orbit-ai/api server
+export ORBIT_API_KEY=your-key
+export ORBIT_API_BASE_URL=https://api.yourapp.com
 orbit contacts list
 
-# Direct mode (local database)
+# Direct mode — connects to a local database (no server required)
 orbit --mode direct --adapter sqlite --database-url ./orbit.db contacts list
 ```
 
+## Global Flags
+
+These flags apply to every command:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--mode <mode>` | `api` | Client mode: `api` (HTTP) or `direct` (local database) |
+| `--adapter <type>` | — | Storage adapter in direct mode: `sqlite` or `postgres` |
+| `--database-url <url>` | — | Database URL in direct mode (e.g. `./orbit.db` or a Postgres DSN) |
+| `--api-key <key>` | — | API key (prefer `ORBIT_API_KEY` env var) |
+| `--base-url <url>` | — | API base URL (prefer `ORBIT_API_BASE_URL` env var) |
+| `--org-id <id>` | — | Organization ID override |
+| `--user-id <id>` | — | User ID override |
+| `--format <format>` | `table` | Output format: `table`, `json`, `csv`, `tsv` |
+| `--json` | — | Shorthand for `--format json` |
+| `--profile <name>` | — | Load a named profile from config |
+| `--quiet` | — | Suppress warnings |
+| `--yes` | — | Skip interactive confirmations |
+
+## Commands
+
+### Setup
+
+```bash
+orbit init              # Initialize a project (.orbit/config.json)
+orbit status            # Show connection status and adapter info
+orbit doctor            # Run diagnostics and check configuration
+orbit seed              # Seed the database with sample data
+```
+
+### Schema & Migrations
+
+```bash
+orbit schema list           # List all registered object types
+orbit schema get <entity>   # Describe an object type and its custom fields
+
+orbit migrate --preview     # Preview pending migrations
+orbit migrate --apply       # Apply pending migrations
+orbit migrate --rollback --id <migration-id> --yes  # Roll back a migration (destructive)
+
+orbit fields list <entity>          # List custom fields on an entity
+orbit fields create <entity>        # Add a custom field interactively
+orbit fields delete <entity> <field-name>   # Delete a custom field (destructive, requires --yes)
+```
+
+### CRM Entities
+
+All entity commands follow the same pattern: `orbit <entity> <verb> [args]`
+
+```bash
+orbit contacts list
+orbit contacts get <id>
+orbit contacts create
+orbit contacts update <id>
+orbit contacts delete <id> --yes
+
+orbit companies list|get|create|update|delete
+orbit deals list|get|create|update|delete
+orbit users list|get|create|update|delete
+orbit pipelines list|get|create|update|delete
+orbit stages list|get|create|update|delete
+orbit activities list|get|create|update|delete
+orbit tasks list|get|create|update|delete
+orbit notes list|get|create|update|delete
+orbit products list|get|create|update|delete
+orbit payments list|get|create|update|delete
+orbit contracts list|get|create|update|delete
+orbit sequences list|get|create|update|delete
+orbit tags list|get|create|update|delete
+orbit webhooks list|get|create|update|delete
+```
+
+### Pipeline & Deals
+
+```bash
+orbit deals move <id> --stage-id <stage-id>   # Move a deal to a different pipeline stage
+```
+
+### Search
+
+```bash
+orbit search <query>                     # Cross-entity text search
+orbit search <query> --entity contacts   # Restrict to a single entity type
+```
+
+### Analytics
+
+```bash
+orbit dashboard                  # Show a summary dashboard
+orbit log                        # Show recent activity log
+# orbit report — not yet implemented (throws NOT_IMPLEMENTED)
+```
+
+### MCP Server
+
+```bash
+# orbit mcp serve — not yet available from the CLI
+# Start the MCP server directly via @orbit-ai/mcp (see packages/mcp/README.md)
+```
+
+### Integrations
+
+```bash
+orbit integrations                             # List configured integrations
+orbit integrations gmail configure             # Configure Gmail connector (OAuth flow)
+orbit integrations calendar configure          # Configure Google Calendar connector
+orbit integrations calendar list               # List upcoming calendar events
+orbit integrations calendar create             # Create a calendar event
+orbit integrations calendar sync               # Sync events to activities
+orbit integrations stripe configure            # Configure Stripe connector
+orbit integrations stripe link-create          # Create a Stripe payment link
+orbit integrations stripe sync                 # Sync payments
+orbit calendar                                 # Alias for orbit integrations calendar
+```
+
+### Imports
+
+```bash
+orbit imports list                                    # List import job records
+orbit imports create --entity-type contacts           # Create an import record (metadata only — no file upload)
+orbit imports get <id>                                # Get an import job record
+```
+
+## Configuration File
+
+The CLI looks for config in two locations, merged together (project overrides user):
+
+- **User config**: `~/.config/orbit/config.json` — API key, base URL, defaults
+- **Project config**: `.orbit/config.json` (walks up from `cwd`) — org ID, profiles only
+
+User config keys:
+
+```json
+{
+  "mode": "api",
+  "apiKey": "orb_...",
+  "apiKeyEnv": "ORBIT_API_KEY",
+  "baseUrl": "https://api.yourapp.com",
+  "orgId": "org_01JXXXX",
+  "userId": "usr_01JXXXX",
+  "adapter": "sqlite",
+  "databaseUrl": "./orbit.db",
+  "orgName": "My Org",
+  "profiles": {
+    "staging": {
+      "baseUrl": "https://staging-api.yourapp.com",
+      "orgId": "org_staging"
+    }
+  }
+}
+```
+
+> **Security:** Set permissions to `0600` on config files that contain API keys:
+> `chmod 0600 ~/.config/orbit/config.json`
+
+Project config (`.orbit/config.json`) only accepts `orgId`, `userId`, and `profiles`.
+
+Switch profiles with `--profile staging`.
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | API or network error |
+| `2` | Validation or usage error |
+| `3` | Configuration error |
+
 ## Direct Mode Trust Boundaries
 
-When using `--mode direct`, the following middleware protections are NOT active:
+When using `--mode direct`, the following API-layer protections are **not active**:
 
-- **Authentication**: No API key validation. Any caller with access to the database can perform all operations.
-- **Rate limiting**: Unlimited operations. Bulk deletes or inserts have no throttling.
-- **Scope enforcement**: Organization isolation is entirely the caller's responsibility. Set `--org-id` correctly.
-- **SSRF protection**: No outbound request filtering. Do not point direct mode at remote databases from untrusted inputs.
+- Authentication — no API key validation
+- Rate limiting — no throttling on bulk operations
+- Scope enforcement — `--org-id` is trusted as-is
+- SSRF protection — no outbound request filtering
 
-Direct mode is intended for local development, scripts running against a local SQLite database, or trusted server-side automation where the database is private. Do not expose direct mode to untrusted user inputs.
+Direct mode is intended for local development, scripts against a local SQLite database, or trusted server-side automation where the database is private. Do not expose direct mode to untrusted user inputs.
 
-See `.orbit/config.json` for configuration options.
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -37,3 +37,93 @@ Alpha (`0.1.0-alpha.0`) — not yet published to npm.
 - Webhook signature verification (Stripe `constructEvent`)
 - Tenant-scoped data access (RLS policies)
 - Provider error redaction (tokens, secrets stripped from logs)
+
+## Setup Guides
+
+### Gmail
+
+**Prerequisites:** A Google Cloud project with billing enabled.
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com) → APIs & Services → Library.
+2. Search for **Gmail API** and click Enable.
+3. Go to APIs & Services → Credentials → Create Credentials → OAuth 2.0 Client ID.
+4. Application type: **Desktop app**. Download the credentials JSON.
+5. Place the credentials file at `.orbit/gmail-credentials.json` in your project root.
+6. Run the configuration command:
+
+```bash
+orbit integrations gmail configure
+```
+
+This opens a browser OAuth consent flow. On completion, the access and refresh tokens are stored encrypted at `.orbit/integrations.json`.
+
+7. Verify connectivity:
+
+```bash
+orbit integrations gmail configure --help
+```
+
+**Scopes requested:** `gmail.readonly`, `gmail.send`, `gmail.labels`
+
+---
+
+### Google Calendar
+
+**Prerequisites:** Same Google Cloud project as Gmail (or a separate one).
+
+1. In Google Cloud Console → APIs & Services → Library, enable the **Google Calendar API**.
+2. Reuse the OAuth credentials from Gmail, or create a new Desktop app credential.
+3. Place credentials at `.orbit/calendar-credentials.json`.
+4. Run:
+
+```bash
+orbit integrations calendar configure
+```
+
+5. Verify:
+
+```bash
+orbit integrations calendar list
+```
+
+**Scopes requested:** `calendar.readonly`, `calendar.events`
+
+---
+
+### Stripe
+
+**Prerequisites:** A Stripe account.
+
+1. Go to [Stripe Dashboard](https://dashboard.stripe.com) → Developers → API Keys.
+2. Copy the **Secret key** (starts with `sk_live_` or `sk_test_`).
+3. Run:
+
+```bash
+orbit integrations stripe configure
+```
+
+Enter the secret key when prompted. It is stored encrypted at `.orbit/integrations.json`.
+
+4. (Optional) Set up a webhook endpoint so Stripe checkout events are synced to Orbit payment records:
+
+```bash
+orbit integrations stripe sync --webhook-url https://api.yourapp.com/webhooks/stripe
+```
+
+5. Verify:
+
+```bash
+orbit integrations stripe link-create --amount 2999 --currency eur --name "Consulting Call"
+```
+
+**API access level:** Secret key (full write access). Store securely — never commit `.orbit/integrations.json`.
+
+---
+
+## Credential Storage
+
+All connector credentials are stored encrypted (AES-256-GCM) at `.orbit/integrations.json`. This file is created by the configure commands and should be:
+
+- Added to `.gitignore`
+- Backed up outside the repo if using long-lived refresh tokens
+- Set to `0600` permissions: `chmod 0600 .orbit/integrations.json`

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,26 +1,165 @@
 # @orbit-ai/mcp
 
-Orbit AI's Model Context Protocol server.
+Model Context Protocol server for Orbit AI CRM. Exposes 23 tools over stdio or HTTP transports — connect directly to Claude Desktop, Cursor, Copilot, or any MCP-compatible host.
 
-This package exposes the fixed 23-tool Orbit MCP surface over the accepted SDK and API contracts.
+**Status**: `0.1.0-alpha`.
 
-Runtime requirement:
+## Installation
 
-- `@orbit-ai/mcp` currently requires Node.js 22+.
+```bash
+pnpm add @orbit-ai/mcp @orbit-ai/core
+# or
+npm install @orbit-ai/mcp @orbit-ai/core
+```
 
-Direct mode trust boundary:
+Requires **Node.js 22+**.
 
-- Direct mode is for trusted local embeddings only.
-- It bypasses API-layer authentication, per-org rate limiting, scope enforcement, and API-layer webhook SSRF validation. API-layer webhook SSRF validation is bypassed, but direct-mode SSRF checks are applied locally before any webhook create/update operation.
-- The server emits a stderr warning whenever the SDK client is adapter-backed without an API key (direct mode). In HTTP transport mode this warning fires per authenticated request, because each request constructs a per-request OrbitClient with adapter and orgId but no apiKey.
+## Starting the Server
 
-HTTP transport:
+### stdio transport (Claude Desktop, Cursor, Copilot)
 
-- Defaults to binding `127.0.0.1`.
-- Requires bearer authentication backed by `RuntimeApiAdapter.lookupApiKeyForAuth()`.
-- Wildcard binding requires explicit `bindAddress` and emits a stderr warning.
+Start the server in stdio mode via the CLI:
 
-Extension tools:
+```bash
+ORBIT_API_KEY=your-key ORBIT_API_BASE_URL=https://api.yourapp.com orbit mcp serve
+```
 
-- The core package remains fixed at 23 tools.
-- Integration-specific extension tools must be registered only in composite runtimes and use provider namespaces such as `integrations.gmail.send_email`.
+Or start it programmatically in HTTP mode and point your MCP host at the HTTP endpoint (see HTTP transport below).
+
+### Configuring Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "orbit": {
+      "command": "orbit",
+      "args": ["mcp", "serve"],
+      "env": {
+        "ORBIT_API_KEY": "your-key-here",
+        "ORBIT_API_BASE_URL": "https://api.yourapp.com"
+      }
+    }
+  }
+}
+```
+
+### HTTP transport (remote or multi-tenant)
+
+```typescript
+import { startHttpTransport } from '@orbit-ai/mcp'
+
+const runtime = await startHttpTransport({
+  adapter,           // RuntimeApiAdapter with lookupApiKeyForAuth wired up
+  client,            // OrbitClient template (per-request clients are created from this)
+  port: 3001,        // default
+  bindAddress: '127.0.0.1',  // default; use '0.0.0.0' only with network controls
+})
+
+console.log(`MCP HTTP server listening on ${runtime.address}:${runtime.port}`)
+```
+
+HTTP transport requires `Authorization: Bearer <api-key>` on every request. The API key is resolved via `adapter.lookupApiKeyForAuth()` — the same lookup used by `@orbit-ai/api`.
+
+## Tool Reference
+
+All 23 tools operate on the entity specified in the `entity` argument (e.g. `"contacts"`, `"deals"`).
+
+### Core CRUD
+
+| Tool | Description |
+|---|---|
+| `search_records` | Full-text search across a single entity type |
+| `get_record` | Get a single record by ID |
+| `create_record` | Create a new record |
+| `update_record` | Patch an existing record |
+| `delete_record` | Delete a record |
+
+### Relationships
+
+| Tool | Description |
+|---|---|
+| `relate_records` | Create a relationship between two records |
+| `list_related_records` | List records related to a given record |
+
+### Bulk
+
+| Tool | Description |
+|---|---|
+| `bulk_operation` | Create, update, or delete multiple records in one call |
+
+### Pipeline & Deals
+
+| Tool | Description |
+|---|---|
+| `get_pipelines` | List pipelines and their stages |
+| `move_deal_stage` | Move a deal to a different pipeline stage |
+| `get_pipeline_stats` | Get win/loss and stage-distribution stats for a pipeline |
+
+### Activities
+
+| Tool | Description |
+|---|---|
+| `log_activity` | Log an activity (call, email, meeting, note) on any record |
+| `list_activities` | List activities for a record or across the org |
+
+### Schema & Custom Fields
+
+| Tool | Description |
+|---|---|
+| `get_schema` | Inspect the schema for an entity, including custom fields |
+| `create_custom_field` | Add a custom field to an entity |
+| `update_custom_field` | Update a custom field definition |
+
+### Imports & Exports
+
+| Tool | Description |
+|---|---|
+| `import_records` | Bulk-import records from a JSON payload |
+| `export_records` | Export records to a JSON payload |
+
+### Sequences
+
+| Tool | Description |
+|---|---|
+| `enroll_in_sequence` | Enroll a contact in a sequence |
+| `unenroll_from_sequence` | Remove a contact from a sequence |
+
+### Analytics
+
+| Tool | Description |
+|---|---|
+| `run_report` | Run a report (activity summary, pipeline health, etc.) |
+| `get_dashboard_summary` | Get a top-level CRM dashboard summary |
+
+### Team
+
+| Tool | Description |
+|---|---|
+| `assign_record` | Assign a record to a team member |
+
+## Extension Tools
+
+The 23 core tools are fixed. Integration-specific tools (Gmail, Calendar, Stripe) are registered in composite runtimes and use the `integrations.<provider>.<action>` namespace:
+
+```
+integrations.gmail.send_email
+integrations.gmail.sync_thread
+integrations.calendar.list_events
+integrations.calendar.create_event
+integrations.stripe.create_payment_link
+integrations.stripe.get_payment_status
+```
+
+Extension tools must be registered by the consuming application — they are not included when importing `@orbit-ai/mcp` alone.
+
+## Transport Trust Boundaries
+
+**Direct mode** (no adapter, no API key): bypasses API-layer auth, rate limiting, scope enforcement, and webhook SSRF validation. Local SSRF checks are still applied before any webhook create/update. Use only for trusted local embeddings.
+
+**HTTP mode**: each request requires a valid Bearer token. Auth, scopes, and revocation are enforced per request. Binding to non-localhost emits a stderr warning.
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Rewrote all 6 package READMEs with complete public-facing reference docs (CLI command table, MCP tool list, integrations setup guides)
- Updated root README to reflect all 6 shipped alpha packages with accurate architecture diagram
- Rewrote AGENTS.MD as a terse runtime reference for AI agents and LLMs (surface selection, entity inventory, error codes, common patterns)
- Added `llms.txt` at repo root — compact machine-readable index following the llms.txt convention
- Restored two public security docs (`docs/security/security-architecture.md`, `docs/security/database-hardening-checklist.md`)
- Documented `codex:rescue` in the PR review tool table in CLAUDE.md

Note: Phase 1 (git history scrub of internal `docs/` via `git filter-repo`) was executed directly on `main` before this branch was created.

## Test Plan

- [x] `pnpm -r lint` — all packages pass
- [x] `pnpm -r build` — all 6 packages build
- [x] `pnpm -r test` — 1605 tests pass (pre-existing flaky ink-views timeout passes in isolation)
- [x] No code changes — docs only
- [x] CodeX review finding (MEDIUM) resolved: `codex:rescue` documented in CLAUDE.md