### PR TITLE
feat(cli): integrations gmail+calendar configure/status (Plan A.5, alpha-scoped)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -130,16 +130,17 @@ orbit log                        # Show recent activity log
 
 ```bash
 orbit integrations                             # List configured integrations
-orbit integrations gmail configure             # Configure Gmail connector (OAuth flow)
-orbit integrations calendar configure          # Configure Google Calendar connector
-orbit integrations calendar list               # List upcoming calendar events
-orbit integrations calendar create             # Create a calendar event
-orbit integrations calendar sync               # Sync events to activities
+orbit integrations gmail configure             # Configure Gmail connector
+orbit integrations gmail status                # Show Gmail connector status
+orbit integrations google-calendar configure   # Configure Google Calendar connector
+orbit integrations google-calendar status      # Show Google Calendar connector status
 orbit integrations stripe configure            # Configure Stripe connector
 orbit integrations stripe link-create          # Create a Stripe payment link
 orbit integrations stripe sync                 # Sync payments
-orbit calendar                                 # Alias for orbit integrations calendar
+orbit calendar                                 # Alias placeholder for calendar integration
 ```
+
+For Gmail and Google Calendar, prefer OAuth token input from environment variables, token files, or `--tokens-stdin`. Avoid passing refresh tokens directly with `--access-token` / `--refresh-token` because argv can be visible in process listings and shell history. Normal integration commands do not apply schema DDL; use `--apply-integrations-schema` only as an explicit setup/migration action.
 
 ### Imports
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,9 +19,11 @@
   },
   "dependencies": {
     "@orbit-ai/core": "workspace:*",
+    "@orbit-ai/integrations": "workspace:*",
     "@orbit-ai/sdk": "workspace:*",
     "cli-table3": "^0.6.0",
     "commander": "^12.0.0",
+    "drizzle-orm": "^0.44.5",
     "ink": "^5.0.0",
     "pg": "^8.11.0",
     "react": "^18.0.0"

--- a/packages/cli/src/__tests__/config-resolve.test.ts
+++ b/packages/cli/src/__tests__/config-resolve.test.ts
@@ -48,7 +48,7 @@ vi.mock('node:sqlite', () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { resolveClient } from '../config/resolve-context.js'
+import { resolveClient, resolveAdapter } from '../config/resolve-context.js'
 import { readConfigFile, canonicalizePath, loadConfig } from '../config/files.js'
 import { createSqliteStorageAdapter, createPostgresStorageAdapter } from '@orbit-ai/core'
 import { OrbitClient } from '@orbit-ai/sdk'
@@ -552,6 +552,39 @@ describe('loadConfig sanitization', () => {
       expect.objectContaining({
         name: 'CliConfigError',
         details: expect.objectContaining({ code: 'CONFIG_PARSE_ERROR', path: 'profiles' }),
+      }),
+    )
+  })
+})
+
+describe('resolveAdapter — env var precedence (Finding #3)', () => {
+  it('ORBIT_ADAPTER env var is used when no flag or config adapter is set', () => {
+    const cwd = makeTmpDir()
+    resolveAdapter({}, {}, cwd, { ORBIT_ADAPTER: 'sqlite' })
+    expect(createSqliteStorageAdapter).toHaveBeenCalled()
+  })
+
+  it('flag adapter takes precedence over ORBIT_ADAPTER env var', () => {
+    const cwd = makeTmpDir()
+    resolveAdapter({ adapter: 'sqlite' }, {}, cwd, { ORBIT_ADAPTER: 'postgres' })
+    expect(createSqliteStorageAdapter).toHaveBeenCalled()
+    expect(createPostgresStorageAdapter).not.toHaveBeenCalled()
+  })
+
+  it('DATABASE_URL env var is used for dbUrl when no flag or config databaseUrl is set', () => {
+    const cwd = makeTmpDir()
+    resolveAdapter({}, {}, cwd, { ORBIT_ADAPTER: 'sqlite', DATABASE_URL: ':memory:' })
+    expect(createSqliteStorageAdapter).toHaveBeenCalled()
+  })
+
+  it('throws CliValidationError with INVALID_ADAPTER_NAME for unknown ORBIT_ADAPTER value', () => {
+    const cwd = makeTmpDir()
+    expect(() =>
+      resolveAdapter({}, {}, cwd, { ORBIT_ADAPTER: 'badvalue' }),
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'CliValidationError',
+        details: expect.objectContaining({ code: 'INVALID_ADAPTER_NAME' }),
       }),
     )
   })

--- a/packages/cli/src/__tests__/ink-views.test.ts
+++ b/packages/cli/src/__tests__/ink-views.test.ts
@@ -67,7 +67,7 @@ describe('Ink views', () => {
       expect(output).toContain('Deal Alpha')
       expect(output).toContain('Deal Beta')
       expect(output).toContain('Deal Gamma')
-    })
+    }, 10_000)
 
     it('renders stage name but no deal bullet rows for empty stage', async () => {
       const { PipelineBoard } = await import('../ink/pipeline-board.js')

--- a/packages/cli/src/__tests__/integrations.test.ts
+++ b/packages/cli/src/__tests__/integrations.test.ts
@@ -140,6 +140,28 @@ describe('registerIntegrationSubcommands', () => {
     await program.parseAsync(['node', 'orbit', 'integrations', 'gmail'])
     expect(action).toHaveBeenCalledOnce()
   })
+
+  it('awaits nested async integration actions and keeps root flags available', async () => {
+    const program = new Command()
+    program.exitOverride()
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    program.option('--apply-integrations-schema')
+
+    const action = vi.fn(async (...args: unknown[]) => {
+      const command = args[args.length - 1] as Command
+      let root: Command = command
+      while (root.parent) root = root.parent
+      expect(root.opts()).toMatchObject({ applyIntegrationsSchema: true })
+      await new Promise((resolve) => setTimeout(resolve, 1))
+    })
+
+    registerIntegrationSubcommands(program, [
+      { name: 'gmail/configure', description: 'Configure Gmail', action },
+    ])
+
+    await program.parseAsync(['node', 'orbit', '--apply-integrations-schema', 'integrations', 'gmail', 'configure'])
+    expect(action).toHaveBeenCalledOnce()
+  })
 })
 
 describe('registerIntegrationsCommand', () => {

--- a/packages/cli/src/__tests__/program.test.ts
+++ b/packages/cli/src/__tests__/program.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { createProgram, isJsonMode, run, _resetJsonMode } from '../program.js'
+import { createProgram, isJsonMode, run, _resetJsonMode, _classifyError } from '../program.js'
 
 describe('program', () => {
   const expectedCommands = [
@@ -164,6 +164,30 @@ describe('program', () => {
       // exitOverride throws on --help
     }
     expect(helpText).toContain('orbit')
+  })
+})
+
+describe('classifyError — OrbitEncryptionConfigError (Finding #4)', () => {
+  it('maps OrbitEncryptionConfigError to exit code 2 with CONFIGURATION_ERROR', () => {
+    const err = Object.assign(new Error('ORBIT_CREDENTIAL_KEY is not set'), {
+      name: 'OrbitEncryptionConfigError',
+      code: 'MISSING_CREDENTIAL_KEY',
+    })
+    const result = _classifyError(err)
+    expect(result.code).toBe(2)
+    expect(result.payload.code).toBe('CONFIGURATION_ERROR')
+    expect(result.payload.detail).toBe('MISSING_CREDENTIAL_KEY')
+  })
+
+  it('maps OrbitEncryptionConfigError with INVALID_CREDENTIAL_KEY to exit code 2', () => {
+    const err = Object.assign(new Error('ORBIT_CREDENTIAL_KEY must be 64 hex chars'), {
+      name: 'OrbitEncryptionConfigError',
+      code: 'INVALID_CREDENTIAL_KEY',
+    })
+    const result = _classifyError(err)
+    expect(result.code).toBe(2)
+    expect(result.payload.code).toBe('CONFIGURATION_ERROR')
+    expect(result.payload.detail).toBe('INVALID_CREDENTIAL_KEY')
   })
 })
 

--- a/packages/cli/src/__tests__/program.test.ts
+++ b/packages/cli/src/__tests__/program.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createProgram, isJsonMode, run, _resetJsonMode, _classifyError } from '../program.js'
+import { OrbitEncryptionConfigError } from '@orbit-ai/integrations'
 
 describe('program', () => {
   const expectedCommands = [
@@ -169,10 +170,7 @@ describe('program', () => {
 
 describe('classifyError — OrbitEncryptionConfigError (Finding #4)', () => {
   it('maps OrbitEncryptionConfigError to exit code 2 with CONFIGURATION_ERROR', () => {
-    const err = Object.assign(new Error('ORBIT_CREDENTIAL_KEY is not set'), {
-      name: 'OrbitEncryptionConfigError',
-      code: 'MISSING_CREDENTIAL_KEY',
-    })
+    const err = new OrbitEncryptionConfigError('MISSING_CREDENTIAL_KEY', 'ORBIT_CREDENTIAL_KEY is required')
     const result = _classifyError(err)
     expect(result.code).toBe(2)
     expect(result.payload.code).toBe('CONFIGURATION_ERROR')
@@ -180,10 +178,7 @@ describe('classifyError — OrbitEncryptionConfigError (Finding #4)', () => {
   })
 
   it('maps OrbitEncryptionConfigError with INVALID_CREDENTIAL_KEY to exit code 2', () => {
-    const err = Object.assign(new Error('ORBIT_CREDENTIAL_KEY must be 64 hex chars'), {
-      name: 'OrbitEncryptionConfigError',
-      code: 'INVALID_CREDENTIAL_KEY',
-    })
+    const err = new OrbitEncryptionConfigError('INVALID_CREDENTIAL_KEY', 'ORBIT_CREDENTIAL_KEY must be 64 hex chars')
     const result = _classifyError(err)
     expect(result.code).toBe(2)
     expect(result.payload.code).toBe('CONFIGURATION_ERROR')

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -66,4 +66,32 @@ describe('runInit --org-id', () => {
     const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as { orgId?: string }
     expect(parsed.orgId).toBeUndefined()
   })
+
+  it('rejects org_id with non-Crockford chars (e.g. I) — strict isOrbitId validation', async () => {
+    await expect(
+      runInit({
+        db: 'sqlite',
+        orgId: 'org_01HZIIIIIIIIIIIIIIIIIIIIII',
+        yes: true,
+        cwd: tmpDir,
+      }),
+    ).rejects.toMatchObject({
+      name: 'CliValidationError',
+      details: { code: 'INVALID_ORG_ID' },
+    })
+  })
+
+  it('rejects case-insensitive match — org_ with lowercase ulid is invalid', async () => {
+    await expect(
+      runInit({
+        db: 'sqlite',
+        orgId: 'org_01hz000000000000000000abcd',
+        yes: true,
+        cwd: tmpDir,
+      }),
+    ).rejects.toMatchObject({
+      name: 'CliValidationError',
+      details: { code: 'INVALID_ORG_ID' },
+    })
+  })
 })

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { runInit } from './init.js'
+import { CliValidationError } from '../errors.js'
+
+describe('runInit --org-id', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-init-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('writes orgId into .orbit/config.json when --org-id is a valid ULID', async () => {
+    await runInit({
+      db: 'sqlite',
+      orgId: 'org_01HZ000000000000000000ABCD',
+      yes: true,
+      cwd: tmpDir,
+    })
+
+    const configPath = path.join(tmpDir, '.orbit', 'config.json')
+    const raw = fs.readFileSync(configPath, 'utf8')
+    const parsed = JSON.parse(raw) as { orgId?: string }
+    expect(parsed.orgId).toBe('org_01HZ000000000000000000ABCD')
+  })
+
+  it('throws CliValidationError with INVALID_ORG_ID for malformed --org-id', async () => {
+    await expect(
+      runInit({
+        db: 'sqlite',
+        orgId: 'BADVALUE',
+        yes: true,
+        cwd: tmpDir,
+      }),
+    ).rejects.toMatchObject({
+      name: 'CliValidationError',
+      details: { code: 'INVALID_ORG_ID' },
+    })
+
+    try {
+      await runInit({
+        db: 'sqlite',
+        orgId: 'BADVALUE',
+        yes: true,
+        cwd: tmpDir,
+      })
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliValidationError)
+    }
+  })
+
+  it('omits orgId from config when flag is not provided', async () => {
+    await runInit({
+      db: 'sqlite',
+      yes: true,
+      cwd: tmpDir,
+    })
+
+    const configPath = path.join(tmpDir, '.orbit', 'config.json')
+    const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as { orgId?: string }
+    expect(parsed.orgId).toBeUndefined()
+  })
+})

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -9,6 +9,7 @@ export function registerInitCommand(program: Command): void {
     .command('init')
     .description('Scaffold .orbit/config.json and .env.example')
     .option('--db <type>', 'Database type: sqlite|postgres', 'sqlite')
+    .option('--org-id <id>', 'Organization id (required for direct-mode commands like integrations)')
     .option('--org-name <name>', 'Organization name')
     .option('--yes', 'Skip confirmation prompts (non-interactive)')
     .option('--overwrite', 'Overwrite existing files')
@@ -20,6 +21,7 @@ export function registerInitCommand(program: Command): void {
 
 interface InitOptions {
   db?: string
+  orgId?: string
   orgName?: string
   yes?: boolean
   overwrite?: boolean
@@ -40,7 +42,7 @@ function assertNotSymlink(targetPath: string, label: string): void {
 }
 
 export async function runInit(opts: InitOptions): Promise<void> {
-  const { db = 'sqlite', orgName, yes, overwrite, envFile, cwd } = opts
+  const { db = 'sqlite', orgId, orgName, yes, overwrite, envFile, cwd } = opts
 
   // Security: never write to .env
   if (envFile) {
@@ -59,6 +61,15 @@ export async function runInit(opts: InitOptions): Promise<void> {
       'orbit init requires --yes in non-interactive mode.',
       { code: 'REQUIRES_CONFIRMATION' },
     )
+  }
+
+  if (orgId !== undefined) {
+    if (!/^org_[0-9A-Z]{26}$/i.test(orgId)) {
+      throw new CliValidationError(
+        '--org-id must be a valid org ULID (org_...).',
+        { code: 'INVALID_ORG_ID' },
+      )
+    }
   }
 
   // Validate org name
@@ -101,6 +112,7 @@ export async function runInit(opts: InitOptions): Promise<void> {
       mode: db === 'sqlite' ? 'direct' : 'api',
       adapter: db,
       apiKeyEnv: 'ORBIT_API_KEY', // never the literal key
+      ...(orgId ? { orgId } : {}),
       ...(orgName ? { orgName } : {}),
     }
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 })

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { Command } from 'commander'
+import { isOrbitId } from '@orbit-ai/core'
 import { CliValidationError } from '../errors.js'
 import { isJsonMode } from '../program.js'
 
@@ -64,7 +65,7 @@ export async function runInit(opts: InitOptions): Promise<void> {
   }
 
   if (orgId !== undefined) {
-    if (!/^org_[0-9A-Z]{26}$/i.test(orgId)) {
+    if (!isOrbitId(orgId, 'organization')) {
       throw new CliValidationError(
         '--org-id must be a valid org ULID (org_...).',
         { code: 'INVALID_ORG_ID' },

--- a/packages/cli/src/commands/integrations.test.ts
+++ b/packages/cli/src/commands/integrations.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { Command } from 'commander'
+import { registerIntegrationSubcommands } from './integrations.js'
+
+describe('registerIntegrationSubcommands', () => {
+  it('registers a nested provider/command path when name includes a slash', () => {
+    const program = new Command()
+    registerIntegrationSubcommands(program, [
+      { name: 'gmail/configure', description: 'Configure Gmail', action: () => {} },
+      { name: 'gmail/status', description: 'Gmail status', action: () => {} },
+      { name: 'google-calendar/configure', description: 'Configure Calendar', action: () => {} },
+    ])
+    const integrations = program.commands.find((c) => c.name() === 'integrations')!
+    const gmail = integrations.commands.find((c) => c.name() === 'gmail')!
+    expect(gmail).toBeDefined()
+    expect(gmail.commands.find((c) => c.name() === 'configure')).toBeDefined()
+    expect(gmail.commands.find((c) => c.name() === 'status')).toBeDefined()
+    const cal = integrations.commands.find((c) => c.name() === 'google-calendar')!
+    expect(cal.commands.find((c) => c.name() === 'configure')).toBeDefined()
+  })
+
+  it('still supports flat names (backwards compatible)', () => {
+    const program = new Command()
+    registerIntegrationSubcommands(program, [
+      { name: 'legacy-flat', description: 'legacy', action: () => {} },
+    ])
+    const integrations = program.commands.find((c) => c.name() === 'integrations')!
+    expect(integrations.commands.find((c) => c.name() === 'legacy-flat')).toBeDefined()
+  })
+})

--- a/packages/cli/src/commands/integrations.ts
+++ b/packages/cli/src/commands/integrations.ts
@@ -27,23 +27,33 @@ export function registerIntegrationSubcommands(program: Command, plugins: Integr
   const parent = findOrCreateIntegrationsParent(program)
 
   for (const plugin of plugins) {
-    const sub = parent.command(plugin.name).description(plugin.description)
+    const path = plugin.name.split('/').map((p) => p.trim()).filter(Boolean)
+    let host = parent
+    for (let i = 0; i < path.length - 1; i += 1) {
+      const segment = path[i]!
+      let group = host.commands.find((c) => c.name() === segment)
+      if (!group) {
+        group = host.command(segment).description(`${segment} integration`)
+      }
+      host = group
+    }
+    const leaf = host.command(path[path.length - 1]!).description(plugin.description)
 
     if (plugin.options) {
       for (const opt of plugin.options) {
         if (opt.defaultValue !== undefined) {
-          sub.option(
+          leaf.option(
             opt.flags,
             opt.description,
             typeof opt.defaultValue === 'boolean' ? opt.defaultValue : String(opt.defaultValue),
           )
         } else {
-          sub.option(opt.flags, opt.description)
+          leaf.option(opt.flags, opt.description)
         }
       }
     }
 
-    sub.action(plugin.action)
+    leaf.action(plugin.action)
   }
 }
 

--- a/packages/cli/src/config/integrations-runtime.test.ts
+++ b/packages/cli/src/config/integrations-runtime.test.ts
@@ -7,20 +7,26 @@ import type { GlobalFlags } from '../types.js'
 import { _resetJsonMode, _setJsonMode } from '../program.js'
 
 const TEST_KEY = 'a'.repeat(64)
+const ORG_TEST = 'org_01ABCDEF0123456789ABCDEF01'
 
 describe('resolveIntegrationsRuntime', () => {
   let tmpRoot: string
   let originalKey: string | undefined
   let originalOrgId: string | undefined
   let originalUserId: string | undefined
+  let originalProfile: string | undefined
+  let originalHome: string | undefined
 
   beforeEach(() => {
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-int-runtime-'))
     originalKey = process.env['ORBIT_CREDENTIAL_KEY']
     originalOrgId = process.env['ORBIT_ORG_ID']
     originalUserId = process.env['ORBIT_USER_ID']
+    originalProfile = process.env['ORBIT_PROFILE']
+    originalHome = process.env['HOME']
     delete process.env['ORBIT_ORG_ID']
     delete process.env['ORBIT_USER_ID']
+    delete process.env['ORBIT_PROFILE']
   })
 
   afterEach(() => {
@@ -31,6 +37,10 @@ describe('resolveIntegrationsRuntime', () => {
     else process.env['ORBIT_ORG_ID'] = originalOrgId
     if (originalUserId === undefined) delete process.env['ORBIT_USER_ID']
     else process.env['ORBIT_USER_ID'] = originalUserId
+    if (originalProfile === undefined) delete process.env['ORBIT_PROFILE']
+    else process.env['ORBIT_PROFILE'] = originalProfile
+    if (originalHome === undefined) delete process.env['HOME']
+    else process.env['HOME'] = originalHome
   })
 
   it('throws CliValidationError when no .orbit/config.json exists', async () => {
@@ -50,18 +60,18 @@ describe('resolveIntegrationsRuntime', () => {
     fs.mkdirSync(orbitDir, { recursive: true })
     fs.writeFileSync(
       path.join(orbitDir, 'config.json'),
-      JSON.stringify({ orgId: 'org-test' }),
+      JSON.stringify({ orgId: ORG_TEST }),
       { mode: 0o600 },
     )
 
     const flags: GlobalFlags = {
-      orgId: 'org-test',
+      orgId: ORG_TEST,
       adapter: 'sqlite',
       databaseUrl: ':memory:',
     }
-    const ctx = await resolveIntegrationsRuntime({ flags, cwd: tmpRoot })
+    const ctx = await resolveIntegrationsRuntime({ flags, cwd: tmpRoot, applySchema: true })
 
-    expect(ctx.organizationId).toBe('org-test')
+    expect(ctx.organizationId).toBe(ORG_TEST)
     expect(ctx.userId).toBe('cli-user')
 
     const creds = {
@@ -71,8 +81,8 @@ describe('resolveIntegrationsRuntime', () => {
       scopes: ['scope1', 'scope2'],
       providerAccountId: 'acct@example.com',
     }
-    await ctx.credentialStore.saveCredentials('org-test', 'gmail', 'cli-user', creds)
-    const loaded = await ctx.credentialStore.getCredentials('org-test', 'gmail', 'cli-user')
+    await ctx.credentialStore.saveCredentials(ORG_TEST, 'gmail', 'cli-user', creds)
+    const loaded = await ctx.credentialStore.getCredentials(ORG_TEST, 'gmail', 'cli-user')
     expect(loaded).not.toBeNull()
     expect(loaded?.accessToken).toBe(creds.accessToken)
     expect(loaded?.refreshToken).toBe(creds.refreshToken)
@@ -110,17 +120,17 @@ describe('resolveIntegrationsRuntime', () => {
     fs.mkdirSync(orbitDir, { recursive: true })
     fs.writeFileSync(
       path.join(orbitDir, 'config.json'),
-      JSON.stringify({ orgId: 'org-test' }),
+      JSON.stringify({ orgId: ORG_TEST }),
       { mode: 0o600 },
     )
     _setJsonMode(true)
     try {
       const flags: GlobalFlags = {
-        orgId: 'org-test',
+        orgId: ORG_TEST,
         adapter: 'sqlite',
         databaseUrl: ':memory:',
       }
-      const ctx = await resolveIntegrationsRuntime({ flags, cwd: tmpRoot })
+      const ctx = await resolveIntegrationsRuntime({ flags, cwd: tmpRoot, applySchema: true })
       const logs: string[] = []
       const original = console.log
       console.log = (msg?: unknown) => {
@@ -150,5 +160,69 @@ describe('resolveIntegrationsRuntime', () => {
     } finally {
       _resetJsonMode()
     }
+  })
+
+  it('resolves profile precedence as --profile over ORBIT_PROFILE over config.profile', async () => {
+    process.env['ORBIT_CREDENTIAL_KEY'] = TEST_KEY
+    process.env['HOME'] = tmpRoot
+    process.env['ORBIT_PROFILE'] = 'env-profile'
+    const userConfigDir = path.join(tmpRoot, '.config', 'orbit')
+    fs.mkdirSync(userConfigDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(userConfigDir, 'config.json'),
+      JSON.stringify({
+        orgId: 'org_01BASE00000000000000000000',
+        profile: 'config-profile',
+        profiles: {
+          'config-profile': { orgId: 'org_01CONFIG000000000000000000', userId: 'user-config' },
+          'env-profile': { orgId: 'org_01ENV000000000000000000000', userId: 'user-env' },
+          'flag-profile': { orgId: 'org_01FLAG00000000000000000000', userId: 'user-flag' },
+        },
+      }),
+      { mode: 0o600 },
+    )
+
+    const envCtx = await resolveIntegrationsRuntime({
+      flags: { adapter: 'sqlite', databaseUrl: ':memory:' },
+      cwd: tmpRoot,
+    })
+    expect(envCtx.organizationId).toBe('org_01ENV000000000000000000000')
+    expect(envCtx.userId).toBe('user-env')
+
+    const flagCtx = await resolveIntegrationsRuntime({
+      flags: { adapter: 'sqlite', databaseUrl: ':memory:', profile: 'flag-profile' },
+      cwd: tmpRoot,
+    })
+    expect(flagCtx.organizationId).toBe('org_01FLAG00000000000000000000')
+    expect(flagCtx.userId).toBe('user-flag')
+
+    delete process.env['ORBIT_PROFILE']
+    const configCtx = await resolveIntegrationsRuntime({
+      flags: { adapter: 'sqlite', databaseUrl: ':memory:' },
+      cwd: tmpRoot,
+    })
+    expect(configCtx.organizationId).toBe('org_01CONFIG000000000000000000')
+    expect(configCtx.userId).toBe('user-config')
+  })
+
+  it('does not request migration authority unless schema application is explicitly enabled', async () => {
+    process.env['ORBIT_CREDENTIAL_KEY'] = TEST_KEY
+    const orbitDir = path.join(tmpRoot, '.orbit')
+    fs.mkdirSync(orbitDir, { recursive: true })
+    fs.writeFileSync(path.join(orbitDir, 'config.json'), JSON.stringify({ orgId: ORG_TEST }), {
+      mode: 0o600,
+    })
+
+    const ctx = await resolveIntegrationsRuntime({
+      flags: { orgId: ORG_TEST, adapter: 'sqlite', databaseUrl: ':memory:' },
+      cwd: tmpRoot,
+    })
+
+    await expect(
+      ctx.credentialStore.saveCredentials(ORG_TEST, 'gmail', 'cli-user', {
+        accessToken: 'a',
+        refreshToken: 'r',
+      }),
+    ).rejects.toThrow(/integration_connections|no such table/i)
   })
 })

--- a/packages/cli/src/config/integrations-runtime.test.ts
+++ b/packages/cli/src/config/integrations-runtime.test.ts
@@ -90,6 +90,20 @@ describe('resolveIntegrationsRuntime', () => {
     expect(loaded?.scopes).toEqual(creds.scopes)
   })
 
+  it('rejects non-Crockford org_id format with INVALID_ORG_ID (runtime strict check)', async () => {
+    process.env['ORBIT_CREDENTIAL_KEY'] = TEST_KEY
+    const orbitDir = path.join(tmpRoot, '.orbit')
+    fs.mkdirSync(orbitDir, { recursive: true })
+    fs.writeFileSync(path.join(orbitDir, 'config.json'), JSON.stringify({ userId: 'someone' }), {
+      mode: 0o600,
+    })
+    // 'I' is not a valid Crockford Base32 character
+    const flags: GlobalFlags = { orgId: 'org_01HZIIIIIIIIIIIIIIIIIIIIII', adapter: 'sqlite', databaseUrl: ':memory:' }
+    await expect(
+      resolveIntegrationsRuntime({ flags, cwd: tmpRoot }),
+    ).rejects.toMatchObject({ details: { code: 'INVALID_ORG_ID', path: 'context.orgId' } })
+  })
+
   it('rejects whitespace-only --org-id with MISSING_REQUIRED_CONFIG', async () => {
     const orbitDir = path.join(tmpRoot, '.orbit')
     fs.mkdirSync(orbitDir, { recursive: true })
@@ -171,12 +185,12 @@ describe('resolveIntegrationsRuntime', () => {
     fs.writeFileSync(
       path.join(userConfigDir, 'config.json'),
       JSON.stringify({
-        orgId: 'org_01BASE00000000000000000000',
+        orgId: 'org_00BASE00000000000000000000',
         profile: 'config-profile',
         profiles: {
-          'config-profile': { orgId: 'org_01CONFIG000000000000000000', userId: 'user-config' },
-          'env-profile': { orgId: 'org_01ENV000000000000000000000', userId: 'user-env' },
-          'flag-profile': { orgId: 'org_01FLAG00000000000000000000', userId: 'user-flag' },
+          'config-profile': { orgId: 'org_00C0NFG0000000000000000000', userId: 'user-config' },
+          'env-profile': { orgId: 'org_00ENVR00000000000000000000', userId: 'user-env' },
+          'flag-profile': { orgId: 'org_00FRAG00000000000000000000', userId: 'user-flag' },
         },
       }),
       { mode: 0o600 },
@@ -186,14 +200,14 @@ describe('resolveIntegrationsRuntime', () => {
       flags: { adapter: 'sqlite', databaseUrl: ':memory:' },
       cwd: tmpRoot,
     })
-    expect(envCtx.organizationId).toBe('org_01ENV000000000000000000000')
+    expect(envCtx.organizationId).toBe('org_00ENVR00000000000000000000')
     expect(envCtx.userId).toBe('user-env')
 
     const flagCtx = await resolveIntegrationsRuntime({
       flags: { adapter: 'sqlite', databaseUrl: ':memory:', profile: 'flag-profile' },
       cwd: tmpRoot,
     })
-    expect(flagCtx.organizationId).toBe('org_01FLAG00000000000000000000')
+    expect(flagCtx.organizationId).toBe('org_00FRAG00000000000000000000')
     expect(flagCtx.userId).toBe('user-flag')
 
     delete process.env['ORBIT_PROFILE']
@@ -201,7 +215,7 @@ describe('resolveIntegrationsRuntime', () => {
       flags: { adapter: 'sqlite', databaseUrl: ':memory:' },
       cwd: tmpRoot,
     })
-    expect(configCtx.organizationId).toBe('org_01CONFIG000000000000000000')
+    expect(configCtx.organizationId).toBe('org_00C0NFG0000000000000000000')
     expect(configCtx.userId).toBe('user-config')
   })
 

--- a/packages/cli/src/config/integrations-runtime.test.ts
+++ b/packages/cli/src/config/integrations-runtime.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { resolveIntegrationsRuntime } from './integrations-runtime.js'
 import type { GlobalFlags } from '../types.js'
+import { _resetJsonMode, _setJsonMode } from '../program.js'
 
 const TEST_KEY = 'a'.repeat(64)
 
@@ -77,5 +78,77 @@ describe('resolveIntegrationsRuntime', () => {
     expect(loaded?.refreshToken).toBe(creds.refreshToken)
     expect(loaded?.providerAccountId).toBe(creds.providerAccountId)
     expect(loaded?.scopes).toEqual(creds.scopes)
+  })
+
+  it('rejects whitespace-only --org-id with MISSING_REQUIRED_CONFIG', async () => {
+    const orbitDir = path.join(tmpRoot, '.orbit')
+    fs.mkdirSync(orbitDir, { recursive: true })
+    fs.writeFileSync(path.join(orbitDir, 'config.json'), JSON.stringify({ userId: 'someone' }), {
+      mode: 0o600,
+    })
+    const flags: GlobalFlags = { orgId: '   ', adapter: 'sqlite', databaseUrl: ':memory:' }
+    await expect(
+      resolveIntegrationsRuntime({ flags, cwd: tmpRoot }),
+    ).rejects.toMatchObject({ details: { code: 'MISSING_REQUIRED_CONFIG', path: 'context.orgId' } })
+  })
+
+  it('rejects empty --org-id with MISSING_REQUIRED_CONFIG', async () => {
+    const orbitDir = path.join(tmpRoot, '.orbit')
+    fs.mkdirSync(orbitDir, { recursive: true })
+    fs.writeFileSync(path.join(orbitDir, 'config.json'), JSON.stringify({ userId: 'someone' }), {
+      mode: 0o600,
+    })
+    const flags: GlobalFlags = { orgId: '', adapter: 'sqlite', databaseUrl: ':memory:' }
+    await expect(
+      resolveIntegrationsRuntime({ flags, cwd: tmpRoot }),
+    ).rejects.toMatchObject({ details: { code: 'MISSING_REQUIRED_CONFIG', path: 'context.orgId' } })
+  })
+
+  it('recursively masks secrets in JSON-mode print output', async () => {
+    process.env['ORBIT_CREDENTIAL_KEY'] = TEST_KEY
+    const orbitDir = path.join(tmpRoot, '.orbit')
+    fs.mkdirSync(orbitDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(orbitDir, 'config.json'),
+      JSON.stringify({ orgId: 'org-test' }),
+      { mode: 0o600 },
+    )
+    _setJsonMode(true)
+    try {
+      const flags: GlobalFlags = {
+        orgId: 'org-test',
+        adapter: 'sqlite',
+        databaseUrl: ':memory:',
+      }
+      const ctx = await resolveIntegrationsRuntime({ flags, cwd: tmpRoot })
+      const logs: string[] = []
+      const original = console.log
+      console.log = (msg?: unknown) => {
+        logs.push(String(msg))
+      }
+      try {
+        ctx.print({
+          accessToken: 'SECRET',
+          nested: { refreshToken: 'NESTED_SECRET', visible: 'ok' },
+        })
+      } finally {
+        console.log = original
+      }
+      expect(logs).toHaveLength(1)
+      const out = logs[0]
+      expect(out).not.toContain('SECRET')
+      expect(out).not.toContain('NESTED_SECRET')
+      expect(out).toContain('***')
+      expect(out).toContain('ok')
+      const parsed = JSON.parse(out!) as {
+        accessToken: string
+        nested: { refreshToken: string; visible: string }
+      }
+      expect(parsed.accessToken).toBe('***')
+      expect(parsed.nested.refreshToken).toBe('***')
+      expect(parsed.nested.visible).toBe('ok')
+    } finally {
+      _resetJsonMode()
+    }
   })
 })

--- a/packages/cli/src/config/integrations-runtime.test.ts
+++ b/packages/cli/src/config/integrations-runtime.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { resolveIntegrationsRuntime } from './integrations-runtime.js'
+import type { GlobalFlags } from '../types.js'
+
+const TEST_KEY = 'a'.repeat(64)
+
+describe('resolveIntegrationsRuntime', () => {
+  let tmpRoot: string
+  let originalKey: string | undefined
+  let originalOrgId: string | undefined
+  let originalUserId: string | undefined
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-int-runtime-'))
+    originalKey = process.env['ORBIT_CREDENTIAL_KEY']
+    originalOrgId = process.env['ORBIT_ORG_ID']
+    originalUserId = process.env['ORBIT_USER_ID']
+    delete process.env['ORBIT_ORG_ID']
+    delete process.env['ORBIT_USER_ID']
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+    if (originalKey === undefined) delete process.env['ORBIT_CREDENTIAL_KEY']
+    else process.env['ORBIT_CREDENTIAL_KEY'] = originalKey
+    if (originalOrgId === undefined) delete process.env['ORBIT_ORG_ID']
+    else process.env['ORBIT_ORG_ID'] = originalOrgId
+    if (originalUserId === undefined) delete process.env['ORBIT_USER_ID']
+    else process.env['ORBIT_USER_ID'] = originalUserId
+  })
+
+  it('throws CliValidationError when no .orbit/config.json exists', async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-int-noconfig-'))
+    try {
+      await expect(
+        resolveIntegrationsRuntime({ flags: {} as GlobalFlags, cwd }),
+      ).rejects.toThrow(/orbit init/i)
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('round-trips credentials via SQLite adapter and AES-GCM encryption', async () => {
+    process.env['ORBIT_CREDENTIAL_KEY'] = TEST_KEY
+    const orbitDir = path.join(tmpRoot, '.orbit')
+    fs.mkdirSync(orbitDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(orbitDir, 'config.json'),
+      JSON.stringify({ orgId: 'org-test' }),
+      { mode: 0o600 },
+    )
+
+    const flags: GlobalFlags = {
+      orgId: 'org-test',
+      adapter: 'sqlite',
+      databaseUrl: ':memory:',
+    }
+    const ctx = await resolveIntegrationsRuntime({ flags, cwd: tmpRoot })
+
+    expect(ctx.organizationId).toBe('org-test')
+    expect(ctx.userId).toBe('cli-user')
+
+    const creds = {
+      accessToken: 'access-abc',
+      refreshToken: 'refresh-xyz',
+      expiresAt: Date.now() + 3600_000,
+      scopes: ['scope1', 'scope2'],
+      providerAccountId: 'acct@example.com',
+    }
+    await ctx.credentialStore.saveCredentials('org-test', 'gmail', 'cli-user', creds)
+    const loaded = await ctx.credentialStore.getCredentials('org-test', 'gmail', 'cli-user')
+    expect(loaded).not.toBeNull()
+    expect(loaded?.accessToken).toBe(creds.accessToken)
+    expect(loaded?.refreshToken).toBe(creds.refreshToken)
+    expect(loaded?.providerAccountId).toBe(creds.providerAccountId)
+    expect(loaded?.scopes).toEqual(creds.scopes)
+  })
+})

--- a/packages/cli/src/config/integrations-runtime.ts
+++ b/packages/cli/src/config/integrations-runtime.ts
@@ -15,6 +15,8 @@ import { isJsonMode } from '../program.js'
 export interface ResolveIntegrationsRuntimeOptions {
   flags: GlobalFlags
   cwd: string
+  /** Test/operator escape hatch. Runtime commands default to no schema mutation. */
+  applySchema?: boolean
 }
 
 export async function resolveIntegrationsRuntime(
@@ -27,7 +29,8 @@ export async function resolveIntegrationsRuntime(
       { code: 'MISSING_REQUIRED_CONFIG', path: 'config' },
     )
   }
-  const config = opts.flags.profile ? applyProfile(rawConfig, opts.flags.profile) : rawConfig
+  const profileName = opts.flags.profile ?? process.env['ORBIT_PROFILE'] ?? rawConfig.profile
+  const config = profileName ? applyProfile(rawConfig, profileName) : rawConfig
 
   const orgId = nonBlank(opts.flags.orgId) ?? nonBlank(process.env['ORBIT_ORG_ID']) ?? nonBlank(config.orgId)
   if (!orgId) {
@@ -44,7 +47,9 @@ export async function resolveIntegrationsRuntime(
 
   const adapter = resolveAdapter(opts.flags, config, opts.cwd)
 
-  await applyIntegrationsSchemaExtension(adapter)
+  if (opts.applySchema === true || opts.flags.applyIntegrationsSchema === true) {
+    await applyIntegrationsSchemaExtension(adapter)
+  }
 
   const encryption = new AesGcmEncryptionProvider()
   const credentialStore = new TableBackedCredentialStore(adapter, encryption)

--- a/packages/cli/src/config/integrations-runtime.ts
+++ b/packages/cli/src/config/integrations-runtime.ts
@@ -29,7 +29,7 @@ export async function resolveIntegrationsRuntime(
   }
   const config = opts.flags.profile ? applyProfile(rawConfig, opts.flags.profile) : rawConfig
 
-  const orgId = opts.flags.orgId ?? process.env['ORBIT_ORG_ID'] ?? config.orgId
+  const orgId = nonBlank(opts.flags.orgId) ?? nonBlank(process.env['ORBIT_ORG_ID']) ?? nonBlank(config.orgId)
   if (!orgId) {
     throw new CliValidationError(
       'orgId is required for integrations. Pass --org-id, set ORBIT_ORG_ID, or run `orbit init --org-id <id>` to persist it in .orbit/config.json.',
@@ -37,7 +37,10 @@ export async function resolveIntegrationsRuntime(
     )
   }
   const userId =
-    opts.flags.userId ?? process.env['ORBIT_USER_ID'] ?? config.userId ?? 'cli-user'
+    nonBlank(opts.flags.userId) ??
+    nonBlank(process.env['ORBIT_USER_ID']) ??
+    nonBlank(config.userId) ??
+    'cli-user'
 
   const adapter = resolveAdapter(opts.flags, config, opts.cwd)
 
@@ -46,19 +49,26 @@ export async function resolveIntegrationsRuntime(
   const encryption = new AesGcmEncryptionProvider()
   const credentialStore = new TableBackedCredentialStore(adapter, encryption)
 
+  const jsonMode = isJsonMode()
+
   return {
     organizationId: orgId,
     userId,
     credentialStore,
-    isJsonMode: isJsonMode(),
+    isJsonMode: jsonMode,
     print(value: unknown) {
-      if (isJsonMode()) {
-        console.log(JSON.stringify(value))
+      const safe = sanitizeForPrint(value)
+      if (jsonMode) {
+        console.log(JSON.stringify(safe))
       } else {
-        console.log(maskSecrets(value))
+        console.log(typeof safe === 'string' ? safe : JSON.stringify(safe, null, 2))
       }
     },
   }
+}
+
+function nonBlank(v: string | undefined | null): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v : undefined
 }
 
 function isPostgresOnlyStatement(stmt: string): boolean {
@@ -90,11 +100,17 @@ export async function applyIntegrationsSchemaExtension(adapter: StorageAdapter):
   })
 }
 
-function maskSecrets(value: unknown): string {
-  if (typeof value !== 'object' || value === null) return String(value)
-  const masked: Record<string, unknown> = { ...(value as Record<string, unknown>) }
-  for (const key of Object.keys(masked)) {
-    if (/token|secret|key|password/i.test(key)) masked[key] = '***'
+const SECRET_KEY_PATTERN = /token|secret|key|password/i
+
+function sanitizeForPrint(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((v) => sanitizeForPrint(v))
+  if (value !== null && typeof value === 'object') {
+    const src = value as Record<string, unknown>
+    const out: Record<string, unknown> = {}
+    for (const key of Object.keys(src)) {
+      out[key] = SECRET_KEY_PATTERN.test(key) ? '***' : sanitizeForPrint(src[key])
+    }
+    return out
   }
-  return JSON.stringify(masked, null, 2)
+  return value
 }

--- a/packages/cli/src/config/integrations-runtime.ts
+++ b/packages/cli/src/config/integrations-runtime.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm'
 import type { StorageAdapter } from '@orbit-ai/core'
+import { isOrbitId } from '@orbit-ai/core'
 import {
   AesGcmEncryptionProvider,
   TableBackedCredentialStore,
@@ -39,13 +40,19 @@ export async function resolveIntegrationsRuntime(
       { code: 'MISSING_REQUIRED_CONFIG', path: 'context.orgId' },
     )
   }
+  if (!isOrbitId(orgId, 'organization')) {
+    throw new CliValidationError(
+      `orgId must be a valid org ULID (org_...). Got: '${orgId}'`,
+      { code: 'INVALID_ORG_ID', path: 'context.orgId' },
+    )
+  }
   const userId =
     nonBlank(opts.flags.userId) ??
     nonBlank(process.env['ORBIT_USER_ID']) ??
     nonBlank(config.userId) ??
     'cli-user'
 
-  const adapter = resolveAdapter(opts.flags, config, opts.cwd)
+  const adapter = resolveAdapter(opts.flags, config, opts.cwd, process.env)
 
   if (opts.applySchema === true || opts.flags.applyIntegrationsSchema === true) {
     await applyIntegrationsSchemaExtension(adapter)

--- a/packages/cli/src/config/integrations-runtime.ts
+++ b/packages/cli/src/config/integrations-runtime.ts
@@ -1,0 +1,100 @@
+import { sql } from 'drizzle-orm'
+import type { StorageAdapter } from '@orbit-ai/core'
+import {
+  AesGcmEncryptionProvider,
+  TableBackedCredentialStore,
+  integrationSchemaExtension,
+  type CliRuntimeContext,
+} from '@orbit-ai/integrations'
+import { CliValidationError } from '../errors.js'
+import type { GlobalFlags } from '../types.js'
+import { loadConfig, applyProfile } from './files.js'
+import { resolveAdapter } from './resolve-context.js'
+import { isJsonMode } from '../program.js'
+
+export interface ResolveIntegrationsRuntimeOptions {
+  flags: GlobalFlags
+  cwd: string
+}
+
+export async function resolveIntegrationsRuntime(
+  opts: ResolveIntegrationsRuntimeOptions,
+): Promise<CliRuntimeContext> {
+  const rawConfig = loadConfig(opts.cwd)
+  if (!rawConfig || Object.keys(rawConfig).length === 0) {
+    throw new CliValidationError(
+      'No .orbit/config.json found. Run `orbit init` first.',
+      { code: 'MISSING_REQUIRED_CONFIG', path: 'config' },
+    )
+  }
+  const config = opts.flags.profile ? applyProfile(rawConfig, opts.flags.profile) : rawConfig
+
+  const orgId = opts.flags.orgId ?? process.env['ORBIT_ORG_ID'] ?? config.orgId
+  if (!orgId) {
+    throw new CliValidationError(
+      'orgId is required for integrations. Pass --org-id, set ORBIT_ORG_ID, or run `orbit init --org-id <id>` to persist it in .orbit/config.json.',
+      { code: 'MISSING_REQUIRED_CONFIG', path: 'context.orgId' },
+    )
+  }
+  const userId =
+    opts.flags.userId ?? process.env['ORBIT_USER_ID'] ?? config.userId ?? 'cli-user'
+
+  const adapter = resolveAdapter(opts.flags, config, opts.cwd)
+
+  await applyIntegrationsSchemaExtension(adapter)
+
+  const encryption = new AesGcmEncryptionProvider()
+  const credentialStore = new TableBackedCredentialStore(adapter, encryption)
+
+  return {
+    organizationId: orgId,
+    userId,
+    credentialStore,
+    isJsonMode: isJsonMode(),
+    print(value: unknown) {
+      if (isJsonMode()) {
+        console.log(JSON.stringify(value))
+      } else {
+        console.log(maskSecrets(value))
+      }
+    },
+  }
+}
+
+function isPostgresOnlyStatement(stmt: string): boolean {
+  const s = stmt.trim().toUpperCase()
+  return (
+    s.includes('ENABLE ROW LEVEL SECURITY') ||
+    s.startsWith('CREATE POLICY') ||
+    s.startsWith('DROP POLICY')
+  )
+}
+
+export async function applyIntegrationsSchemaExtension(adapter: StorageAdapter): Promise<void> {
+  const isSqlite = adapter.dialect === 'sqlite'
+  await adapter.runWithMigrationAuthority(async (db) => {
+    for (const migration of integrationSchemaExtension.migrations) {
+      for (const stmt of migration.up) {
+        if (isSqlite && isPostgresOnlyStatement(stmt)) continue
+        const sanitized = isSqlite ? stmt.replace(/::jsonb/g, '') : stmt
+        try {
+          await db.execute(sql.raw(sanitized))
+        } catch (err) {
+          console.error(
+            `[applyIntegrationsSchemaExtension] failed statement in ${migration.id}: ${err instanceof Error ? err.message : String(err)}`,
+          )
+          throw err
+        }
+      }
+    }
+  })
+}
+
+function maskSecrets(value: unknown): string {
+  if (typeof value !== 'object' || value === null) return String(value)
+  const masked: Record<string, unknown> = { ...(value as Record<string, unknown>) }
+  for (const key of Object.keys(masked)) {
+    if (/token|secret|key|password/i.test(key)) masked[key] = '***'
+  }
+  return JSON.stringify(masked, null, 2)
+}

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -32,9 +32,28 @@ export interface ResolveContextOptions {
   overrideHome?: string
 }
 
-export function resolveAdapter(flags: GlobalFlags, config: OrbitConfig, cwd: string): StorageAdapter {
-  const adapterName = flags.adapter ?? config.adapter ?? 'sqlite'
-  const dbUrl = flags.databaseUrl ?? config.databaseUrl ?? ''
+const VALID_ADAPTER_NAMES = ['sqlite', 'postgres', 'supabase', 'neon'] as const
+type ValidAdapterName = (typeof VALID_ADAPTER_NAMES)[number]
+
+function isValidAdapterName(value: string): value is ValidAdapterName {
+  return (VALID_ADAPTER_NAMES as readonly string[]).includes(value)
+}
+
+export function resolveAdapter(
+  flags: GlobalFlags,
+  config: OrbitConfig,
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): StorageAdapter {
+  const envAdapter = env['ORBIT_ADAPTER']
+  if (envAdapter !== undefined && !isValidAdapterName(envAdapter)) {
+    throw new CliValidationError(
+      `ORBIT_ADAPTER must be one of: ${VALID_ADAPTER_NAMES.join(', ')}. Got: '${envAdapter}'`,
+      { code: 'INVALID_ADAPTER_NAME', value: envAdapter },
+    )
+  }
+  const adapterName = flags.adapter ?? envAdapter ?? config.adapter ?? 'sqlite'
+  const dbUrl = flags.databaseUrl ?? env['DATABASE_URL'] ?? config.databaseUrl ?? ''
 
   if (adapterName === 'sqlite') {
     // Validate URL scheme — block any scheme except file:

--- a/packages/cli/src/config/resolve-context.ts
+++ b/packages/cli/src/config/resolve-context.ts
@@ -32,7 +32,7 @@ export interface ResolveContextOptions {
   overrideHome?: string
 }
 
-function resolveAdapter(flags: GlobalFlags, config: OrbitConfig, cwd: string): StorageAdapter {
+export function resolveAdapter(flags: GlobalFlags, config: OrbitConfig, cwd: string): StorageAdapter {
   const adapterName = flags.adapter ?? config.adapter ?? 'sqlite'
   const dbUrl = flags.databaseUrl ?? config.databaseUrl ?? ''
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -30,8 +30,12 @@ import { registerFieldsCommand } from './commands/fields.js'
 import { registerReportCommand } from './commands/report.js'
 import { registerDashboardCommand } from './commands/dashboard.js'
 import { registerMcpCommand } from './commands/mcp.js'
-import { registerIntegrationsCommand } from './commands/integrations.js'
+import { registerIntegrationsCommand, registerIntegrationSubcommands } from './commands/integrations.js'
 import { registerCalendarAliasCommand } from './commands/calendar-alias.js'
+import { buildGmailCommands } from '@orbit-ai/integrations/gmail'
+import { buildCalendarCommands } from '@orbit-ai/integrations/google-calendar'
+import { resolveIntegrationsRuntime } from './config/integrations-runtime.js'
+import type { IntegrationCommand, CliRuntimeContext } from '@orbit-ai/integrations'
 
 let _jsonMode = false
 let _sigintHandler: (() => void) | null = null
@@ -173,6 +177,39 @@ export function createProgram(): Command {
   registerMcpCommand(program)
   registerIntegrationsCommand(program)
   registerCalendarAliasCommand(program)
+
+  const placeholderRuntime: CliRuntimeContext = {
+    organizationId: '',
+    userId: '',
+    isJsonMode: false,
+    credentialStore: null as never,
+    print: () => {},
+  }
+
+  function wrapForDeferredRuntime(
+    factory: (runtime: CliRuntimeContext) => IntegrationCommand[],
+  ): IntegrationCommand[] {
+    const placeholders = factory(placeholderRuntime)
+    return placeholders.map((cmd) => ({
+      ...cmd,
+      async action(...args: unknown[]) {
+        const invokedCommand = args[args.length - 1] as Command
+        let root: Command = invokedCommand
+        while (root.parent) root = root.parent
+        const flags = root.opts() as GlobalFlags
+        const runtime = await resolveIntegrationsRuntime({ flags, cwd: process.cwd() })
+        const real = factory(runtime)
+        const match = real.find((c) => c.name === cmd.name)
+        if (!match) throw new Error(`Command ${cmd.name} not found in factory rebuild`)
+        await match.action(...args)
+      },
+    }))
+  }
+
+  registerIntegrationSubcommands(program, [
+    ...wrapForDeferredRuntime(buildGmailCommands),
+    ...wrapForDeferredRuntime(buildCalendarCommands),
+  ])
 
   return program
 }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -143,6 +143,7 @@ export function createProgram(): Command {
     .option('--adapter <type>', 'Storage adapter: sqlite|postgres (direct mode)')
     .option('--mode <mode>', 'Client mode: api|direct', 'api')
     .option('--profile <name>', 'Config profile name')
+    .option('--apply-integrations-schema', 'Apply integration schema extension before running integration commands')
     .option('--quiet', 'Suppress warnings')
     .option('--yes', 'Skip interactive confirmations (bypass for --yes flag)')
     .hook('preAction', (thisCommand) => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -49,6 +49,11 @@ export function _resetJsonMode(): void {
   _jsonMode = false
 }
 
+// test-only
+export function _setJsonMode(value: boolean): void {
+  _jsonMode = value
+}
+
 // test-only export
 export { classifyError as _classifyError }
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -98,6 +98,23 @@ function classifyError(error: unknown): { code: number; payload: Record<string, 
       },
     }
   }
+  // OrbitEncryptionConfigError → exit code 2 (configuration problem, not runtime error)
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    (error as { name?: unknown }).name === 'OrbitEncryptionConfigError' &&
+    typeof (error as { code?: unknown }).code === 'string'
+  ) {
+    const e = error as { code: string; message: string }
+    return {
+      code: 2,
+      payload: {
+        code: 'CONFIGURATION_ERROR',
+        detail: e.code,
+        message: e.message,
+      },
+    }
+  }
   // OrbitApiError and HTTP errors → exit code 1
   if (
     error instanceof Error &&

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -13,6 +13,7 @@ export interface GlobalFlags {
   adapter?: string
   mode?: 'api' | 'direct'
   profile?: string
+  applyIntegrationsSchema?: boolean
   quiet?: boolean
   yes?: boolean
 }

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -10,16 +10,16 @@ Alpha (`0.1.0-alpha.0`) — not yet published to npm.
 
 | Connector | OAuth | Operations | Sync | MCP Tools | CLI Commands |
 |-----------|-------|------------|------|-----------|--------------|
-| Gmail | ✓ | send, list, get | message → activity | send_email, sync_thread | — |
-| Google Calendar | ✓ | list, create, update, delete, availability | event → activity | list_events, create_event | list, create, sync |
+| Gmail | ✓ | send, list, get | message → activity | send_email, sync_thread | configure, status |
+| Google Calendar | ✓ | list, create, update, delete, availability | event → activity | list_events, create_event | configure, status |
 | Stripe | API key | payment link, payment status | checkout → payment | create_payment_link, get_payment_status | link-create, sync |
 
 ## Architecture
 
 - **Plugin contract**: `OrbitIntegrationPlugin` — install/uninstall/healthcheck lifecycle
 - **Registry**: Dynamic plugin registration with `IntegrationRegistry`
-- **Config**: `.orbit/integrations.json` for enabling/disabling connectors
-- **Credential store**: `CredentialStore` interface with AES-256-GCM encryption
+- **Config**: Orbit CLI config plus provider OAuth token input from env, files, or stdin
+- **Credential store**: `CredentialStore` interface backed by `integration_connections` with AES-256-GCM encryption
 - **Event bus**: Internal domain events with routing enforcement (provider ≠ customer events)
 - **Retry**: Bounded exponential backoff with jitter for provider API calls
 
@@ -47,20 +47,23 @@ Alpha (`0.1.0-alpha.0`) — not yet published to npm.
 1. Go to [Google Cloud Console](https://console.cloud.google.com) → APIs & Services → Library.
 2. Search for **Gmail API** and click Enable.
 3. Go to APIs & Services → Credentials → Create Credentials → OAuth 2.0 Client ID.
-4. Application type: **Desktop app**. Download the credentials JSON.
-5. Place the credentials file at `.orbit/gmail-credentials.json` in your project root.
-6. Run the configuration command:
+4. Application type: **Desktop app**.
+5. Complete your OAuth consent flow outside the alpha CLI and collect the issued access and refresh tokens.
+6. On first install, apply the integration schema explicitly while configuring credentials:
 
 ```bash
-orbit integrations gmail configure
+export ORBIT_CREDENTIAL_KEY="$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")"
+export ORBIT_GMAIL_ACCESS_TOKEN="..."
+export ORBIT_GMAIL_REFRESH_TOKEN="..."
+orbit --apply-integrations-schema integrations gmail configure --skip-validation
 ```
 
-This opens a browser OAuth consent flow. On completion, the access and refresh tokens are stored encrypted at `.orbit/integrations.json`.
+Alpha configuration persists the supplied access and refresh tokens encrypted in the `integration_connections` table. Avoid `--access-token` and `--refresh-token` in shared environments because command-line arguments can appear in shell history and process listings. Safer alternatives are `ORBIT_GMAIL_ACCESS_TOKEN` / `ORBIT_GMAIL_REFRESH_TOKEN`, `--access-token-env` / `--refresh-token-env`, token files with `0600` permissions, or `--tokens-stdin`.
 
 7. Verify connectivity:
 
 ```bash
-orbit integrations gmail configure --help
+orbit integrations gmail status
 ```
 
 **Scopes requested:** `gmail.readonly`, `gmail.send`, `gmail.labels`
@@ -72,18 +75,21 @@ orbit integrations gmail configure --help
 **Prerequisites:** Same Google Cloud project as Gmail (or a separate one).
 
 1. In Google Cloud Console → APIs & Services → Library, enable the **Google Calendar API**.
-2. Reuse the OAuth credentials from Gmail, or create a new Desktop app credential.
-3. Place credentials at `.orbit/calendar-credentials.json`.
-4. Run:
+2. Reuse the OAuth client from Gmail, or create a new Desktop app credential.
+3. Complete your OAuth consent flow outside the alpha CLI and collect the issued access and refresh tokens.
+4. On first install, apply the integration schema explicitly while configuring credentials:
 
 ```bash
-orbit integrations calendar configure
+export ORBIT_CREDENTIAL_KEY="$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")"
+export ORBIT_GOOGLE_CALENDAR_ACCESS_TOKEN="..."
+export ORBIT_GOOGLE_CALENDAR_REFRESH_TOKEN="..."
+orbit --apply-integrations-schema integrations google-calendar configure --skip-validation
 ```
 
 5. Verify:
 
 ```bash
-orbit integrations calendar list
+orbit integrations google-calendar status
 ```
 
 **Scopes requested:** `calendar.readonly`, `calendar.events`
@@ -122,8 +128,10 @@ orbit integrations stripe link-create --amount 2999 --currency eur --name "Consu
 
 ## Credential Storage
 
-All connector credentials are stored encrypted (AES-256-GCM) at `.orbit/integrations.json`. This file is created by the configure commands and should be:
+Google connector credentials are stored encrypted (AES-256-GCM) in `integration_connections`. Operators must set `ORBIT_CREDENTIAL_KEY` to a 64-character hex key before configuring or reading credentials. Token files, if used as CLI input, should be:
 
-- Added to `.gitignore`
+- Added to `.gitignore` if they live under the project
 - Backed up outside the repo if using long-lived refresh tokens
-- Set to `0600` permissions: `chmod 0600 .orbit/integrations.json`
+- Set to `0600` permissions
+
+Integration schema creation is an explicit operator action. Normal `configure` and `status` commands do not apply DDL; pass the CLI `--apply-integrations-schema` flag only during setup/migration when using a database that has not already installed the integration tables.

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -9,6 +9,14 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./gmail": {
+      "types": "./dist/gmail/index.d.ts",
+      "import": "./dist/gmail/index.js"
+    },
+    "./google-calendar": {
+      "types": "./dist/google-calendar/index.d.ts",
+      "import": "./dist/google-calendar/index.js"
     }
   },
   "scripts": {

--- a/packages/integrations/src/credentials.test.ts
+++ b/packages/integrations/src/credentials.test.ts
@@ -1,9 +1,16 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { sql } from 'drizzle-orm'
-import { createSqliteOrbitDatabase, createSqliteStorageAdapter, type StorageAdapter } from '@orbit-ai/core'
+import {
+  createSqliteOrbitDatabase,
+  createSqliteStorageAdapter,
+  type OrbitAuthContext,
+  type OrbitDatabase,
+  type StorageAdapter,
+} from '@orbit-ai/core'
 import { InMemoryCredentialStore, TableBackedCredentialStore } from './credentials.js'
 import type { StoredCredentials } from './credentials.js'
 import { NoopEncryptionProvider } from './encryption.js'
+import type { EncryptionProvider } from './encryption.js'
 import { integrationSchemaExtension } from './schema-extension.js'
 
 function isPostgresOnlyStatement(stmt: string): boolean {
@@ -29,6 +36,96 @@ async function setupSqliteAdapter(): Promise<StorageAdapter> {
   return adapter
 }
 
+function createTenantContextRecordingAdapter(queryRows: Record<string, unknown>[] = []): {
+  adapter: StorageAdapter
+  tenantDb: OrbitDatabase
+  rawDb: OrbitDatabase
+  contexts: OrbitAuthContext[]
+} {
+  const contexts: OrbitAuthContext[] = []
+  const rawDb: OrbitDatabase = {
+    transaction: vi.fn(async (fn) => fn(rawDb)),
+    query: vi.fn(async () => {
+      throw new Error('unsafe raw query used')
+    }),
+    execute: vi.fn(async () => {
+      throw new Error('unsafe raw execute used')
+    }),
+  }
+  const tenantDb: OrbitDatabase = {
+    transaction: vi.fn(async (fn) => fn(tenantDb)),
+    query: vi.fn(async () => queryRows),
+    execute: vi.fn(async () => undefined),
+  }
+  const adapter: StorageAdapter = {
+    name: 'sqlite',
+    dialect: 'sqlite',
+    supportsRls: false,
+    supportsBranching: false,
+    supportsJsonbIndexes: false,
+    authorityModel: {
+      runtimeAuthority: 'request-scoped',
+      migrationAuthority: 'elevated',
+      requestPathMayUseElevatedCredentials: false,
+      notes: [],
+    },
+    unsafeRawDatabase: rawDb,
+    users: {
+      async resolveByExternalAuthId() {
+        return null
+      },
+      async upsertFromAuth() {
+        return 'user_test'
+      },
+    },
+    async connect() {},
+    async disconnect() {},
+    async migrate() {},
+    async runWithMigrationAuthority(fn) {
+      return fn({} as never)
+    },
+    async lookupApiKeyForAuth() {
+      return null
+    },
+    async transaction(fn) {
+      return fn(tenantDb)
+    },
+    beginTransaction() {
+      return {
+        async run(ctx, fn) {
+          contexts.push(ctx)
+          return fn(tenantDb)
+        },
+      }
+    },
+    async execute() {
+      return undefined
+    },
+    async query() {
+      return []
+    },
+    async withTenantContext(ctx, fn) {
+      contexts.push(ctx)
+      return fn(tenantDb)
+    },
+    async getSchemaSnapshot() {
+      return { customFields: [], tables: [] }
+    },
+  }
+
+  return { adapter, tenantDb, rawDb, contexts }
+}
+
+class ThrowingEncryptionProvider implements EncryptionProvider {
+  async encrypt(plaintext: string): Promise<string> {
+    throw new Error(`encryption failed for ${plaintext}`)
+  }
+
+  async decrypt(ciphertext: string): Promise<string> {
+    throw new Error(`decryption failed for ${ciphertext}`)
+  }
+}
+
 const makeCredentials = (overrides: Partial<StoredCredentials> = {}): StoredCredentials => ({
   accessToken: 'access-token-abc',
   refreshToken: 'refresh-token-xyz',
@@ -37,6 +134,9 @@ const makeCredentials = (overrides: Partial<StoredCredentials> = {}): StoredCred
   providerAccountId: 'user@example.com',
   ...overrides,
 })
+
+const ORG_1 = 'org_01ABCDEF0123456789ABCDEF01'
+const ORG_2 = 'org_01ABCDEF0123456789ABCDEF02'
 
 describe('InMemoryCredentialStore', () => {
   let store: InMemoryCredentialStore
@@ -131,14 +231,14 @@ describe('TableBackedCredentialStore', () => {
   })
 
   it('returns null when no credentials exist', async () => {
-    const result = await store.getCredentials('org-1', 'gmail', 'user-1')
+    const result = await store.getCredentials(ORG_1, 'gmail', 'user-1')
     expect(result).toBeNull()
   })
 
   it('round-trips credentials through encryption + decryption', async () => {
     const creds = makeCredentials()
-    await store.saveCredentials('org-1', 'gmail', 'user-1', creds)
-    const result = await store.getCredentials('org-1', 'gmail', 'user-1')
+    await store.saveCredentials(ORG_1, 'gmail', 'user-1', creds)
+    const result = await store.getCredentials(ORG_1, 'gmail', 'user-1')
     expect(result).not.toBeNull()
     expect(result?.accessToken).toBe(creds.accessToken)
     expect(result?.refreshToken).toBe(creds.refreshToken)
@@ -150,33 +250,80 @@ describe('TableBackedCredentialStore', () => {
   it('UPSERTs on duplicate (org, provider, user) — second save wins', async () => {
     const original = makeCredentials({ accessToken: 'first-access', refreshToken: 'first-refresh' })
     const updated = makeCredentials({ accessToken: 'second-access', refreshToken: 'second-refresh' })
-    await store.saveCredentials('org-1', 'gmail', 'user-1', original)
-    await expect(store.saveCredentials('org-1', 'gmail', 'user-1', updated)).resolves.toBeUndefined()
-    const result = await store.getCredentials('org-1', 'gmail', 'user-1')
+    await store.saveCredentials(ORG_1, 'gmail', 'user-1', original)
+    await expect(store.saveCredentials(ORG_1, 'gmail', 'user-1', updated)).resolves.toBeUndefined()
+    const result = await store.getCredentials(ORG_1, 'gmail', 'user-1')
     expect(result?.accessToken).toBe('second-access')
     expect(result?.refreshToken).toBe('second-refresh')
   })
 
   it('delete removes the row', async () => {
-    await store.saveCredentials('org-1', 'gmail', 'user-1', makeCredentials())
-    await store.deleteCredentials('org-1', 'gmail', 'user-1')
-    expect(await store.getCredentials('org-1', 'gmail', 'user-1')).toBeNull()
+    await store.saveCredentials(ORG_1, 'gmail', 'user-1', makeCredentials())
+    await store.deleteCredentials(ORG_1, 'gmail', 'user-1')
+    expect(await store.getCredentials(ORG_1, 'gmail', 'user-1')).toBeNull()
   })
 
   it('isolates tenants — org A credentials are invisible to org B', async () => {
-    await store.saveCredentials('org-a', 'gmail', 'user-1', makeCredentials({ accessToken: 'a-token' }))
-    expect(await store.getCredentials('org-b', 'gmail', 'user-1')).toBeNull()
-    expect((await store.getCredentials('org-a', 'gmail', 'user-1'))?.accessToken).toBe('a-token')
+    await store.saveCredentials(ORG_1, 'gmail', 'user-1', makeCredentials({ accessToken: 'a-token' }))
+    expect(await store.getCredentials(ORG_2, 'gmail', 'user-1')).toBeNull()
+    expect((await store.getCredentials(ORG_1, 'gmail', 'user-1'))?.accessToken).toBe('a-token')
   })
 
   it('handles credentials without optional fields', async () => {
     const minimal: StoredCredentials = { accessToken: 'a', refreshToken: 'r' }
-    await store.saveCredentials('org-1', 'stripe', 'user-1', minimal)
-    const result = await store.getCredentials('org-1', 'stripe', 'user-1')
+    await store.saveCredentials(ORG_1, 'stripe', 'user-1', minimal)
+    const result = await store.getCredentials(ORG_1, 'stripe', 'user-1')
     expect(result?.accessToken).toBe('a')
     expect(result?.refreshToken).toBe('r')
     expect(result?.scopes).toBeUndefined()
     expect(result?.expiresAt).toBeUndefined()
     expect(result?.providerAccountId).toBeUndefined()
+  })
+
+  it('runs get, save, and delete inside tenant context using the callback database handle', async () => {
+    const { adapter, contexts, rawDb, tenantDb } = createTenantContextRecordingAdapter()
+    const recordedStore = new TableBackedCredentialStore(adapter, new NoopEncryptionProvider())
+
+    await recordedStore.getCredentials(ORG_1, 'gmail', 'user-1')
+    await recordedStore.saveCredentials(ORG_1, 'gmail', 'user-1', makeCredentials())
+    await recordedStore.deleteCredentials(ORG_1, 'gmail', 'user-1')
+
+    expect(contexts).toEqual([
+      { orgId: ORG_1, userId: 'user-1' },
+      { orgId: ORG_1, userId: 'user-1' },
+      { orgId: ORG_1, userId: 'user-1' },
+    ])
+    expect(tenantDb.query).toHaveBeenCalledTimes(1)
+    expect(tenantDb.execute).toHaveBeenCalledTimes(2)
+    expect(rawDb.query).not.toHaveBeenCalled()
+    expect(rawDb.execute).not.toHaveBeenCalled()
+  })
+
+  it('does not log plaintext secrets when credential encryption fails', async () => {
+    const { adapter } = createTenantContextRecordingAdapter()
+    const recordedStore = new TableBackedCredentialStore(adapter, new ThrowingEncryptionProvider())
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const credentials = makeCredentials({
+      accessToken: 'plaintext-access-secret',
+      refreshToken: 'plaintext-refresh-secret',
+    })
+
+    try {
+      await expect(recordedStore.saveCredentials(ORG_1, 'gmail', 'user-1', credentials)).rejects.toThrow(
+        'plaintext-access-secret',
+      )
+
+      expect(consoleError).not.toHaveBeenCalled()
+      expect(
+        consoleError.mock.calls
+          .flat()
+          .some((part) =>
+            String(part).includes('plaintext-access-secret') ||
+            String(part).includes('plaintext-refresh-secret'),
+          ),
+      ).toBe(false)
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 })

--- a/packages/integrations/src/credentials.test.ts
+++ b/packages/integrations/src/credentials.test.ts
@@ -1,6 +1,33 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { InMemoryCredentialStore } from './credentials.js'
+import { sql } from 'drizzle-orm'
+import { createSqliteOrbitDatabase, createSqliteStorageAdapter, type StorageAdapter } from '@orbit-ai/core'
+import { InMemoryCredentialStore, TableBackedCredentialStore } from './credentials.js'
 import type { StoredCredentials } from './credentials.js'
+import { NoopEncryptionProvider } from './encryption.js'
+import { integrationSchemaExtension } from './schema-extension.js'
+
+function isPostgresOnlyStatement(stmt: string): boolean {
+  const s = stmt.trim().toUpperCase()
+  return (
+    s.includes('ENABLE ROW LEVEL SECURITY') ||
+    s.startsWith('CREATE POLICY') ||
+    s.startsWith('DROP POLICY')
+  )
+}
+
+async function setupSqliteAdapter(): Promise<StorageAdapter> {
+  const database = createSqliteOrbitDatabase()
+  const adapter = createSqliteStorageAdapter({ database })
+  for (const migration of integrationSchemaExtension.migrations) {
+    for (const stmt of migration.up) {
+      if (isPostgresOnlyStatement(stmt)) continue
+      // SQLite doesn't recognize ::jsonb cast syntax — strip it for the test harness.
+      const sanitized = stmt.replace(/::jsonb/g, '')
+      await database.execute(sql.raw(sanitized))
+    }
+  }
+  return adapter
+}
 
 const makeCredentials = (overrides: Partial<StoredCredentials> = {}): StoredCredentials => ({
   accessToken: 'access-token-abc',
@@ -91,5 +118,65 @@ describe('InMemoryCredentialStore', () => {
 
   it('deleting non-existent entry does not throw', async () => {
     await expect(store.deleteCredentials('org-99', 'stripe', 'user-99')).resolves.toBeUndefined()
+  })
+})
+
+describe('TableBackedCredentialStore', () => {
+  let adapter: StorageAdapter
+  let store: TableBackedCredentialStore
+
+  beforeEach(async () => {
+    adapter = await setupSqliteAdapter()
+    store = new TableBackedCredentialStore(adapter, new NoopEncryptionProvider())
+  })
+
+  it('returns null when no credentials exist', async () => {
+    const result = await store.getCredentials('org-1', 'gmail', 'user-1')
+    expect(result).toBeNull()
+  })
+
+  it('round-trips credentials through encryption + decryption', async () => {
+    const creds = makeCredentials()
+    await store.saveCredentials('org-1', 'gmail', 'user-1', creds)
+    const result = await store.getCredentials('org-1', 'gmail', 'user-1')
+    expect(result).not.toBeNull()
+    expect(result?.accessToken).toBe(creds.accessToken)
+    expect(result?.refreshToken).toBe(creds.refreshToken)
+    expect(result?.providerAccountId).toBe(creds.providerAccountId)
+    expect(result?.scopes).toEqual(creds.scopes)
+    expect(result?.expiresAt).toBe(creds.expiresAt)
+  })
+
+  it('UPSERTs on duplicate (org, provider, user) — second save wins', async () => {
+    const original = makeCredentials({ accessToken: 'first-access', refreshToken: 'first-refresh' })
+    const updated = makeCredentials({ accessToken: 'second-access', refreshToken: 'second-refresh' })
+    await store.saveCredentials('org-1', 'gmail', 'user-1', original)
+    await expect(store.saveCredentials('org-1', 'gmail', 'user-1', updated)).resolves.toBeUndefined()
+    const result = await store.getCredentials('org-1', 'gmail', 'user-1')
+    expect(result?.accessToken).toBe('second-access')
+    expect(result?.refreshToken).toBe('second-refresh')
+  })
+
+  it('delete removes the row', async () => {
+    await store.saveCredentials('org-1', 'gmail', 'user-1', makeCredentials())
+    await store.deleteCredentials('org-1', 'gmail', 'user-1')
+    expect(await store.getCredentials('org-1', 'gmail', 'user-1')).toBeNull()
+  })
+
+  it('isolates tenants — org A credentials are invisible to org B', async () => {
+    await store.saveCredentials('org-a', 'gmail', 'user-1', makeCredentials({ accessToken: 'a-token' }))
+    expect(await store.getCredentials('org-b', 'gmail', 'user-1')).toBeNull()
+    expect((await store.getCredentials('org-a', 'gmail', 'user-1'))?.accessToken).toBe('a-token')
+  })
+
+  it('handles credentials without optional fields', async () => {
+    const minimal: StoredCredentials = { accessToken: 'a', refreshToken: 'r' }
+    await store.saveCredentials('org-1', 'stripe', 'user-1', minimal)
+    const result = await store.getCredentials('org-1', 'stripe', 'user-1')
+    expect(result?.accessToken).toBe('a')
+    expect(result?.refreshToken).toBe('r')
+    expect(result?.scopes).toBeUndefined()
+    expect(result?.expiresAt).toBeUndefined()
+    expect(result?.providerAccountId).toBeUndefined()
   })
 })

--- a/packages/integrations/src/credentials.ts
+++ b/packages/integrations/src/credentials.ts
@@ -1,3 +1,8 @@
+import { randomUUID } from 'node:crypto'
+
+import { sql } from 'drizzle-orm'
+import type { StorageAdapter } from '@orbit-ai/core'
+
 import type { EncryptionProvider } from './encryption.js'
 
 export interface StoredCredentials {
@@ -37,30 +42,132 @@ export class InMemoryCredentialStore implements CredentialStore {
   }
 }
 
+interface IntegrationConnectionRow extends Record<string, unknown> {
+  credentials_encrypted: string | null
+  refresh_token_encrypted: string | null
+  access_token_expires_at: string | null
+  scopes: string | null
+  provider_account_id: string | null
+}
+
+interface DecryptedCredentialsPayload {
+  accessToken: string
+  providerAccountId?: string
+}
+
 /**
  * Production credential store backed by the integration_connections table.
- * Encrypts refreshToken and credentials before writing; decrypts on read.
- * Full implementation wired in Slice 7+ when the db adapter interface is available.
+ *
+ * Encrypts access-token payload (JSON) and refresh token via the supplied
+ * EncryptionProvider. The refresh token lives in its own column so rotations
+ * can be audited independently of the rest of the credential blob.
  */
 export class TableBackedCredentialStore implements CredentialStore {
   constructor(
-    private readonly db: unknown,   // core storage adapter — typed as unknown to avoid circular deps
+    private readonly db: StorageAdapter,
     private readonly encryption: EncryptionProvider,
   ) {}
 
-  async getCredentials(_orgId: string, _provider: string, _userId?: string): Promise<StoredCredentials | null> {
-    // Implementation: query integration_connections for org+provider+userId
-    // Return null if not found; decrypt on read
-    // Note: full implementation requires db query interface — this is a stub
-    // that will be wired up when the adapter is integrated in Slice 7+
-    throw new Error('TableBackedCredentialStore requires database integration — use InMemoryCredentialStore in tests')
+  async getCredentials(orgId: string, provider: string, userId?: string): Promise<StoredCredentials | null> {
+    try {
+      const rows = userId === undefined
+        ? await this.db.unsafeRawDatabase.query<IntegrationConnectionRow>(sql`
+            SELECT credentials_encrypted, refresh_token_encrypted, access_token_expires_at, scopes, provider_account_id
+            FROM integration_connections
+            WHERE organization_id = ${orgId} AND provider = ${provider} AND user_id IS NULL
+            LIMIT 1
+          `)
+        : await this.db.unsafeRawDatabase.query<IntegrationConnectionRow>(sql`
+            SELECT credentials_encrypted, refresh_token_encrypted, access_token_expires_at, scopes, provider_account_id
+            FROM integration_connections
+            WHERE organization_id = ${orgId} AND provider = ${provider} AND user_id = ${userId}
+            LIMIT 1
+          `)
+
+      const row = rows[0]
+      if (!row) return null
+      if (!row.credentials_encrypted || !row.refresh_token_encrypted) return null
+
+      const credsJson = await this.encryption.decrypt(row.credentials_encrypted)
+      const refreshToken = await this.encryption.decrypt(row.refresh_token_encrypted)
+      const payload = JSON.parse(credsJson) as DecryptedCredentialsPayload
+
+      const result: StoredCredentials = {
+        accessToken: payload.accessToken,
+        refreshToken,
+      }
+      if (payload.providerAccountId) result.providerAccountId = payload.providerAccountId
+      if (row.provider_account_id && !result.providerAccountId) {
+        result.providerAccountId = row.provider_account_id
+      }
+      if (row.scopes) {
+        result.scopes = row.scopes.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
+      }
+      if (row.access_token_expires_at) {
+        const ms = Date.parse(row.access_token_expires_at)
+        if (!Number.isNaN(ms)) result.expiresAt = ms
+      }
+      return result
+    } catch (err) {
+      console.error(`[TableBackedCredentialStore] getCredentials failed: ${err instanceof Error ? err.message : String(err)}`)
+      throw err
+    }
   }
 
-  async saveCredentials(_orgId: string, _provider: string, _userId: string, _credentials: StoredCredentials): Promise<void> {
-    throw new Error('TableBackedCredentialStore requires database integration — use InMemoryCredentialStore in tests')
+  async saveCredentials(orgId: string, provider: string, userId: string, credentials: StoredCredentials): Promise<void> {
+    try {
+      const payload: DecryptedCredentialsPayload = { accessToken: credentials.accessToken }
+      if (credentials.providerAccountId) payload.providerAccountId = credentials.providerAccountId
+
+      const credentialsEncrypted = await this.encryption.encrypt(JSON.stringify(payload))
+      const refreshEncrypted = await this.encryption.encrypt(credentials.refreshToken)
+      const expiresAt = credentials.expiresAt ? new Date(credentials.expiresAt).toISOString() : null
+      const scopesCsv = credentials.scopes && credentials.scopes.length > 0 ? credentials.scopes.join(',') : null
+      const providerAccountId = credentials.providerAccountId ?? null
+      const id = randomUUID()
+      const now = new Date().toISOString()
+
+      await this.db.unsafeRawDatabase.execute(sql`
+        INSERT INTO integration_connections (
+          id, organization_id, provider, connection_type, user_id, status,
+          credentials_encrypted, refresh_token_encrypted, access_token_expires_at,
+          provider_account_id, scopes, failure_count, created_at, updated_at
+        ) VALUES (
+          ${id}, ${orgId}, ${provider}, 'oauth2', ${userId}, 'active',
+          ${credentialsEncrypted}, ${refreshEncrypted}, ${expiresAt},
+          ${providerAccountId}, ${scopesCsv}, 0, ${now}, ${now}
+        )
+        ON CONFLICT(organization_id, provider, user_id) DO UPDATE SET
+          credentials_encrypted = excluded.credentials_encrypted,
+          refresh_token_encrypted = excluded.refresh_token_encrypted,
+          access_token_expires_at = excluded.access_token_expires_at,
+          provider_account_id = excluded.provider_account_id,
+          scopes = excluded.scopes,
+          status = 'active',
+          updated_at = excluded.updated_at
+      `)
+    } catch (err) {
+      console.error(`[TableBackedCredentialStore] saveCredentials failed: ${err instanceof Error ? err.message : String(err)}`)
+      throw err
+    }
   }
 
-  async deleteCredentials(_orgId: string, _provider: string, _userId?: string): Promise<void> {
-    throw new Error('TableBackedCredentialStore requires database integration — use InMemoryCredentialStore in tests')
+  async deleteCredentials(orgId: string, provider: string, userId?: string): Promise<void> {
+    try {
+      if (userId === undefined) {
+        await this.db.unsafeRawDatabase.execute(sql`
+          DELETE FROM integration_connections
+          WHERE organization_id = ${orgId} AND provider = ${provider} AND user_id IS NULL
+        `)
+      } else {
+        await this.db.unsafeRawDatabase.execute(sql`
+          DELETE FROM integration_connections
+          WHERE organization_id = ${orgId} AND provider = ${provider} AND user_id = ${userId}
+        `)
+      }
+    } catch (err) {
+      console.error(`[TableBackedCredentialStore] deleteCredentials failed: ${err instanceof Error ? err.message : String(err)}`)
+      throw err
+    }
   }
 }

--- a/packages/integrations/src/credentials.ts
+++ b/packages/integrations/src/credentials.ts
@@ -69,15 +69,15 @@ export class TableBackedCredentialStore implements CredentialStore {
   ) {}
 
   async getCredentials(orgId: string, provider: string, userId?: string): Promise<StoredCredentials | null> {
-    try {
+    return this.db.withTenantContext({ orgId, ...(userId === undefined ? {} : { userId }) }, async (db) => {
       const rows = userId === undefined
-        ? await this.db.unsafeRawDatabase.query<IntegrationConnectionRow>(sql`
+        ? await db.query<IntegrationConnectionRow>(sql`
             SELECT credentials_encrypted, refresh_token_encrypted, access_token_expires_at, scopes, provider_account_id
             FROM integration_connections
             WHERE organization_id = ${orgId} AND provider = ${provider} AND user_id IS NULL
             LIMIT 1
           `)
-        : await this.db.unsafeRawDatabase.query<IntegrationConnectionRow>(sql`
+        : await db.query<IntegrationConnectionRow>(sql`
             SELECT credentials_encrypted, refresh_token_encrypted, access_token_expires_at, scopes, provider_account_id
             FROM integration_connections
             WHERE organization_id = ${orgId} AND provider = ${provider} AND user_id = ${userId}
@@ -108,14 +108,11 @@ export class TableBackedCredentialStore implements CredentialStore {
         if (!Number.isNaN(ms)) result.expiresAt = ms
       }
       return result
-    } catch (err) {
-      console.error(`[TableBackedCredentialStore] getCredentials failed: ${err instanceof Error ? err.message : String(err)}`)
-      throw err
-    }
+    })
   }
 
   async saveCredentials(orgId: string, provider: string, userId: string, credentials: StoredCredentials): Promise<void> {
-    try {
+    await this.db.withTenantContext({ orgId, userId }, async (db) => {
       const payload: DecryptedCredentialsPayload = { accessToken: credentials.accessToken }
       if (credentials.providerAccountId) payload.providerAccountId = credentials.providerAccountId
 
@@ -127,7 +124,7 @@ export class TableBackedCredentialStore implements CredentialStore {
       const id = randomUUID()
       const now = new Date().toISOString()
 
-      await this.db.unsafeRawDatabase.execute(sql`
+      await db.execute(sql`
         INSERT INTO integration_connections (
           id, organization_id, provider, connection_type, user_id, status,
           credentials_encrypted, refresh_token_encrypted, access_token_expires_at,
@@ -146,28 +143,22 @@ export class TableBackedCredentialStore implements CredentialStore {
           status = 'active',
           updated_at = excluded.updated_at
       `)
-    } catch (err) {
-      console.error(`[TableBackedCredentialStore] saveCredentials failed: ${err instanceof Error ? err.message : String(err)}`)
-      throw err
-    }
+    })
   }
 
   async deleteCredentials(orgId: string, provider: string, userId?: string): Promise<void> {
-    try {
+    await this.db.withTenantContext({ orgId, ...(userId === undefined ? {} : { userId }) }, async (db) => {
       if (userId === undefined) {
-        await this.db.unsafeRawDatabase.execute(sql`
+        await db.execute(sql`
           DELETE FROM integration_connections
           WHERE organization_id = ${orgId} AND provider = ${provider} AND user_id IS NULL
         `)
       } else {
-        await this.db.unsafeRawDatabase.execute(sql`
+        await db.execute(sql`
           DELETE FROM integration_connections
           WHERE organization_id = ${orgId} AND provider = ${provider} AND user_id = ${userId}
         `)
       }
-    } catch (err) {
-      console.error(`[TableBackedCredentialStore] deleteCredentials failed: ${err instanceof Error ? err.message : String(err)}`)
-      throw err
-    }
+    })
   }
 }

--- a/packages/integrations/src/encryption.test.ts
+++ b/packages/integrations/src/encryption.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { AesGcmEncryptionProvider, NoopEncryptionProvider } from './encryption.js'
+import { AesGcmEncryptionProvider, NoopEncryptionProvider, OrbitEncryptionConfigError } from './encryption.js'
 
 const VALID_KEY = 'a'.repeat(64) // 64 hex chars = 32 bytes
 
@@ -32,16 +32,36 @@ describe('AesGcmEncryptionProvider', () => {
     expect(parts[2]).toHaveLength(32)
   })
 
-  it('throws on missing key (no arg, no env var)', () => {
+  it('throws OrbitEncryptionConfigError with MISSING_CREDENTIAL_KEY on missing key', () => {
     const originalEnv = process.env['ORBIT_CREDENTIAL_KEY']
     delete process.env['ORBIT_CREDENTIAL_KEY']
     try {
-      expect(() => new AesGcmEncryptionProvider()).toThrow('ORBIT_CREDENTIAL_KEY')
+      let thrown: unknown
+      try {
+        new AesGcmEncryptionProvider()
+      } catch (err) {
+        thrown = err
+      }
+      expect(thrown).toBeDefined()
+      expect((thrown as { name?: unknown }).name).toBe('OrbitEncryptionConfigError')
+      expect((thrown as OrbitEncryptionConfigError).code).toBe('MISSING_CREDENTIAL_KEY')
     } finally {
       if (originalEnv !== undefined) {
         process.env['ORBIT_CREDENTIAL_KEY'] = originalEnv
       }
     }
+  })
+
+  it('throws OrbitEncryptionConfigError with INVALID_CREDENTIAL_KEY on malformed key', () => {
+    let thrown: unknown
+    try {
+      new AesGcmEncryptionProvider('abc123')
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown).toBeDefined()
+    expect((thrown as { name?: unknown }).name).toBe('OrbitEncryptionConfigError')
+    expect((thrown as OrbitEncryptionConfigError).code).toBe('INVALID_CREDENTIAL_KEY')
   })
 
   it('throws on key that is too short', () => {

--- a/packages/integrations/src/encryption.ts
+++ b/packages/integrations/src/encryption.ts
@@ -5,6 +5,16 @@ export interface EncryptionProvider {
   decrypt(ciphertext: string): Promise<string>
 }
 
+export class OrbitEncryptionConfigError extends Error {
+  readonly code: 'MISSING_CREDENTIAL_KEY' | 'INVALID_CREDENTIAL_KEY'
+
+  constructor(code: 'MISSING_CREDENTIAL_KEY' | 'INVALID_CREDENTIAL_KEY', message: string) {
+    super(message)
+    this.name = 'OrbitEncryptionConfigError'
+    this.code = code
+  }
+}
+
 /**
  * AES-256-GCM encryption provider.
  * Key must be a 64-character hex string (32 bytes = 256 bits).
@@ -15,8 +25,16 @@ export class AesGcmEncryptionProvider implements EncryptionProvider {
 
   constructor(keyHex?: string) {
     const k = keyHex ?? process.env['ORBIT_CREDENTIAL_KEY']
-    if (!k || !/^[0-9a-fA-F]{64}$/.test(k)) {
-      throw new Error(
+    if (!k) {
+      throw new OrbitEncryptionConfigError(
+        'MISSING_CREDENTIAL_KEY',
+        'ORBIT_CREDENTIAL_KEY is not set. ' +
+        'Generate with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"',
+      )
+    }
+    if (!/^[0-9a-fA-F]{64}$/.test(k)) {
+      throw new OrbitEncryptionConfigError(
+        'INVALID_CREDENTIAL_KEY',
         'ORBIT_CREDENTIAL_KEY must be a 64-character hex string (32 bytes). ' +
         'Generate with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"',
       )

--- a/packages/integrations/src/gmail/cli.test.ts
+++ b/packages/integrations/src/gmail/cli.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { buildGmailCommands, type GmailConfigureArgs } from './cli.js'
+import { InMemoryCredentialStore } from '../credentials.js'
+import type { CliRuntimeContext } from '../types.js'
+
+describe('gmail CLI commands', () => {
+  let store: InMemoryCredentialStore
+  let runtime: CliRuntimeContext
+  let printed: unknown[]
+
+  beforeEach(() => {
+    store = new InMemoryCredentialStore()
+    printed = []
+    runtime = {
+      organizationId: 'org_01TEST',
+      userId: 'user_01TEST',
+      credentialStore: store,
+      isJsonMode: true,
+      print: (v) => { printed.push(v) },
+    }
+  })
+
+  it('configure persists OAuth2 tokens and prints configured=true with --skip-validation', async () => {
+    const cmds = buildGmailCommands(runtime)
+    const configure = cmds.find((c) => c.name === 'gmail/configure')!
+    await configure.action({
+      accessToken: 'a',
+      refreshToken: 'r',
+      skipValidation: true,
+    } satisfies GmailConfigureArgs)
+    expect(printed[0]).toMatchObject({ configured: true, provider: 'gmail' })
+    expect(await store.getCredentials('org_01TEST', 'gmail', 'user_01TEST')).toBeTruthy()
+  })
+
+  it('configure without --skip-validation refuses (alpha scope)', async () => {
+    const cmds = buildGmailCommands(runtime)
+    const configure = cmds.find((c) => c.name === 'gmail/configure')!
+    await configure.action({ accessToken: 'a', refreshToken: 'r' })
+    expect(printed[0]).toMatchObject({ configured: false, provider: 'gmail' })
+    expect(await store.getCredentials('org_01TEST', 'gmail', 'user_01TEST')).toBeNull()
+  })
+
+  it('status reports configured=false when no credentials saved', async () => {
+    const cmds = buildGmailCommands(runtime)
+    const status = cmds.find((c) => c.name === 'gmail/status')!
+    await status.action({})
+    expect(printed[0]).toMatchObject({ configured: false, status: 'not_configured', provider: 'gmail' })
+  })
+
+  it('configure does not print raw secrets to stdout', async () => {
+    const cmds = buildGmailCommands(runtime)
+    const configure = cmds.find((c) => c.name === 'gmail/configure')!
+    await configure.action({
+      accessToken: 'SECRET_ACCESS_VALUE',
+      refreshToken: 'SECRET_REFRESH_VALUE',
+      skipValidation: true,
+    })
+    const out = JSON.stringify(printed)
+    expect(out).not.toContain('SECRET_ACCESS_VALUE')
+    expect(out).not.toContain('SECRET_REFRESH_VALUE')
+  })
+})

--- a/packages/integrations/src/gmail/cli.test.ts
+++ b/packages/integrations/src/gmail/cli.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import { buildGmailCommands, type GmailConfigureArgs } from './cli.js'
 import { InMemoryCredentialStore } from '../credentials.js'
 import type { CliRuntimeContext } from '../types.js'
@@ -58,5 +61,30 @@ describe('gmail CLI commands', () => {
     const out = JSON.stringify(printed)
     expect(out).not.toContain('SECRET_ACCESS_VALUE')
     expect(out).not.toContain('SECRET_REFRESH_VALUE')
+  })
+
+  it('configure accepts OAuth2 tokens from files instead of argv token values', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-gmail-token-files-'))
+    try {
+      const accessTokenFile = path.join(tmpDir, 'access-token')
+      const refreshTokenFile = path.join(tmpDir, 'refresh-token')
+      fs.writeFileSync(accessTokenFile, 'file-access\n', { mode: 0o600 })
+      fs.writeFileSync(refreshTokenFile, 'file-refresh\n', { mode: 0o600 })
+      const cmds = buildGmailCommands(runtime)
+      const configure = cmds.find((c) => c.name === 'gmail/configure')!
+      await configure.action({
+        accessTokenFile,
+        refreshTokenFile,
+        skipValidation: true,
+      } satisfies GmailConfigureArgs)
+
+      const saved = await store.getCredentials('org_01TEST', 'gmail', 'user_01TEST')
+      expect(saved?.accessToken).toBe('file-access')
+      expect(saved?.refreshToken).toBe('file-refresh')
+      expect(JSON.stringify(printed)).not.toContain('file-access')
+      expect(JSON.stringify(printed)).not.toContain('file-refresh')
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/integrations/src/gmail/cli.ts
+++ b/packages/integrations/src/gmail/cli.ts
@@ -1,11 +1,47 @@
-import type { CliRuntimeContext, IntegrationCommand } from '../types.js'
+import type { IntegrationCommand, CliRuntimeContext } from '../types.js'
+import { runConfigureAction, runStatusAction } from '../shared/cli-helpers.js'
 
 export interface GmailConfigureArgs {
-  accessToken: string
-  refreshToken: string
-  skipValidation?: boolean
+  readonly accessToken: string
+  readonly refreshToken: string
+  readonly skipValidation?: boolean
 }
 
-export function buildGmailCommands(_runtime: CliRuntimeContext): IntegrationCommand[] {
-  return []
+export function buildGmailCommands(runtime: CliRuntimeContext): IntegrationCommand[] {
+  return [
+    {
+      name: 'gmail/configure',
+      description: 'Configure the Gmail connector with OAuth2 tokens',
+      options: [
+        { flags: '--access-token <token>',  description: 'OAuth2 access token (short-lived)' },
+        { flags: '--refresh-token <token>', description: 'OAuth2 refresh token' },
+        { flags: '--skip-validation',       description: 'Skip live validation — required in alpha', defaultValue: false },
+      ],
+      async action(...actionArgs: unknown[]) {
+        const args = (actionArgs[0] ?? {}) as GmailConfigureArgs
+        const result = await runConfigureAction({
+          provider: 'gmail',
+          organizationId: runtime.organizationId,
+          userId: runtime.userId,
+          credentials: { accessToken: args.accessToken, refreshToken: args.refreshToken },
+          credentialStore: runtime.credentialStore,
+          skipValidation: Boolean(args.skipValidation),
+        })
+        runtime.print(result)
+      },
+    },
+    {
+      name: 'gmail/status',
+      description: 'Show the Gmail connector configuration status',
+      async action() {
+        const result = await runStatusAction({
+          provider: 'gmail',
+          organizationId: runtime.organizationId,
+          userId: runtime.userId,
+          credentialStore: runtime.credentialStore,
+        })
+        runtime.print(result)
+      },
+    },
+  ]
 }

--- a/packages/integrations/src/gmail/cli.ts
+++ b/packages/integrations/src/gmail/cli.ts
@@ -1,11 +1,23 @@
 import type { IntegrationCommand, CliRuntimeContext } from '../types.js'
-import { runConfigureAction, runStatusAction } from '../shared/cli-helpers.js'
+import {
+  resolveOAuthCredentialsFromArgs,
+  runConfigureAction,
+  runStatusAction,
+} from '../shared/cli-helpers.js'
 
 export interface GmailConfigureArgs {
-  readonly accessToken: string
-  readonly refreshToken: string
+  readonly accessToken?: string
+  readonly refreshToken?: string
+  readonly accessTokenEnv?: string
+  readonly refreshTokenEnv?: string
+  readonly accessTokenFile?: string
+  readonly refreshTokenFile?: string
+  readonly tokensStdin?: boolean
   readonly skipValidation?: boolean
 }
+
+const GMAIL_ACCESS_TOKEN_ENV = 'ORBIT_GMAIL_ACCESS_TOKEN'
+const GMAIL_REFRESH_TOKEN_ENV = 'ORBIT_GMAIL_REFRESH_TOKEN'
 
 export function buildGmailCommands(runtime: CliRuntimeContext): IntegrationCommand[] {
   return [
@@ -13,17 +25,32 @@ export function buildGmailCommands(runtime: CliRuntimeContext): IntegrationComma
       name: 'gmail/configure',
       description: 'Configure the Gmail connector with OAuth2 tokens',
       options: [
-        { flags: '--access-token <token>',  description: 'OAuth2 access token (short-lived)' },
-        { flags: '--refresh-token <token>', description: 'OAuth2 refresh token' },
+        { flags: '--access-token <token>',  description: `OAuth2 access token (prefer ${GMAIL_ACCESS_TOKEN_ENV})` },
+        { flags: '--refresh-token <token>', description: `OAuth2 refresh token (prefer ${GMAIL_REFRESH_TOKEN_ENV})` },
+        { flags: '--access-token-env <name>', description: 'Environment variable containing the OAuth2 access token' },
+        { flags: '--refresh-token-env <name>', description: 'Environment variable containing the OAuth2 refresh token' },
+        { flags: '--access-token-file <path>', description: 'File containing the OAuth2 access token' },
+        { flags: '--refresh-token-file <path>', description: 'File containing the OAuth2 refresh token' },
+        { flags: '--tokens-stdin', description: 'Read OAuth2 tokens as JSON from stdin', defaultValue: false },
         { flags: '--skip-validation',       description: 'Skip live validation — required in alpha', defaultValue: false },
       ],
       async action(...actionArgs: unknown[]) {
         const args = (actionArgs[0] ?? {}) as GmailConfigureArgs
+        const credentials = await resolveOAuthCredentialsFromArgs(args, {
+          provider: 'gmail',
+          defaultAccessTokenEnv: GMAIL_ACCESS_TOKEN_ENV,
+          defaultRefreshTokenEnv: GMAIL_REFRESH_TOKEN_ENV,
+          warn: (message) => process.stderr.write(`${message}\n`),
+        })
+        if ('error' in credentials) {
+          runtime.print({ configured: false, provider: 'gmail', error: credentials.error })
+          return
+        }
         const result = await runConfigureAction({
           provider: 'gmail',
           organizationId: runtime.organizationId,
           userId: runtime.userId,
-          credentials: { accessToken: args.accessToken, refreshToken: args.refreshToken },
+          credentials,
           credentialStore: runtime.credentialStore,
           skipValidation: Boolean(args.skipValidation),
         })

--- a/packages/integrations/src/gmail/cli.ts
+++ b/packages/integrations/src/gmail/cli.ts
@@ -1,0 +1,11 @@
+import type { CliRuntimeContext, IntegrationCommand } from '../types.js'
+
+export interface GmailConfigureArgs {
+  accessToken: string
+  refreshToken: string
+  skipValidation?: boolean
+}
+
+export function buildGmailCommands(_runtime: CliRuntimeContext): IntegrationCommand[] {
+  return []
+}

--- a/packages/integrations/src/gmail/index.ts
+++ b/packages/integrations/src/gmail/index.ts
@@ -1,0 +1,3 @@
+export { gmailPlugin, GMAIL_SLUG } from './connector.js'
+export { buildGmailCommands } from './cli.js'
+export type { GmailConfigureArgs } from './cli.js'

--- a/packages/integrations/src/google-calendar/cli.test.ts
+++ b/packages/integrations/src/google-calendar/cli.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { buildCalendarCommands, type CalendarConfigureArgs } from './cli.js'
+import { InMemoryCredentialStore } from '../credentials.js'
+import type { CliRuntimeContext } from '../types.js'
+
+describe('google-calendar CLI commands', () => {
+  let store: InMemoryCredentialStore
+  let runtime: CliRuntimeContext
+  let printed: unknown[]
+
+  beforeEach(() => {
+    store = new InMemoryCredentialStore()
+    printed = []
+    runtime = {
+      organizationId: 'org_01TEST',
+      userId: 'user_01TEST',
+      credentialStore: store,
+      isJsonMode: true,
+      print: (v) => { printed.push(v) },
+    }
+  })
+
+  it('configure persists OAuth2 tokens and prints configured=true with --skip-validation', async () => {
+    const cmds = buildCalendarCommands(runtime)
+    const configure = cmds.find((c) => c.name === 'google-calendar/configure')!
+    await configure.action({
+      accessToken: 'a',
+      refreshToken: 'r',
+      skipValidation: true,
+    } satisfies CalendarConfigureArgs)
+    expect(printed[0]).toMatchObject({ configured: true, provider: 'google-calendar' })
+    expect(await store.getCredentials('org_01TEST', 'google-calendar', 'user_01TEST')).toBeTruthy()
+  })
+
+  it('configure without --skip-validation refuses (alpha scope)', async () => {
+    const cmds = buildCalendarCommands(runtime)
+    const configure = cmds.find((c) => c.name === 'google-calendar/configure')!
+    await configure.action({ accessToken: 'a', refreshToken: 'r' })
+    expect(printed[0]).toMatchObject({ configured: false, provider: 'google-calendar' })
+    expect(await store.getCredentials('org_01TEST', 'google-calendar', 'user_01TEST')).toBeNull()
+  })
+
+  it('status reports configured=false when no credentials saved', async () => {
+    const cmds = buildCalendarCommands(runtime)
+    const status = cmds.find((c) => c.name === 'google-calendar/status')!
+    await status.action({})
+    expect(printed[0]).toMatchObject({ configured: false, status: 'not_configured', provider: 'google-calendar' })
+  })
+
+  it('configure does not print raw secrets to stdout', async () => {
+    const cmds = buildCalendarCommands(runtime)
+    const configure = cmds.find((c) => c.name === 'google-calendar/configure')!
+    await configure.action({
+      accessToken: 'SECRET_ACCESS_VALUE',
+      refreshToken: 'SECRET_REFRESH_VALUE',
+      skipValidation: true,
+    })
+    const out = JSON.stringify(printed)
+    expect(out).not.toContain('SECRET_ACCESS_VALUE')
+    expect(out).not.toContain('SECRET_REFRESH_VALUE')
+  })
+})

--- a/packages/integrations/src/google-calendar/cli.test.ts
+++ b/packages/integrations/src/google-calendar/cli.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import { buildCalendarCommands, type CalendarConfigureArgs } from './cli.js'
 import { InMemoryCredentialStore } from '../credentials.js'
 import type { CliRuntimeContext } from '../types.js'
@@ -58,5 +61,30 @@ describe('google-calendar CLI commands', () => {
     const out = JSON.stringify(printed)
     expect(out).not.toContain('SECRET_ACCESS_VALUE')
     expect(out).not.toContain('SECRET_REFRESH_VALUE')
+  })
+
+  it('configure accepts OAuth2 tokens from files instead of argv token values', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-calendar-token-files-'))
+    try {
+      const accessTokenFile = path.join(tmpDir, 'access-token')
+      const refreshTokenFile = path.join(tmpDir, 'refresh-token')
+      fs.writeFileSync(accessTokenFile, 'file-access\n', { mode: 0o600 })
+      fs.writeFileSync(refreshTokenFile, 'file-refresh\n', { mode: 0o600 })
+      const cmds = buildCalendarCommands(runtime)
+      const configure = cmds.find((c) => c.name === 'google-calendar/configure')!
+      await configure.action({
+        accessTokenFile,
+        refreshTokenFile,
+        skipValidation: true,
+      } satisfies CalendarConfigureArgs)
+
+      const saved = await store.getCredentials('org_01TEST', 'google-calendar', 'user_01TEST')
+      expect(saved?.accessToken).toBe('file-access')
+      expect(saved?.refreshToken).toBe('file-refresh')
+      expect(JSON.stringify(printed)).not.toContain('file-access')
+      expect(JSON.stringify(printed)).not.toContain('file-refresh')
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/integrations/src/google-calendar/cli.ts
+++ b/packages/integrations/src/google-calendar/cli.ts
@@ -1,0 +1,5 @@
+import type { CliRuntimeContext, IntegrationCommand } from '../types.js'
+
+export function buildCalendarCommands(_runtime: CliRuntimeContext): IntegrationCommand[] {
+  return []
+}

--- a/packages/integrations/src/google-calendar/cli.ts
+++ b/packages/integrations/src/google-calendar/cli.ts
@@ -1,5 +1,47 @@
-import type { CliRuntimeContext, IntegrationCommand } from '../types.js'
+import type { IntegrationCommand, CliRuntimeContext } from '../types.js'
+import { runConfigureAction, runStatusAction } from '../shared/cli-helpers.js'
 
-export function buildCalendarCommands(_runtime: CliRuntimeContext): IntegrationCommand[] {
-  return []
+export interface CalendarConfigureArgs {
+  readonly accessToken: string
+  readonly refreshToken: string
+  readonly skipValidation?: boolean
+}
+
+export function buildCalendarCommands(runtime: CliRuntimeContext): IntegrationCommand[] {
+  return [
+    {
+      name: 'google-calendar/configure',
+      description: 'Configure the Google Calendar connector with OAuth2 tokens',
+      options: [
+        { flags: '--access-token <token>',  description: 'OAuth2 access token' },
+        { flags: '--refresh-token <token>', description: 'OAuth2 refresh token' },
+        { flags: '--skip-validation',       description: 'Skip live validation — required in alpha', defaultValue: false },
+      ],
+      async action(...actionArgs: unknown[]) {
+        const args = (actionArgs[0] ?? {}) as CalendarConfigureArgs
+        const result = await runConfigureAction({
+          provider: 'google-calendar',
+          organizationId: runtime.organizationId,
+          userId: runtime.userId,
+          credentials: { accessToken: args.accessToken, refreshToken: args.refreshToken },
+          credentialStore: runtime.credentialStore,
+          skipValidation: Boolean(args.skipValidation),
+        })
+        runtime.print(result)
+      },
+    },
+    {
+      name: 'google-calendar/status',
+      description: 'Show the Google Calendar connector configuration status',
+      async action() {
+        const result = await runStatusAction({
+          provider: 'google-calendar',
+          organizationId: runtime.organizationId,
+          userId: runtime.userId,
+          credentialStore: runtime.credentialStore,
+        })
+        runtime.print(result)
+      },
+    },
+  ]
 }

--- a/packages/integrations/src/google-calendar/cli.ts
+++ b/packages/integrations/src/google-calendar/cli.ts
@@ -1,11 +1,23 @@
 import type { IntegrationCommand, CliRuntimeContext } from '../types.js'
-import { runConfigureAction, runStatusAction } from '../shared/cli-helpers.js'
+import {
+  resolveOAuthCredentialsFromArgs,
+  runConfigureAction,
+  runStatusAction,
+} from '../shared/cli-helpers.js'
 
 export interface CalendarConfigureArgs {
-  readonly accessToken: string
-  readonly refreshToken: string
+  readonly accessToken?: string
+  readonly refreshToken?: string
+  readonly accessTokenEnv?: string
+  readonly refreshTokenEnv?: string
+  readonly accessTokenFile?: string
+  readonly refreshTokenFile?: string
+  readonly tokensStdin?: boolean
   readonly skipValidation?: boolean
 }
+
+const CALENDAR_ACCESS_TOKEN_ENV = 'ORBIT_GOOGLE_CALENDAR_ACCESS_TOKEN'
+const CALENDAR_REFRESH_TOKEN_ENV = 'ORBIT_GOOGLE_CALENDAR_REFRESH_TOKEN'
 
 export function buildCalendarCommands(runtime: CliRuntimeContext): IntegrationCommand[] {
   return [
@@ -13,17 +25,32 @@ export function buildCalendarCommands(runtime: CliRuntimeContext): IntegrationCo
       name: 'google-calendar/configure',
       description: 'Configure the Google Calendar connector with OAuth2 tokens',
       options: [
-        { flags: '--access-token <token>',  description: 'OAuth2 access token' },
-        { flags: '--refresh-token <token>', description: 'OAuth2 refresh token' },
+        { flags: '--access-token <token>',  description: `OAuth2 access token (prefer ${CALENDAR_ACCESS_TOKEN_ENV})` },
+        { flags: '--refresh-token <token>', description: `OAuth2 refresh token (prefer ${CALENDAR_REFRESH_TOKEN_ENV})` },
+        { flags: '--access-token-env <name>', description: 'Environment variable containing the OAuth2 access token' },
+        { flags: '--refresh-token-env <name>', description: 'Environment variable containing the OAuth2 refresh token' },
+        { flags: '--access-token-file <path>', description: 'File containing the OAuth2 access token' },
+        { flags: '--refresh-token-file <path>', description: 'File containing the OAuth2 refresh token' },
+        { flags: '--tokens-stdin', description: 'Read OAuth2 tokens as JSON from stdin', defaultValue: false },
         { flags: '--skip-validation',       description: 'Skip live validation — required in alpha', defaultValue: false },
       ],
       async action(...actionArgs: unknown[]) {
         const args = (actionArgs[0] ?? {}) as CalendarConfigureArgs
+        const credentials = await resolveOAuthCredentialsFromArgs(args, {
+          provider: 'google-calendar',
+          defaultAccessTokenEnv: CALENDAR_ACCESS_TOKEN_ENV,
+          defaultRefreshTokenEnv: CALENDAR_REFRESH_TOKEN_ENV,
+          warn: (message) => process.stderr.write(`${message}\n`),
+        })
+        if ('error' in credentials) {
+          runtime.print({ configured: false, provider: 'google-calendar', error: credentials.error })
+          return
+        }
         const result = await runConfigureAction({
           provider: 'google-calendar',
           organizationId: runtime.organizationId,
           userId: runtime.userId,
-          credentials: { accessToken: args.accessToken, refreshToken: args.refreshToken },
+          credentials,
           credentialStore: runtime.credentialStore,
           skipValidation: Boolean(args.skipValidation),
         })

--- a/packages/integrations/src/google-calendar/index.ts
+++ b/packages/integrations/src/google-calendar/index.ts
@@ -1,0 +1,2 @@
+export { calendarPlugin, CALENDAR_SLUG } from './connector.js'
+export { buildCalendarCommands } from './cli.js'

--- a/packages/integrations/src/google-calendar/mcp-tools.test.ts
+++ b/packages/integrations/src/google-calendar/mcp-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildCalendarTools, buildCalendarCommands, type CalendarToolContext } from './mcp-tools.js'
+import { buildCalendarTools, buildCalendarMcpTools, type CalendarToolContext } from './mcp-tools.js'
 import type { CalendarConnectorConfig } from './types.js'
 import type { CredentialStore } from '../credentials.js'
 
@@ -123,20 +123,20 @@ describe('buildCalendarTools', () => {
   })
 })
 
-describe('buildCalendarCommands', () => {
+describe('buildCalendarMcpTools', () => {
   it('returns 3 commands', () => {
-    const commands = buildCalendarCommands(makeContext())
+    const commands = buildCalendarMcpTools(makeContext())
     expect(commands).toHaveLength(3)
   })
 
   it('command names are list, create, sync', () => {
-    const commands = buildCalendarCommands(makeContext())
+    const commands = buildCalendarMcpTools(makeContext())
     const names = commands.map((c) => c.name)
     expect(names).toEqual(['list', 'create', 'sync'])
   })
 
   it('list command has correct options', () => {
-    const commands = buildCalendarCommands(makeContext())
+    const commands = buildCalendarMcpTools(makeContext())
     const listCmd = commands.find((c) => c.name === 'list')!
     expect(listCmd.options).toBeDefined()
     expect(listCmd.options!.length).toBe(3)
@@ -148,14 +148,14 @@ describe('buildCalendarCommands', () => {
   })
 
   it('create command has correct options', () => {
-    const commands = buildCalendarCommands(makeContext())
+    const commands = buildCalendarMcpTools(makeContext())
     const createCmd = commands.find((c) => c.name === 'create')!
     expect(createCmd.options).toBeDefined()
     expect(createCmd.options!.length).toBe(3)
   })
 
   it('sync command has correct options', () => {
-    const commands = buildCalendarCommands(makeContext())
+    const commands = buildCalendarMcpTools(makeContext())
     const syncCmd = commands.find((c) => c.name === 'sync')!
     expect(syncCmd.options).toBeDefined()
     expect(syncCmd.options!.length).toBe(1)

--- a/packages/integrations/src/google-calendar/mcp-tools.ts
+++ b/packages/integrations/src/google-calendar/mcp-tools.ts
@@ -79,10 +79,10 @@ export function buildCalendarTools(context: CalendarToolContext): IntegrationToo
 }
 
 /**
- * Build CLI commands for Calendar.
- * These register under 'orbit integrations google-calendar' and alias as 'orbit calendar'.
+ * Build MCP-tool-style command builders for Calendar (list/create/sync).
+ * Distinct from the CLI factory in `./cli.ts` which builds configure/status.
  */
-export function buildCalendarCommands(context: CalendarToolContext): IntegrationCommand[] {
+export function buildCalendarMcpTools(context: CalendarToolContext): IntegrationCommand[] {
   return [
     {
       name: 'list',

--- a/packages/integrations/src/shared/cli-helpers.test.ts
+++ b/packages/integrations/src/shared/cli-helpers.test.ts
@@ -22,7 +22,7 @@ describe('runConfigureAction', () => {
     expect(await store.getCredentials('org_01TEST', 'gmail', 'user_01TEST')).toBeTruthy()
   })
 
-  it('rejects live validation requests during alpha (skipValidation=false throws NOT_SUPPORTED)', async () => {
+  it('returns configured=false with NOT_SUPPORTED error when skipValidation=false', async () => {
     const store = new InMemoryCredentialStore()
     const result = await runConfigureAction({
       provider: 'gmail',

--- a/packages/integrations/src/shared/cli-helpers.test.ts
+++ b/packages/integrations/src/shared/cli-helpers.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runConfigureAction, runStatusAction, sanitizeErrorMessage } from './cli-helpers.js'
+import { InMemoryCredentialStore } from '../credentials.js'
+
+describe('runConfigureAction', () => {
+  it('persists credentials and reports configured=true when skipValidation=true', async () => {
+    const store = new InMemoryCredentialStore()
+    const result = await runConfigureAction({
+      provider: 'gmail',
+      organizationId: 'org_01TEST',
+      userId: 'user_01TEST',
+      credentials: { accessToken: 'a', refreshToken: 'r' },
+      credentialStore: store,
+      skipValidation: true,
+    })
+    expect(result.configured).toBe(true)
+    expect(await store.getCredentials('org_01TEST', 'gmail', 'user_01TEST')).toBeTruthy()
+  })
+
+  it('rejects live validation requests during alpha (skipValidation=false throws NOT_SUPPORTED)', async () => {
+    const store = new InMemoryCredentialStore()
+    const result = await runConfigureAction({
+      provider: 'gmail',
+      organizationId: 'org_01TEST',
+      userId: 'user_01TEST',
+      credentials: { accessToken: 'a', refreshToken: 'r' },
+      credentialStore: store,
+      skipValidation: false,
+    })
+    expect(result.configured).toBe(false)
+    expect(result.error).toMatch(/live validation.*not.*supported/i)
+    expect(await store.getCredentials('org_01TEST', 'gmail', 'user_01TEST')).toBeNull()
+  })
+})
+
+describe('runStatusAction', () => {
+  it('returns configured=true when credentials exist for the provider', async () => {
+    const store = new InMemoryCredentialStore()
+    await store.saveCredentials('org_01TEST', 'gmail', 'user_01TEST', { accessToken: 'a', refreshToken: 'r' })
+    const result = await runStatusAction({
+      provider: 'gmail',
+      organizationId: 'org_01TEST',
+      userId: 'user_01TEST',
+      credentialStore: store,
+    })
+    expect(result).toMatchObject({ provider: 'gmail', configured: true, status: 'configured' })
+  })
+
+  it('returns configured=false when credentials do not exist', async () => {
+    const store = new InMemoryCredentialStore()
+    const result = await runStatusAction({
+      provider: 'gmail',
+      organizationId: 'org_01TEST',
+      userId: 'user_01TEST',
+      credentialStore: store,
+    })
+    expect(result.configured).toBe(false)
+  })
+})
+
+describe('sanitizeErrorMessage', () => {
+  it('masks tokens, keys, and bearer headers in error text', () => {
+    const msg = 'Unauthorized: token=sk_live_abc123 Bearer ya29.a0AfH6SMC_XYZ refresh_token=1//abcdefgh'
+    const sanitized = sanitizeErrorMessage(msg)
+    expect(sanitized).not.toContain('sk_live_abc123')
+    expect(sanitized).not.toContain('ya29.a0AfH6SMC_XYZ')
+    expect(sanitized).not.toContain('1//abcdefgh')
+    expect(sanitized).toMatch(/\*\*\*/)
+  })
+  it('preserves non-secret error structure', () => {
+    expect(sanitizeErrorMessage('Network error: ECONNREFUSED')).toBe('Network error: ECONNREFUSED')
+  })
+})

--- a/packages/integrations/src/shared/cli-helpers.test.ts
+++ b/packages/integrations/src/shared/cli-helpers.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
-import { runConfigureAction, runStatusAction, sanitizeErrorMessage } from './cli-helpers.js'
+import {
+  resolveOAuthCredentials,
+  runConfigureAction,
+  runStatusAction,
+  sanitizeErrorMessage,
+} from './cli-helpers.js'
 import { InMemoryCredentialStore } from '../credentials.js'
 
 describe('runConfigureAction', () => {
@@ -69,5 +74,80 @@ describe('sanitizeErrorMessage', () => {
   })
   it('preserves non-secret error structure', () => {
     expect(sanitizeErrorMessage('Network error: ECONNREFUSED')).toBe('Network error: ECONNREFUSED')
+  })
+
+  it('masks JSON, camelCase, and snake_case secret fields in error text', () => {
+    const msg = [
+      'request failed',
+      '{"accessToken":"ya29.camel","refresh_token":"1//snake","clientSecret":"topsecret"}',
+      'apiKey: sk_live_abcdefghijkl',
+      'refreshToken = 1//camelrefresh',
+    ].join(' ')
+    const sanitized = sanitizeErrorMessage(msg)
+    expect(sanitized).not.toContain('ya29.camel')
+    expect(sanitized).not.toContain('1//snake')
+    expect(sanitized).not.toContain('topsecret')
+    expect(sanitized).not.toContain('sk_live_abcdefghijkl')
+    expect(sanitized).not.toContain('1//camelrefresh')
+    expect(sanitized).toContain('"accessToken":"***"')
+    expect(sanitized).toContain('"refresh_token":"***"')
+  })
+})
+
+describe('resolveOAuthCredentials', () => {
+  it('resolves OAuth tokens from environment variables without argv values', async () => {
+    const credentials = await resolveOAuthCredentials(
+      {
+        accessTokenEnv: 'TEST_ACCESS_TOKEN',
+        refreshTokenEnv: 'TEST_REFRESH_TOKEN',
+      },
+      {
+        env: {
+          TEST_ACCESS_TOKEN: 'env-access',
+          TEST_REFRESH_TOKEN: 'env-refresh',
+        },
+      },
+    )
+    expect(credentials).toEqual({ accessToken: 'env-access', refreshToken: 'env-refresh' })
+  })
+
+  it('warns and redacts process argv when OAuth tokens are supplied as argv flags', async () => {
+    const stderr: string[] = []
+    const argv = [
+      'node',
+      'orbit',
+      '--access-token',
+      'argv-access',
+      '--refresh-token=argv-refresh',
+    ]
+    const credentials = await resolveOAuthCredentials(
+      { accessToken: 'argv-access', refreshToken: 'argv-refresh' },
+      {
+        argv,
+        warn: (msg) => stderr.push(msg),
+      },
+    )
+    expect(credentials).toEqual({ accessToken: 'argv-access', refreshToken: 'argv-refresh' })
+    expect(stderr.join('\n')).toMatch(/visible in process listings/i)
+    expect(argv).not.toContain('argv-access')
+    expect(argv).not.toContain('--refresh-token=argv-refresh')
+    expect(argv).toContain('[REDACTED]')
+    expect(argv).toContain('--refresh-token=[REDACTED]')
+  })
+
+  it('lets explicit argv token values override ambient default provider env vars', async () => {
+    const credentials = await resolveOAuthCredentials(
+      { accessToken: 'argv-access', refreshToken: 'argv-refresh' },
+      {
+        defaultAccessTokenEnv: 'ORBIT_GMAIL_ACCESS_TOKEN',
+        defaultRefreshTokenEnv: 'ORBIT_GMAIL_REFRESH_TOKEN',
+        env: {
+          ORBIT_GMAIL_ACCESS_TOKEN: 'stale-env-access',
+          ORBIT_GMAIL_REFRESH_TOKEN: 'stale-env-refresh',
+        },
+        argv: ['node', 'orbit'],
+      },
+    )
+    expect(credentials).toEqual({ accessToken: 'argv-access', refreshToken: 'argv-refresh' })
   })
 })

--- a/packages/integrations/src/shared/cli-helpers.ts
+++ b/packages/integrations/src/shared/cli-helpers.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs'
 import type { CredentialStore, StoredCredentials } from '../credentials.js'
 
 export interface ConfigureInput {
@@ -26,7 +27,142 @@ export function sanitizeErrorMessage(msg: string): string {
     .replace(/\b(sk|rk|pk|whsec)_[A-Za-z0-9_]{10,}/g, '***')
     .replace(/\b1\/\/[A-Za-z0-9_-]+/g, '***')
     .replace(/\b(token|key|secret|password)=([^\s&"',;]+)/gi, '$1=***')
+    .replace(
+      /\b(accessToken|refreshToken|access_token|refresh_token|apiKey|api_key|clientSecret|client_secret|token|key|secret|password)\s*[:=]\s*([^\s,}"']+)/gi,
+      '$1=***',
+    )
+    .replace(
+      /(["'])(accessToken|refreshToken|access_token|refresh_token|apiKey|api_key|clientSecret|client_secret|token|key|secret|password)\1\s*:\s*(["'])(.*?)\3/gi,
+      '$1$2$1:$3***$3',
+    )
     .replace(/\bBearer\s+[A-Za-z0-9._-]+/gi, 'Bearer ***')
+}
+
+export interface OAuthCredentialArgs {
+  readonly accessToken?: string
+  readonly refreshToken?: string
+  readonly accessTokenEnv?: string
+  readonly refreshTokenEnv?: string
+  readonly accessTokenFile?: string
+  readonly refreshTokenFile?: string
+  readonly tokensStdin?: boolean
+}
+
+export interface ResolveOAuthCredentialInputOptions {
+  readonly provider?: string
+  readonly defaultAccessTokenEnv?: string
+  readonly defaultRefreshTokenEnv?: string
+  readonly env?: NodeJS.ProcessEnv | Record<string, string | undefined>
+  readonly argv?: string[]
+  readonly warn?: (message: string) => void
+  readonly readFile?: (path: string) => string
+  readonly readStdin?: () => string | Promise<string>
+}
+
+const SECRET_ARG_FLAGS = new Set(['--access-token', '--refresh-token'])
+
+export function redactOAuthTokenArgv(argv: string[] = process.argv): boolean {
+  let redacted = false
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i] ?? ''
+    if (SECRET_ARG_FLAGS.has(arg) && i + 1 < argv.length) {
+      argv[i + 1] = '[REDACTED]'
+      redacted = true
+    } else if (arg.startsWith('--access-token=')) {
+      argv[i] = '--access-token=[REDACTED]'
+      redacted = true
+    } else if (arg.startsWith('--refresh-token=')) {
+      argv[i] = '--refresh-token=[REDACTED]'
+      redacted = true
+    }
+  }
+  return redacted
+}
+
+function readEnv(
+  name: string | undefined,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): string | undefined {
+  if (!name) return undefined
+  const value = env[name]
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined
+}
+
+function readTokenFile(
+  filePath: string | undefined,
+  readFile: (path: string) => string,
+): string | undefined {
+  if (!filePath) return undefined
+  const value = readFile(filePath).trim()
+  return value.length > 0 ? value : undefined
+}
+
+async function readStdin(readStdin?: () => string | Promise<string>): Promise<string> {
+  if (readStdin) return readStdin()
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)))
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+function parseStdinCredentials(input: string): Partial<StoredCredentials> | { error: string } {
+  try {
+    const parsed = JSON.parse(input) as Partial<StoredCredentials>
+    const credentials: Partial<StoredCredentials> = {}
+    if (typeof parsed.accessToken === 'string') credentials.accessToken = parsed.accessToken
+    if (typeof parsed.refreshToken === 'string') credentials.refreshToken = parsed.refreshToken
+    return credentials
+  } catch {
+    return { error: 'OAuth token stdin input must be JSON with accessToken and refreshToken fields.' }
+  }
+}
+
+export async function resolveOAuthCredentials(
+  args: OAuthCredentialArgs,
+  opts: ResolveOAuthCredentialInputOptions = {},
+): Promise<StoredCredentials> {
+  const result = await resolveOAuthCredentialsFromArgs(args, opts)
+  if ('error' in result) throw new Error(result.error)
+  return result
+}
+
+export async function resolveOAuthCredentialsFromArgs(
+  args: OAuthCredentialArgs,
+  opts: ResolveOAuthCredentialInputOptions,
+): Promise<StoredCredentials | { error: string }> {
+  const env = opts.env ?? process.env
+  const readFile = opts.readFile ?? ((filePath: string) => fs.readFileSync(filePath, 'utf8'))
+  const usedArgSecret = typeof args.accessToken === 'string' || typeof args.refreshToken === 'string'
+  if (usedArgSecret && redactOAuthTokenArgv(opts.argv ?? process.argv)) {
+    opts.warn?.(
+      `[${opts.provider}] Warning: OAuth tokens passed as CLI flags may be visible in process listings. Prefer ${opts.defaultAccessTokenEnv}/${opts.defaultRefreshTokenEnv} or --access-token-env/--refresh-token-env.`,
+    )
+  }
+
+  const stdinCredentials = args.tokensStdin ? parseStdinCredentials(await readStdin(opts.readStdin)) : {}
+  if ('error' in stdinCredentials) return stdinCredentials
+
+  const accessToken =
+    stdinCredentials.accessToken ??
+    readTokenFile(args.accessTokenFile, readFile) ??
+    args.accessToken ??
+    readEnv(args.accessTokenEnv, env) ??
+    readEnv(opts.defaultAccessTokenEnv, env)
+  const refreshToken =
+    stdinCredentials.refreshToken ??
+    readTokenFile(args.refreshTokenFile, readFile) ??
+    args.refreshToken ??
+    readEnv(args.refreshTokenEnv, env) ??
+    readEnv(opts.defaultRefreshTokenEnv, env)
+
+  if (!accessToken || !refreshToken) {
+    return {
+      error: `OAuth access and refresh tokens are required. Prefer ${opts.defaultAccessTokenEnv ?? 'provider token env vars'}, --access-token-env/--refresh-token-env, --access-token-file/--refresh-token-file, or --tokens-stdin.`,
+    }
+  }
+
+  return { accessToken, refreshToken }
 }
 
 export async function runConfigureAction(input: ConfigureInput): Promise<ConfigureResult> {

--- a/packages/integrations/src/shared/cli-helpers.ts
+++ b/packages/integrations/src/shared/cli-helpers.ts
@@ -1,0 +1,77 @@
+import type { CredentialStore, StoredCredentials } from '../credentials.js'
+
+export interface ConfigureInput {
+  readonly provider: string
+  readonly organizationId: string
+  readonly userId: string
+  readonly credentials: StoredCredentials
+  readonly credentialStore: CredentialStore
+  readonly skipValidation: boolean
+}
+
+export interface ConfigureResult {
+  readonly configured: boolean
+  readonly provider: string
+  readonly error?: string
+}
+
+/**
+ * Masks secret-looking substrings before any error text leaves this package.
+ * Applied to BOTH success and failure paths so stderr/stdout cannot leak tokens
+ * even if a validator or underlying SDK embeds a token in its error message.
+ */
+export function sanitizeErrorMessage(msg: string): string {
+  return msg
+    .replace(/\b(ya29\.[A-Za-z0-9_-]+)/g, '***')
+    .replace(/\b(sk|rk|pk|whsec)_[A-Za-z0-9_]{10,}/g, '***')
+    .replace(/\b1\/\/[A-Za-z0-9_-]+/g, '***')
+    .replace(/\b(token|key|secret|password)=([^\s&"',;]+)/gi, '$1=***')
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+/gi, 'Bearer ***')
+}
+
+export async function runConfigureAction(input: ConfigureInput): Promise<ConfigureResult> {
+  if (!input.skipValidation) {
+    return {
+      configured: false,
+      provider: input.provider,
+      error: `Live validation is not supported in alpha. Pass --skip-validation to persist credentials without a probe.`,
+    }
+  }
+  try {
+    await input.credentialStore.saveCredentials(
+      input.organizationId,
+      input.provider,
+      input.userId,
+      input.credentials,
+    )
+    return { configured: true, provider: input.provider }
+  } catch (err) {
+    const raw = err instanceof Error ? err.message : String(err)
+    const safe = sanitizeErrorMessage(raw)
+    console.error(`[${input.provider}] configure: save failed — ${safe}`)
+    return { configured: false, provider: input.provider, error: safe }
+  }
+}
+
+export interface StatusInput {
+  readonly provider: string
+  readonly organizationId: string
+  readonly userId: string
+  readonly credentialStore: CredentialStore
+}
+
+export interface StatusResult {
+  readonly provider: string
+  readonly configured: boolean
+  readonly status: 'configured' | 'not_configured'
+}
+
+export async function runStatusAction(input: StatusInput): Promise<StatusResult> {
+  const creds = await input.credentialStore.getCredentials(
+    input.organizationId,
+    input.provider,
+    input.userId,
+  )
+  const configured = creds !== null
+  return { provider: input.provider, configured, status: configured ? 'configured' : 'not_configured' }
+}

--- a/packages/integrations/src/shared/cli-helpers.ts
+++ b/packages/integrations/src/shared/cli-helpers.ts
@@ -113,7 +113,7 @@ function parseStdinCredentials(input: string): Partial<StoredCredentials> | { er
     if (typeof parsed.accessToken === 'string') credentials.accessToken = parsed.accessToken
     if (typeof parsed.refreshToken === 'string') credentials.refreshToken = parsed.refreshToken
     return credentials
-  } catch {
+  } catch (_err) {
     return { error: 'OAuth token stdin input must be JSON with accessToken and refreshToken fields.' }
   }
 }

--- a/packages/integrations/src/types.ts
+++ b/packages/integrations/src/types.ts
@@ -1,4 +1,5 @@
 import type { ZodTypeAny } from 'zod'
+import type { CredentialStore } from './credentials.js'
 
 // ─── Plugin contract ───────────────────────────────────────────────────────────
 
@@ -67,4 +68,19 @@ export interface IntegrationResult<T> {
   data: T
   provider: string
   rawResponse?: unknown
+}
+
+// ─── CLI runtime ──────────────────────────────────────────────────────────────
+
+/**
+ * Runtime context passed to integration CLI command factories
+ * (buildGmailCommands, buildCalendarCommands).
+ */
+export interface CliRuntimeContext {
+  readonly organizationId: string
+  readonly userId: string
+  readonly credentialStore: CredentialStore
+  readonly isJsonMode: boolean
+  /** Print a response object. JSON mode emits JSON; otherwise human-readable with secrets masked. */
+  print(value: unknown): void
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@orbit-ai/core':
         specifier: workspace:*
         version: link:../core
+      '@orbit-ai/integrations':
+        specifier: workspace:*
+        version: link:../integrations
       '@orbit-ai/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -69,6 +72,9 @@ importers:
       commander:
         specifier: ^12.0.0
         version: 12.1.0
+      drizzle-orm:
+        specifier: ^0.44.5
+        version: 0.44.7(@types/pg@8.20.0)(pg@8.20.0)
       ink:
         specifier: ^5.0.0
         version: 5.2.1(@types/react@18.3.28)(react@18.3.1)


### PR DESCRIPTION
## Summary

Plan A.5 implementation: ships `orbit integrations gmail configure --skip-validation`, `orbit integrations gmail status`, and the same two commands for `google-calendar`. Unblocks release-definition-v2 §5.1 journeys 12–13.

- New `CliRuntimeContext` + subpath exports (`@orbit-ai/integrations/gmail`, `/google-calendar`)
- Real `TableBackedCredentialStore` (was a throwing stub) with AES-GCM encryption + `(org_id, provider, user_id)` UPSERT
- Action-time runtime resolver: builds adapter + credential store inside each Commander callback so flags merge correctly
- Nested-subcommand support in `registerIntegrationSubcommands` (`gmail/configure` → `orbit integrations gmail configure`)
- `orbit init --org-id` flag (prerequisite — direct-mode commands need a persisted org id)
- Schema extension applied at runtime via core's `runWithMigrationAuthority` (idempotent DDL)
- `MCP buildCalendarCommands` renamed to `buildCalendarMcpTools` to free the CLI name

## Stripe is deferred

Stripe is out of scope. Current connector uses env-backed config (`secretKeyEnv`, `webhookSecretEnv`); switching to credential-store storage is a product/API change (per-org vs per-env scoping, webhook rotation) that belongs in a separate proposal. Recommendation: a follow-up `orbit integrations stripe status` reading the env model, no `configure`. (`docs/decisions/2026-04-23-stripe-config-model.md` is local-only — `docs/*` is gitignored.)

## Tests

- Baseline: 1652 → **1682 passing** (+30)
- New tests: shared helpers (6), TableBackedCredentialStore (6 incl. cross-tenant), Gmail CLI (4), Calendar CLI (4), nested-subcommand (2), runtime resolver (5 incl. blank-orgId guard + recursive secret masking), init --org-id (3)

## Review fixes applied pre-PR

- Tenant safety MEDIUM: blank/whitespace `--org-id` no longer bypasses the required-config guard (same for userId).
- Code quality HIGH: `print()` now uses a recursive `sanitizeForPrint` in both JSON and human modes.
- Code quality HIGH: `isJsonMode` snapshotted once at runtime construction (no live/snapshot divergence).

## Smoke

```
$ orbit integrations gmail configure --access-token a --refresh-token r --skip-validation --json
{"configured":true,"provider":"gmail"}
$ orbit --json integrations gmail status
{"provider":"gmail","configured":true,"status":"configured"}
```

## Known follow-ups (NOT in this PR)

- `orbit init` global `--yes` shadows init-local `--yes` in the built bin (pre-existing flag collision; surfaced during smoke test).
- Stripe `status` command per the decision doc above.
- Live OAuth validation path for `configure` (alpha refuses without `--skip-validation`).

## Test plan

- [ ] CI: `pnpm -r build && pnpm -r typecheck && pnpm -r test && pnpm -r lint` all green
- [ ] Manual smoke: configure + status round-trip on SQLite (commands above)
- [ ] Verify cross-tenant isolation: `credentials.test.ts` covers org A save → org B get returns null

🤖 Generated with [Claude Code](https://claude.com/claude-code)