### PR TITLE
docs: align post-merge release readiness notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,16 @@ jobs:
       ORBIT_CREDENTIAL_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # Pinned from actions/checkout v4.3.1.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        # Pinned from pnpm/action-setup v4.4.0.
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        # Pinned from actions/setup-node v4.4.0.
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
@@ -123,11 +126,14 @@ jobs:
       ORBIT_E2E_ADAPTER: postgres
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # Pinned from actions/checkout v4.3.1.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        # Pinned from pnpm/action-setup v4.4.0.
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        # Pinned from actions/setup-node v4.4.0.
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -42,7 +42,7 @@ Pass `ORBIT_API_KEY` as an environment variable when starting the server. The se
 
 ```bash
 export ORBIT_API_KEY=orb_...
-export ORBIT_API_BASE_URL=https://api.yourapp.com
+export ORBIT_BASE_URL=https://api.yourapp.com
 ```
 
 Or set `apiKey` and `baseUrl` in `~/.config/orbit/config.json`.
@@ -55,26 +55,26 @@ No API key. Pass `adapter` and `context: { orgId }` directly. Only for trusted s
 
 ## Entity Inventory
 
-All entities share the same ID prefix convention (`cnt_`, `cmp_`, etc.) and support CRUD + cursor-based list pagination.
+All entities share the same ID prefix convention (`contact_`, `company_`, etc.) and support CRUD + cursor-based list pagination.
 
 | Entity | ID prefix | What it is |
 |---|---|---|
-| `contacts` | `cnt_` | People — leads, customers, prospects |
-| `companies` | `cmp_` | Organizations that contacts belong to |
+| `contacts` | `contact_` | People — leads, customers, prospects |
+| `companies` | `company_` | Organizations that contacts belong to |
 | `deals` | `deal_` | Sales opportunities moving through a pipeline |
-| `pipelines` | `pip_` | Named pipelines containing ordered stages |
-| `stages` | `stg_` | Stages within a pipeline (ordered by `position`) |
-| `users` | `usr_` | Team members with access to the org |
-| `activities` | `act_` | Logged interactions: calls, emails, meetings, notes |
-| `tasks` | `tsk_` | To-do items assigned to users |
-| `notes` | `nte_` | Free-text notes attached to any record |
-| `products` | `prd_` | Product or service catalog items |
-| `payments` | `pay_` | Payment records (often synced from Stripe) |
-| `contracts` | `ctr_` | Contract records |
-| `sequences` | `seq_` | Automated contact engagement sequences |
+| `pipelines` | `pipeline_` | Named pipelines containing ordered stages |
+| `stages` | `stage_` | Stages within a pipeline (ordered by `position`) |
+| `users` | `user_` | Team members with access to the org |
+| `activities` | `activity_` | Logged interactions: calls, emails, meetings, notes |
+| `tasks` | `task_` | To-do items assigned to users |
+| `notes` | `note_` | Free-text notes attached to any record |
+| `products` | `product_` | Product or service catalog items |
+| `payments` | `payment_` | Payment records (often synced from Stripe) |
+| `contracts` | `contract_` | Contract records |
+| `sequences` | `sequence_` | Automated contact engagement sequences |
 | `tags` | `tag_` | Labels attached to any record |
-| `webhooks` | `whk_` | Outbound webhook subscriptions |
-| `imports` | `imp_` | Bulk import jobs |
+| `webhooks` | `webhook_` | Outbound webhook subscriptions |
+| `imports` | `import_` | Bulk import jobs |
 
 ---
 
@@ -89,7 +89,7 @@ const contact = await client.contacts.create({
 })
 
 await client.activities.create({
-  contactId: contact.id,
+  contact_id: contact.id,
   type: 'email',
   subject: 'Introduction',
   body: 'Sent intro email.',
@@ -104,23 +104,23 @@ const pipelines = await client.pipelines.list()
 const stage = pipelines.data[0].stages.find(s => s.name === 'Proposal Sent')
 
 // 2. Update the deal
-await client.deals.update(dealId, { stageId: stage.id })
+await client.deals.update(dealId, { stage_id: stage.id })
 ```
 
 ### Move a deal via MCP
 
 ```
 Tool: move_deal_stage
-Args: { "deal_id": "deal_01JXXXX", "stage_id": "stg_01JXXXX" }
+Args: { "deal_id": "deal_01JXXXX", "stage_id": "stage_01JXXXX" }
 ```
 
 ### Add a custom field to contacts (SDK)
 
 ```typescript
-await client.schema.createCustomField('contacts', {
+await client.schema.addField('contacts', {
   name: 'linkedin_url',
   label: 'LinkedIn URL',
-  fieldType: 'text',
+  type: 'text',
 })
 ```
 
@@ -162,7 +162,7 @@ SDK wraps these as `OrbitApiError`:
 import { OrbitApiError } from '@orbit-ai/sdk'
 
 try {
-  await client.contacts.get('cnt_bad')
+  await client.contacts.get('contact_bad')
 } catch (err) {
   if (err instanceof OrbitApiError) {
     console.error(err.code)       // 'RESOURCE_NOT_FOUND'
@@ -198,5 +198,7 @@ packages/sdk/README.md           — client usage, DirectTransport, pagination
 packages/cli/README.md           — command reference, global flags, config file
 packages/mcp/README.md           — tool reference, server setup, transports
 packages/integrations/README.md  — Gmail, Calendar, Stripe setup guides
+packages/demo-seed/README.md     — deterministic demo data package
+e2e/README.md                    — launch-gate journey tests
 examples/nodejs-quickstart/      — runnable end-to-end example
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,14 @@
 
 ## Project
 
-Orbit AI — CRM infrastructure for AI agents and developers. TypeScript monorepo (Turborepo + pnpm). All 6 packages implemented: `@orbit-ai/core`, `@orbit-ai/api`, `@orbit-ai/sdk`, `@orbit-ai/cli`, `@orbit-ai/mcp`, `@orbit-ai/integrations`. 1,605 tests passing. Not yet published to npm.
+Orbit AI — CRM infrastructure for AI agents and developers. TypeScript monorepo (Turborepo + pnpm). All 7 public packages implemented: `@orbit-ai/core`, `@orbit-ai/api`, `@orbit-ai/sdk`, `@orbit-ai/cli`, `@orbit-ai/mcp`, `@orbit-ai/integrations`, `@orbit-ai/demo-seed`; `@orbit-ai/e2e` is a private launch-gate test package. 1,784 package tests passing. Not yet published to npm.
 
 ## Commands
 
 ```bash
 pnpm install              # Install all workspace dependencies
 pnpm -r build             # Build all packages (core must build first)
-pnpm -r test              # Run all tests (vitest) — expect 1145 passing
+pnpm -r test              # Run all package tests (vitest) — expect 1784 passing
 pnpm -r typecheck         # TypeScript type checking
 pnpm -r lint              # Lint all packages
 
@@ -28,6 +28,8 @@ packages/api/           # @orbit-ai/api — Hono REST API server
 packages/cli/           # @orbit-ai/cli — Terminal interface (Commander.js)
 packages/mcp/           # @orbit-ai/mcp — Model Context Protocol server
 packages/integrations/  # @orbit-ai/integrations — Gmail, Google Calendar, Stripe connectors
+packages/demo-seed/      # @orbit-ai/demo-seed — deterministic multi-tenant demo data
+e2e/                     # @orbit-ai/e2e — private launch-gate journey tests
 examples/               # nodejs-quickstart (runnable E2E smoke test)
 docs/                   # Strategy, specs, security, review artifacts, implementation plans
 ```
@@ -172,7 +174,7 @@ pnpm -r test        # must be ≥ current baseline (update baseline below after 
 pnpm -r lint
 ```
 
-**Test baseline**: 1744 tests (update this number after each merge to main)
+**Test baseline**: 1784 package tests (update this number after each merge to main)
 
 **Before any npm-publish branch**: verify `CHANGELOG.md` is updated and `files` field in each `package.json` is correct (`dist/`, `README.md`, `LICENSE` only).
 
@@ -214,7 +216,7 @@ When updating, keep sections concise. Prefer tables and numbered lists over pros
 ## Gotchas
 
 - This is NOT `smb-sale-crm-app` (the Next.js CRM app). This is the extracted infrastructure project.
-- All 5 packages (`core`, `api`, `sdk`, `cli`, `mcp`) are implemented but NOT yet published to npm.
+- All 7 public packages (`core`, `api`, `sdk`, `cli`, `mcp`, `integrations`, `demo-seed`) are implemented but NOT yet published to npm.
 - The `files` field in each package.json limits `pnpm pack` to `dist/`, `README.md`, `LICENSE`.
 - Core build script runs `rm -rf dist && tsc` to prevent stale test artifacts in tarballs.
 - SDK barrel does NOT export resource classes (ContactResource etc.) — only types. Consumers access resources via `client.contacts`, not by constructing classes.

--- a/README.md
+++ b/README.md
@@ -157,5 +157,5 @@ MIT — see [`LICENSE`](LICENSE).
 
 - **npm publish** — `0.1.0-alpha.1` will be the first public npm release. Until then, install from source: `pnpm install && pnpm -r build`.
 - **Hosted tier** — a managed Orbit AI API endpoint (beta) is planned alongside the npm release.
-- **E2E test suite** — cross-surface journey tests and multi-tenant denial tests are in progress.
+- **E2E test suite** — cross-surface launch-gate journeys now live in [`e2e/`](e2e); multi-tenant denial expansion remains a post-alpha follow-up.
 - **Documentation site** — a full docs site is planned post-publish.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,7 +16,7 @@ End-to-end journey tests for Orbit AI. This package is the publish gate for `0.1
 | 8 | Preview + apply a reversible migration | CLI (`migrate --preview`, `migrate --apply`) |
 | 9 | SDK in HTTP mode (auth, pagination, typed errors) | SDK HTTP |
 | 10 | SDK in direct-core mode (in-process, shared error semantics) | SDK direct |
-| 11 | MCP server + core tool flows | MCP JSON-RPC (search/create/update/delete) |
+| 11 | MCP server + core tool flows | MCP JSON-RPC (tool registration, search/create/get) |
 | 12 | Configure Gmail connector | CLI `integrations gmail configure/status` |
 | 13 | Configure Google Calendar connector | CLI `integrations google-calendar configure/status` |
 | 14 | Configure Stripe connector | CLI `integrations stripe configure/status` |

--- a/e2e/src/harness/build-stack.ts
+++ b/e2e/src/harness/build-stack.ts
@@ -86,11 +86,13 @@ export async function buildStack(opts: StackOptions): Promise<Stack> {
     })
     await adapter.migrate()
 
-    // Seed tenants
-    const acme = await seed(adapter, { profile: TENANT_PROFILES.acme })
+    // Postgres CI runs multiple journey files against the same safe local test
+    // database, so each stack build resets the deterministic demo tenants.
+    const postgresSeedOptions = { mode: 'reset' as const, allowResetOfExistingOrg: true }
+    const acme = await seed(adapter, { profile: TENANT_PROFILES.acme, ...postgresSeedOptions })
     const beta =
       opts.tenant === 'both' || opts.tenant === 'beta'
-        ? await seed(adapter, { profile: TENANT_PROFILES.beta })
+        ? await seed(adapter, { profile: TENANT_PROFILES.beta, ...postgresSeedOptions })
         : undefined
 
     // Insert test API key directly into the database

--- a/llms.txt
+++ b/llms.txt
@@ -13,13 +13,14 @@ Not yet published to npm. Alpha status. MIT license.
 - @orbit-ai/cli     — terminal interface, orbit <entity> <verb>, --mode api|direct
 - @orbit-ai/mcp     — Model Context Protocol server, 23 tools, stdio and HTTP transports
 - @orbit-ai/integrations — Gmail, Google Calendar, Stripe connectors with OAuth lifecycle
+- @orbit-ai/demo-seed — deterministic multi-tenant demo data for local tests and examples
 
 ## Entities
 
-contacts (cnt_), companies (cmp_), deals (deal_), pipelines (pip_), stages (stg_),
-users (usr_), activities (act_), tasks (tsk_), notes (nte_), products (prd_),
-payments (pay_), contracts (ctr_), sequences (seq_), tags (tag_),
-webhooks (whk_), imports (imp_)
+contacts (contact_), companies (company_), deals (deal_), pipelines (pipeline_),
+stages (stage_), users (user_), activities (activity_), tasks (task_),
+notes (note_), products (product_), payments (payment_), contracts (contract_),
+sequences (sequence_), tags (tag_), webhooks (webhook_), imports (import_)
 
 All entities: CRUD + cursor-based list pagination + orgId tenant scoping.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,7 +19,7 @@ Requires **Node.js 22+**.
 ```bash
 # API mode (default) — requires a running @orbit-ai/api server
 export ORBIT_API_KEY=your-key
-export ORBIT_API_BASE_URL=https://api.yourapp.com
+export ORBIT_BASE_URL=https://api.yourapp.com
 orbit contacts list
 
 # Direct mode — connects to a local database (no server required)
@@ -36,7 +36,7 @@ These flags apply to every command:
 | `--adapter <type>` | — | Storage adapter in direct mode: `sqlite` or `postgres` |
 | `--database-url <url>` | — | Database URL in direct mode (e.g. `./orbit.db` or a Postgres DSN) |
 | `--api-key <key>` | — | API key (prefer `ORBIT_API_KEY` env var) |
-| `--base-url <url>` | — | API base URL (prefer `ORBIT_API_BASE_URL` env var) |
+| `--base-url <url>` | — | API base URL (prefer `ORBIT_BASE_URL` env var) |
 | `--org-id <id>` | — | Organization ID override |
 | `--user-id <id>` | — | User ID override |
 | `--format <format>` | `table` | Output format: `table`, `json`, `csv`, `tsv` |
@@ -166,7 +166,7 @@ User config keys:
   "apiKeyEnv": "ORBIT_API_KEY",
   "baseUrl": "https://api.yourapp.com",
   "orgId": "org_01JXXXX",
-  "userId": "usr_01JXXXX",
+  "userId": "user_01JXXXX",
   "adapter": "sqlite",
   "databaseUrl": "./orbit.db",
   "orgName": "My Org",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -21,7 +21,7 @@ Requires **Node.js 22+**.
 Start the server in stdio mode via the CLI:
 
 ```bash
-ORBIT_API_KEY=your-key ORBIT_API_BASE_URL=https://api.yourapp.com orbit mcp serve
+ORBIT_API_KEY=your-key ORBIT_BASE_URL=https://api.yourapp.com orbit mcp serve
 ```
 
 Or start it programmatically in HTTP mode and point your MCP host at the HTTP endpoint (see HTTP transport below).
@@ -38,7 +38,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
       "args": ["mcp", "serve"],
       "env": {
         "ORBIT_API_KEY": "your-key-here",
-        "ORBIT_API_BASE_URL": "https://api.yourapp.com"
+        "ORBIT_BASE_URL": "https://api.yourapp.com"
       }
     }
   }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -24,7 +24,7 @@ import { OrbitClient } from '@orbit-ai/sdk'
 
 const client = new OrbitClient({
   apiKey: process.env.ORBIT_API_KEY!,
-  baseUrl: process.env.ORBIT_API_BASE_URL!, // e.g. https://api.yourapp.com
+  baseUrl: process.env.ORBIT_BASE_URL!, // e.g. https://api.yourapp.com
 })
 ```
 
@@ -142,13 +142,13 @@ const client = new OrbitClient({
 const contact = await client.contacts.create({ name: 'Test User' })
 ```
 
-## What's NOT in this release
+## What's NOT in the SDK package
 
-- CLI (`orbit` command) — planned as `@orbit-ai/cli`
-- MCP server tools — planned as `@orbit-ai/mcp`
-- Gmail / Google Calendar / Stripe integrations — planned as `@orbit-ai/integrations`
-- Real-time subscriptions / webhooks push — post-v1
-- Batch mutations — the API types exist but the implementation is not complete
+- CLI commands live in `@orbit-ai/cli`.
+- MCP server tools live in `@orbit-ai/mcp`.
+- Gmail, Google Calendar, and Stripe connectors live in `@orbit-ai/integrations`.
+- Real-time subscriptions / webhooks push — post-v1.
+- Batch mutations — the API types exist but the implementation is not complete.
 
 The full list of known alpha gaps is in
 [`docs/review/2026-04-08-post-stack-audit.md`](../../docs/review/2026-04-08-post-stack-audit.md).


### PR DESCRIPTION
## Summary
- Pin the E2E CI jobs to the same action SHAs used by the main verify job.
- Refresh post-merge docs after PRs #41/#43/#44/#48/#60: package counts, test baseline, ID prefixes, env var names, SDK package scope, and E2E status.
- Correct the E2E README's Journey 11 surface description to match the actual test.

## Review scope
- Reviewed the last merged PRs: #60, #48, #44, #43, and #41.
- Checked feature/docs drift against CHANGELOG, README, CLAUDE.md, AGENTS.MD, llms.txt, package READMEs, and e2e/README.md.
- Confirmed no remaining unpinned @v actions in .github/workflows.

## Validation
- pnpm test:release-workflow
- pnpm release:verify-artifacts
- pnpm -F @orbit-ai/e2e test
- pnpm -r lint
