### PR TITLE
fix(release): harden Plan B publish readiness

### DIFF
--- a/.changeset/release-readiness-check.md
+++ b/.changeset/release-readiness-check.md
@@ -1,0 +1,7 @@
+---
+"@orbit-ai/cli": patch
+"@orbit-ai/demo-seed": patch
+"@orbit-ai/integrations": patch
+---
+
+Add missing npm metadata for the CLI, demo seed, and integrations packages, and harden the alpha publish workflow with package artifact verification.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Lint
         run: pnpm -r lint
 
+      - name: Test release workflow
+        run: pnpm test:release-workflow
+
       - name: Test
         run: pnpm -r test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Typecheck
         run: pnpm -r typecheck
 
+      - name: Test release workflow
+        run: pnpm test:release-workflow
+
       - name: Test
         run: pnpm -r test
 
@@ -233,7 +236,10 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: package-dist
-          path: .
+          path: packages
+
+      - name: Verify package artifacts
+        run: node scripts/verify-package-artifacts.mjs
 
       - name: Publish packages
         # Pinned from changesets/action v1.7.0.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -64,6 +64,9 @@ The dry run builds every package and runs `pnpm publish --dry-run` for each
 public `@orbit-ai/*` package with lifecycle scripts disabled, matching the
 credential-bearing publish step. CI builds in the read-only validation job and
 the publish job downloads those built artifacts before exposing npm credentials.
+The publish job also runs `pnpm release:verify-artifacts` before publishing to
+confirm each publishable package has its declared `main`, `types`, `exports`,
+and CLI `bin` files in `packages/*/dist`.
 Use the dry run to confirm the packages, versions, files, registry auth, and
 publish plan before merging the generated release PR. Running the dry run on
 `main` before the version PR merges checks the pre-versioned state, not the
@@ -105,6 +108,57 @@ emergency release.
 Manual publish should leave the repository in the same state as the automated
 workflow: versions and changelogs committed on `main`, npm packages published,
 and GitHub releases present.
+
+## Bad Publish Recovery
+
+Use this path when a publish already reached npm but the release is incomplete,
+broken, or has incorrect metadata. Prefer fix-forward releases over unpublish
+whenever users may already have installed the version.
+
+1. Stop further release attempts and record the affected package names,
+   versions, workflow run, npm publish output, and GitHub release links.
+2. Check the npm state for every fixed-group package:
+
+   ```bash
+   for package in api cli core demo-seed integrations mcp sdk; do
+     npm view "@orbit-ai/${package}" dist-tags versions --json
+   done
+   ```
+
+3. If only some packages published, do not manually publish the missing
+   packages until maintainers decide whether the package group can remain at
+   that version. Partial fixed-group releases should usually be replaced by a
+   new alpha for every public package.
+4. Prefer a fix-forward alpha when the version is public, the package contents
+   are installable enough for users to have consumed, or more than a few minutes
+   have passed. Land the fix, add a changeset, let the generated release PR bump
+   all fixed-group packages, and publish the replacement through the normal
+   workflow.
+5. Use `npm unpublish` only for a just-published alpha that is clearly unusable
+   and still within npm policy. Confirm no users or downstream automation have
+   consumed it first. If unpublish is used, remove or reconcile the matching
+   GitHub release and document why.
+6. If the bad version stays on npm, deprecate every affected package version:
+
+   ```bash
+   npm deprecate "@orbit-ai/api@0.1.0-alpha.N" "Bad alpha release; use 0.1.0-alpha.N+1."
+   ```
+
+   Repeat for each affected fixed-group package.
+7. Verify the `alpha` dist-tag points at the intended replacement version:
+
+   ```bash
+   npm dist-tag ls @orbit-ai/core
+   npm dist-tag add @orbit-ai/core@0.1.0-alpha.N+1 alpha
+   ```
+
+   Repeat only when a tag is wrong. Do not move `latest` during alpha.
+8. Reconcile GitHub Releases and changelogs. If the bad release remains visible,
+   edit the GitHub release notes to point users at the replacement. If it was
+   unpublished, delete or clearly mark the GitHub release as withdrawn.
+9. Open a follow-up issue or incident note with the cause, affected versions,
+   replacement version, npm dist-tag state, deprecation or unpublish actions,
+   and prevention work.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint": "turbo run lint",
     "release": "changeset publish --tag alpha",
     "release:dry-run": "pnpm -r build && node scripts/release-dry-run.mjs",
-    "test": "turbo run test",
+    "release:verify-artifacts": "node scripts/verify-package-artifacts.mjs",
+    "test:release-workflow": "node --test scripts/release-workflow.test.mjs",
+    "test": "pnpm test:release-workflow && turbo run test",
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,23 @@
   "description": "Terminal interface for Orbit AI CRM",
   "license": "MIT",
   "type": "module",
+  "keywords": [
+    "crm",
+    "ai-agents",
+    "orbit-ai",
+    "cli",
+    "typescript"
+  ],
+  "author": "Orbit AI Contributors",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sharonds/orbit-ai.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/sharonds/orbit-ai#readme",
+  "bugs": {
+    "url": "https://github.com/sharonds/orbit-ai/issues"
+  },
   "bin": {
     "orbit": "dist/index.js"
   },
@@ -17,6 +34,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "rm -rf dist && tsc && chmod +x dist/index.js",

--- a/packages/demo-seed/package.json
+++ b/packages/demo-seed/package.json
@@ -4,6 +4,23 @@
   "description": "Deterministic multi-tenant demo dataset for Orbit AI — designed to power E2E tests, starters, and demo content.",
   "license": "MIT",
   "type": "module",
+  "keywords": [
+    "crm",
+    "ai-agents",
+    "orbit-ai",
+    "demo-data",
+    "seed"
+  ],
+  "author": "Orbit AI Contributors",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sharonds/orbit-ai.git",
+    "directory": "packages/demo-seed"
+  },
+  "homepage": "https://github.com/sharonds/orbit-ai#readme",
+  "bugs": {
+    "url": "https://github.com/sharonds/orbit-ai/issues"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -3,6 +3,15 @@
   "version": "0.1.0-alpha.0",
   "description": "Integration connectors for Orbit AI CRM (Gmail, Google Calendar, Stripe)",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sharonds/orbit-ai.git",
+    "directory": "packages/integrations"
+  },
+  "homepage": "https://github.com/sharonds/orbit-ai#readme",
+  "bugs": {
+    "url": "https://github.com/sharonds/orbit-ai/issues"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const workflow = readFileSync(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8')
+
+test('publish job restores built package artifacts under packages/', () => {
+  assert.match(
+    workflow,
+    /name: Download built package artifacts[\s\S]*?with:\n\s+name: package-dist\n\s+path: packages\n/,
+  )
+})
+
+test('publish job verifies package entrypoints before publishing', () => {
+  const verifyIndex = workflow.indexOf('name: Verify package artifacts')
+  const publishIndex = workflow.indexOf('publish: pnpm release')
+
+  assert.ok(verifyIndex > -1, 'missing package artifact verification step')
+  assert.ok(publishIndex > -1, 'missing publish step')
+  assert.ok(verifyIndex < publishIndex, 'artifact verification must happen before publish')
+  assert.match(workflow, /run: node scripts\/verify-package-artifacts\.mjs/)
+})

--- a/scripts/verify-package-artifacts.mjs
+++ b/scripts/verify-package-artifacts.mjs
@@ -1,0 +1,76 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const packagesDir = join(process.cwd(), 'packages')
+const packageDirs = readdirSync(packagesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => join(packagesDir, entry.name))
+  .sort()
+
+const failures = []
+
+for (const dir of packageDirs) {
+  const manifestPath = join(dir, 'package.json')
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+
+  if (manifest.private || !manifest.name?.startsWith('@orbit-ai/')) {
+    continue
+  }
+
+  const requiredFiles = new Set()
+
+  if (manifest.main) {
+    requiredFiles.add(manifest.main)
+  }
+
+  if (manifest.types) {
+    requiredFiles.add(manifest.types)
+  }
+
+  for (const binPath of Object.values(manifest.bin ?? {})) {
+    requiredFiles.add(binPath)
+  }
+
+  collectExportFiles(manifest.exports, requiredFiles)
+
+  for (const file of requiredFiles) {
+    const normalized = file.replace(/^\.\//, '')
+    if (!existsSync(join(dir, normalized))) {
+      failures.push(`${manifest.name}: missing ${normalized}`)
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Package artifact verification failed:')
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log('Package artifact verification passed.')
+
+function collectExportFiles(value, requiredFiles) {
+  if (!value) {
+    return
+  }
+
+  if (typeof value === 'string') {
+    requiredFiles.add(value)
+    return
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectExportFiles(item, requiredFiles)
+    }
+    return
+  }
+
+  if (typeof value === 'object') {
+    for (const item of Object.values(value)) {
+      collectExportFiles(item, requiredFiles)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fix the Plan B publish artifact restore path and add a prepublish package artifact verifier.
- Wire release workflow regression tests into CI, release validation, and root `pnpm test`.
- Add bad-publish recovery docs and fill missing public package npm metadata.

Closes #56.
Closes #57.
Closes #58.

## Validation

- `pnpm test:release-workflow`
- `pnpm release:verify-artifacts`
- `pnpm release:dry-run`
- `pnpm -r build`
- `pnpm -r typecheck`
- `pnpm -r lint`
- `pnpm test`

## Reviews

- Release workflow correctness review: approved after fixes.
- Docs/package metadata review: approved after fixes.
- Security review: no findings in scoped release-pipeline changes.
