### PR TITLE
ci: scope E2E and document security operations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,14 @@ updates:
       day: monday
       time: "09:00"
       timezone: Europe/Amsterdam
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     groups:
       development-dependencies:
         dependency-type: development
+        patterns:
+          - "@types/*"
+          - "typescript"
+          - "vitest"
 
   - package-ecosystem: github-actions
     directory: /
@@ -19,4 +23,4 @@ updates:
       day: monday
       time: "09:30"
       timezone: Europe/Amsterdam
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,13 +15,42 @@ jobs:
     name: Build, typecheck, lint, test
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      run_sqlite_e2e: ${{ steps.e2e-scope.outputs.run_sqlite_e2e }}
+      run_postgres_e2e: ${{ steps.e2e-scope.outputs.run_postgres_e2e }}
 
     steps:
       - name: Checkout
         # Pinned from actions/checkout v4.3.1.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Determine E2E scope
+        id: e2e-scope
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_sqlite_e2e=true" >> "$GITHUB_OUTPUT"
+            echo "run_postgres_e2e=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+          printf '%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -E '^(packages/(core|api|sdk|cli|mcp|integrations)/src/|e2e/|examples/nodejs-quickstart/)'; then
+            echo "run_sqlite_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_sqlite_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if printf '%s\n' "$changed_files" | grep -E '^(packages/(core|api|sdk)/src/|e2e/src/(harness|journeys/(02|03|04|05|06|07|08|09|10|11))/)'; then
+            echo "run_postgres_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_postgres_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
 
       # Changesets/action v1 opens its version PR from a same-repo branch named
       # `changeset-release/main`. Keep the repo+actor checks so fork branches
@@ -65,7 +95,7 @@ jobs:
         run: pnpm test:release-workflow
 
       - name: Test
-        run: pnpm -r test
+        run: pnpm -r --filter '!@orbit-ai/e2e' test
 
       - name: Run quickstart example (smoke)
         run: |
@@ -80,6 +110,7 @@ jobs:
     name: E2E launch journeys
     runs-on: ubuntu-latest
     needs: verify
+    if: ${{ needs.verify.outputs.run_sqlite_e2e == 'true' }}
     timeout-minutes: 20
     env:
       ORBIT_CREDENTIAL_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -112,6 +143,7 @@ jobs:
     name: E2E journeys (Postgres subset)
     runs-on: ubuntu-latest
     needs: verify
+    if: ${{ needs.verify.outputs.run_postgres_e2e == 'true' }}
     timeout-minutes: 25
     services:
       postgres:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         run: pnpm test:release-workflow
 
       - name: Test
-        run: pnpm -r test
+        run: pnpm -r --filter '!@orbit-ai/e2e' test
 
       - name: Lint
         run: pnpm -r lint

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,10 @@ validate the issue before any public disclosure.
 - Issues in packages not yet released (`@orbit-ai/cli`, `@orbit-ai/mcp`,
   `@orbit-ai/integrations`)
 
+Third-party dependency vulnerabilities are out of scope for external vulnerability
+reports, but they are still tracked internally through Dependabot, Socket, and
+release-readiness review.
+
 ## Security model (summary)
 
 Orbit AI uses a three-layer security model:

--- a/docs/security/security-operations.md
+++ b/docs/security/security-operations.md
@@ -1,0 +1,104 @@
+# Security Operations
+
+_Last updated: 2026-04-24_
+
+This document turns the security tooling recommendation into an operating policy
+for day-to-day PR review. The goal is to improve security without making every PR
+wait on every deep check.
+
+## PR Comment Handling
+
+Automated review comments from Copilot, Codex, CodeQL, Socket, Dependabot, or
+future tooling should be handled in one of four ways:
+
+1. **Fix now** when the comment identifies a real bug, broken link, invalid
+   example, dependency risk, or security issue.
+2. **Resolve with explanation** when the finding is correct but intentionally
+   accepted for alpha, tests, or local-only tooling.
+3. **Create follow-up issue** when the finding is valid but too large for the
+   current PR.
+4. **Dismiss as false positive** only with a short reason.
+
+Required conversation resolution is enabled on `main`, so unresolved review
+threads block merge.
+
+## Security Tools
+
+### Socket
+
+Use Socket as the first dependency and supply-chain security tool.
+
+Initial policy:
+
+- Install the Socket GitHub app for this public repository.
+- Start in non-blocking PR comment/check mode.
+- Block only high-confidence malware, compromised packages, severe supply-chain
+  risk, and unacceptable license findings after a short tuning period.
+- Do not treat every transitive advisory as merge-blocking until it is triaged.
+
+### GitHub CodeQL
+
+Use CodeQL as the first static-analysis tool.
+
+Initial policy:
+
+- GitHub CodeQL default setup was enabled on 2026-04-24 for GitHub Actions and
+  JavaScript/TypeScript using the default query suite.
+- Keep CodeQL non-required until the first alert batch is triaged.
+- Fix high-confidence security findings promptly.
+- Suppress false positives with a clear justification in GitHub code scanning.
+
+### CodeRabbit / Copilot Reviews
+
+Use AI PR review as review assistance, not as the primary security gate.
+
+Recommended policy:
+
+- Keep automated review comments enabled for documentation, examples, and code
+  quality feedback.
+- Do not rely on CodeRabbit or Copilot as a replacement for Socket, CodeQL, or
+  maintainer review.
+- Consider CodeRabbit later if external PR volume grows and we want broader PR
+  summarization and review assistance.
+
+## CI Triage Policy
+
+The required PR gate is `Build, typecheck, lint, test`. That job intentionally
+excludes the `@orbit-ai/e2e` package so E2E coverage is owned by explicit E2E
+jobs instead of running twice.
+
+Deep E2E runs are intentionally scoped:
+
+- Run all E2E on pushes to `main`.
+- Run all E2E when manually started through `workflow_dispatch`.
+- Run SQLite E2E automatically for source changes in core runtime surfaces.
+- Run Postgres E2E automatically for core/API/SDK or E2E harness changes.
+- Do not automatically run deep E2E for docs-only changes or dependency manifest
+  bumps unless the maintainer manually dispatches it.
+- Watch E2E jobs before merging high-risk PRs even when they are not branch
+  protection requirements.
+
+For risky dependency PRs, manually run E2E before merge when the dependency affects:
+
+- database behavior (`drizzle-orm`, `pg`)
+- HTTP/API behavior (`hono`)
+- auth/OAuth (`google-auth-library`)
+- payments (`stripe`)
+- CLI parsing/rendering (`commander`, `ink`)
+- runtime or build tooling used during publish
+
+## Dependabot Triage
+
+Triage order:
+
+1. Security advisories with active exploitability.
+2. Runtime dependencies used by published packages.
+3. GitHub Actions updates.
+4. Development dependency groups.
+
+Default handling:
+
+- Merge patch updates after required CI passes and changelog review.
+- Review major updates manually.
+- Keep security-sensitive packages in separate PRs.
+- Do not merge grouped dev dependency updates if they obscure the failing package.


### PR DESCRIPTION
## Summary
- split package tests from @orbit-ai/e2e so the required verify job no longer runs E2E twice
- run SQLite/Postgres E2E automatically for source changes, all pushes to main, and manual workflow dispatch
- reduce Dependabot PR fan-out and keep high-risk dependencies triaged manually
- add security operations policy for PR comments, Socket, CodeQL, CodeRabbit/Copilot, CI, and Dependabot
- clarify SECURITY.md dependency-vulnerability handling for internal Dependabot/Socket triage

## Security tooling
- Enabled GitHub CodeQL default setup for Actions and JavaScript/TypeScript with the default query suite. Setup run succeeded.
- Socket still requires installing the GitHub App; recommended as non-blocking at first.
- CodeRabbit/Copilot should remain advisory review help, not a primary security gate.

## Validation
- Parsed GitHub workflow and Dependabot YAML with Ruby YAML parser
- Checked markdown relative links in SECURITY.md and docs/security/*.md
- Ran pnpm install --frozen-lockfile after stale local node_modules surfaced
- Ran pnpm -r build
- Ran pnpm -r --filter '!@orbit-ai/e2e' test
- Ran ORBIT_CREDENTIAL_KEY=... pnpm -F @orbit-ai/e2e test

## Notes
- actionlint is not installed locally, so workflow validation used YAML parse plus GitHub PR CI.
- Postgres E2E was not run locally; CI should exercise it when scoped conditions require it.