### PR TITLE
docs: add reusable security resources

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,12 @@
+# Security Resources
+
+Reusable security guidance for Orbit AI and other open source or private projects.
+
+## Resources
+
+- [Open Source AI Security Blog Brief](open-source-ai-security-blog-brief.md) - outline for a public article about practical supply-chain security.
+- [Open Source Security Manifesto](open-source-security-manifesto.md) - cross-project philosophy and operating principles.
+- [Security Tools Playbook](security-tools-playbook.md) - recommended tools, where each one helps, and how to adopt them safely.
+- [Security Operations](security-operations.md) - Orbit AI-specific operational policies for PR comments, dependency updates, CI, CodeQL, Socket, and Dependabot.
+- [Security Tooling Recommendation](security-tooling-recommendation.md) - Orbit AI-specific comparison of Socket, CodeQL, CodeRabbit, and related tools.
+

--- a/docs/security/open-source-ai-security-blog-brief.md
+++ b/docs/security/open-source-ai-security-blog-brief.md
@@ -1,0 +1,138 @@
+# Open Source AI Security Blog Brief
+
+## Working Title
+
+Securing an Open Source AI Project: Practical Supply Chain Defenses That Do Not Slow You Down
+
+## Core Angle
+
+Open source AI projects move quickly and often depend on many packages, SDKs, CLIs, integrations, test runners, and automation tools. The right security posture is not to add every possible tool. The right posture is layered defense: prevent risky dependencies from entering too quickly, detect suspicious behavior, keep CI useful, and make security decisions transparent.
+
+## Audience
+
+- Open source maintainers
+- AI tool builders
+- TypeScript and Node.js maintainers
+- Small teams publishing public repositories
+- Teams that want the same posture for private internal projects
+
+## Thesis
+
+Security for open source AI projects should be layered:
+
+1. Protect the repository and default branch.
+2. Prevent risky dependency updates from landing too quickly.
+3. Detect malicious or suspicious packages.
+4. Keep CI strong without making it wasteful.
+5. Document tradeoffs publicly so contributors can trust the process.
+
+## Suggested Structure
+
+### 1. Why AI and Open Source Projects Need Extra Supply Chain Attention
+
+AI infrastructure projects often include SDKs, CLIs, MCP servers, API packages, examples, integrations, and test harnesses. That creates a broad dependency surface.
+
+The risk is not only known CVEs. It also includes:
+
+- malicious package releases
+- compromised maintainer accounts
+- risky install scripts
+- typosquatting and package confusion
+- unexpected transitive dependencies
+- noisy automation that maintainers stop trusting
+
+### 2. Start With GitHub Native Security
+
+Baseline controls should come first:
+
+- branch protection
+- required CI before merge
+- no force pushes or branch deletion
+- secret scanning and push protection
+- Dependabot alerts and security updates
+- CodeQL
+- CODEOWNERS where ownership is clear
+- `SECURITY.md`
+- private vulnerability reporting
+
+GitHub security controls protect the path to `main`. Everything else is weaker if the default branch is not protected.
+
+### 3. Add Socket For Dependency Behavior Risk
+
+Socket helps with a different class of risk than normal vulnerability scanning. It looks at package behavior and supply-chain signals.
+
+Useful signals include:
+
+- suspicious install scripts
+- malware-like behavior
+- package reputation changes
+- risky package capabilities
+- dependency confusion and typosquatting-style risk
+- newly introduced supply-chain behavior
+
+Recommended adoption:
+
+- install in non-blocking mode first
+- review signals for a few dependency PRs
+- only block high-confidence supply-chain or malware findings after tuning
+
+### 4. Use DepsGuard For Package Manager Hardening
+
+DepsGuard scans package-manager configuration and recommends safer defaults.
+
+Where it helps:
+
+- minimum release age for new packages
+- disabling install scripts where practical
+- stricter pnpm dependency build behavior
+- Dependabot or Renovate cooldowns
+- package manager hardening that reduces fast-burn supply-chain attacks
+
+Important caveat:
+
+Some protections depend on package-manager versions. For example, several pnpm protections require pnpm 10+. Run DepsGuard in read-only mode first, then apply only the settings that fit the project.
+
+### 5. Keep CI Strong But Not Wasteful
+
+Slow CI becomes ignored CI. The practical model is tiered validation:
+
+- every PR: build, typecheck, lint, unit tests
+- relevant PRs: scoped integration or E2E tests
+- `main` and release paths: full deep validation
+- manual workflow: full validation on demand
+
+Security improves when maintainers can get fast, meaningful feedback and still have deep coverage before release.
+
+### 6. Be Transparent About Dependency Decisions
+
+Do not silently close major dependency PRs. Explain why:
+
+- routine security patch
+- normal minor dependency update
+- major compatibility migration
+- risky toolchain change
+- false positive
+- deferred until a planned migration
+
+Public tracking issues make the process auditable.
+
+## Practical Checklist
+
+- Enable secret scanning and push protection.
+- Enable Dependabot alerts and security updates.
+- Enable CodeQL.
+- Add `SECURITY.md`.
+- Protect `main`.
+- Require build/typecheck/lint/test before merge.
+- Install Socket in non-blocking mode.
+- Run `depsguard scan` read-only.
+- Add Dependabot cooldowns if appropriate.
+- Use frozen lockfile installs in CI.
+- Use `--ignore-scripts` in CI where practical.
+- Pin GitHub Actions to commit SHAs where practical.
+- Track risky major upgrades in public issues.
+
+## Closing Point
+
+The best open source security posture is not one tool. It is a workflow: prevent risky installs, detect suspicious dependencies, keep CI trustworthy, and make every security decision visible to contributors.
+

--- a/docs/security/open-source-security-manifesto.md
+++ b/docs/security/open-source-security-manifesto.md
@@ -1,0 +1,222 @@
+# Open Source Security Manifesto
+
+Security for an open source project is not one tool, one badge, or one CI job. It is a layered operating model: reduce what can enter, inspect what does enter, make changes reviewable, and keep the process transparent enough that contributors can trust it.
+
+The goal is not maximum friction. The goal is secure velocity.
+
+## Principles
+
+### 1. Security Must Be Layered
+
+No single product catches everything. Use overlapping defenses:
+
+- GitHub native protections for repository control
+- CodeQL for code scanning
+- Dependabot for known vulnerable dependencies
+- Socket or similar tools for dependency behavior and supply-chain risk
+- DepsGuard or package-manager hardening for safer install defaults
+- human review for context
+
+Each layer should catch a different class of risk.
+
+### 2. Protect The Path To Main
+
+The most important security boundary is what can land in `main`.
+
+Every public repository should have:
+
+- protected default branch
+- required CI
+- no force pushes
+- no branch deletion
+- secret scanning and push protection
+- CODEOWNERS where useful
+- clear merge ownership
+- private vulnerability reporting where available
+
+If `main` is protected, mistakes are recoverable. If `main` is open, every other tool is weaker.
+
+### 3. Treat Dependencies As Code
+
+Dependencies are not passive metadata. They execute code, run install scripts, change transitive trees, and can affect production behavior.
+
+For every project:
+
+- review dependency PRs
+- avoid blind automerge for major updates
+- use lockfiles
+- use frozen installs in CI
+- prefer dependency cooldowns
+- watch for new maintainers, new install scripts, new binaries, and unusual package behavior
+
+Dependency updates are code review work.
+
+### 4. Delay Brand-New Packages When Possible
+
+Many supply-chain attacks depend on speed: a malicious package version is published, installed quickly, then removed later.
+
+Use tools and settings that delay brand-new versions:
+
+- Dependabot cooldowns
+- Renovate minimum release age
+- package-manager minimum release age where supported
+- DepsGuard as a scanner and checklist
+
+A short delay can block many fast-burn poisoned release attacks.
+
+### 5. Disable Install Scripts Where Practical
+
+Install scripts are powerful and risky.
+
+In CI:
+
+- use frozen lockfiles
+- use `--ignore-scripts` where possible
+- explicitly allow scripts only when needed
+
+This limits what dependencies can execute during install.
+
+### 6. Separate Security Patches From Migrations
+
+Not every dependency PR is equal.
+
+Classify updates:
+
+- patch security fix: fast path, focused review
+- minor update: normal review
+- major toolchain or framework update: planned migration
+- failed bot PR: investigate, document, defer or fix intentionally
+
+Do not bury TypeScript, React, test runner, package manager, and lockfile changes in one giant dependency update.
+
+### 7. Keep CI Strong But Not Wasteful
+
+Slow CI becomes ignored CI.
+
+Use tiered validation:
+
+- every PR: build, typecheck, lint, unit tests
+- relevant PRs: scoped integration or E2E tests
+- `main` and release paths: full deep test suite
+- manual workflow: full validation on demand
+
+Security improves when checks are fast enough that maintainers actually wait for them.
+
+### 8. Make Security Decisions Public
+
+Open source security requires trust.
+
+Use public artifacts:
+
+- `SECURITY.md`
+- issue trackers
+- PR comments
+- security operations docs
+- migration plans
+- clear explanations when closing Dependabot PRs
+
+If a major update is deferred, explain why. If a tool is advisory, say so. If a warning is a false positive, document the reason.
+
+### 9. Use Advisory Tools As Advisory Tools
+
+AI, code review, and security tools are useful, but they are not maintainers.
+
+Use tools like CodeRabbit, Copilot review, Socket, CodeQL, and Dependabot as signal sources. Human maintainers still decide:
+
+- severity
+- exploitability
+- user impact
+- compatibility risk
+- timing
+
+Do not let noisy tools become automatic blockers without tuning.
+
+### 10. Prefer Small, Reversible Changes
+
+Security work should be easy to audit.
+
+Prefer:
+
+- one setting per PR
+- one dependency class per PR
+- one migration phase per PR
+- clear rollback path
+- explicit validation checklist
+
+Small security PRs are safer than heroic rewrites.
+
+## Baseline Checklist
+
+### Repository
+
+- Add `SECURITY.md`.
+- Add a license.
+- Add CODEOWNERS if ownership is clear.
+- Enable private vulnerability reporting where available.
+- Protect `main`.
+- Require CI before merge.
+- Disable force pushes and branch deletion.
+
+### GitHub Security
+
+- Enable Dependabot alerts.
+- Enable Dependabot security updates.
+- Enable secret scanning.
+- Enable push protection.
+- Enable CodeQL.
+- Review branch protection after every major workflow change.
+
+### Dependencies
+
+- Keep lockfiles committed.
+- Use frozen installs in CI.
+- Avoid blind automerge.
+- Add Dependabot or Renovate cooldowns where practical.
+- Use Socket or an equivalent supply-chain scanner.
+- Run DepsGuard read-only and apply safe recommendations.
+- Defer risky major upgrades into public migration issues.
+
+### CI
+
+- Require build, typecheck, lint, and tests.
+- Scope E2E to risky paths on PRs.
+- Run full E2E on `main`.
+- Provide a manual full validation workflow.
+- Use minimal workflow permissions.
+- Pin GitHub Actions to commit SHAs where practical.
+
+### Release
+
+- Separate release PRs from feature PRs.
+- Verify generated release PR provenance.
+- Use npm provenance and OIDC where possible.
+- Protect publish tokens.
+- Do not expose publish credentials during build steps.
+- Document release rollback steps.
+
+### Community
+
+- Explain how to report vulnerabilities.
+- Label dependency and security issues clearly.
+- Document why bot PRs are closed or deferred.
+- Keep migration plans public.
+- Avoid security theater; explain tradeoffs plainly.
+
+## Operating Rule
+
+Every project should be able to answer:
+
+- Who can merge?
+- What must pass before merge?
+- How are secrets blocked?
+- How are dependency risks reviewed?
+- What happens when a security tool flags something?
+- What happens when a major dependency upgrade fails?
+- How does someone report a vulnerability privately?
+
+If those answers are written down and enforced in GitHub, the project has a real security posture.
+
+## One-Sentence Philosophy
+
+Secure open source is not about blocking every change; it is about making risky changes visible, reviewable, delayed when appropriate, tested at the right depth, and merged only through protected paths.
+

--- a/docs/security/security-tools-playbook.md
+++ b/docs/security/security-tools-playbook.md
@@ -1,0 +1,155 @@
+# Security Tools Playbook
+
+This playbook describes a practical security stack for open source and private projects. The tools are complementary: each covers a different class of risk.
+
+## Recommended Stack
+
+| Layer | Tooling | Purpose |
+| --- | --- | --- |
+| Repository control | GitHub branch protection, CODEOWNERS, required checks | Protect `main` and make merges reviewable |
+| Secret protection | GitHub secret scanning and push protection | Block accidental credential leaks |
+| Code scanning | CodeQL | Detect code-level security issues |
+| Known dependency vulnerabilities | Dependabot alerts and security updates | Track CVEs and vulnerable versions |
+| Dependency behavior | Socket | Detect risky package behavior and supply-chain signals |
+| Package-manager hardening | DepsGuard | Check safer install and update defaults |
+| Review support | CodeRabbit, Copilot review, human review | Advisory feedback and maintainability checks |
+| Release safety | Changesets, provenance, OIDC, publish-token isolation | Make releases auditable and reduce credential exposure |
+
+## GitHub Native Security
+
+Use GitHub's built-in protections as the baseline:
+
+- protected default branch
+- required CI
+- secret scanning
+- push protection
+- Dependabot alerts
+- Dependabot security updates
+- CodeQL
+- private vulnerability reporting
+
+These should be enabled before adding third-party tools.
+
+## Socket
+
+Socket helps with dependency behavior and supply-chain risk. It is useful because it can flag risks that normal CVE scanning may miss.
+
+Use Socket for:
+
+- suspicious install scripts
+- malware-like package behavior
+- risky package capabilities
+- package reputation changes
+- unexpected new dependency behavior
+- dependency confusion and typosquatting-style risk
+
+Recommended rollout:
+
+1. Install Socket in non-blocking mode.
+2. Watch a few dependency PRs.
+3. Tune noise before requiring it.
+4. Block only high-confidence malware, compromise, or severe supply-chain findings.
+
+Socket should complement Dependabot and CodeQL, not replace them.
+
+## DepsGuard
+
+DepsGuard scans package-manager configuration and recommends supply-chain hardening.
+
+It can help with:
+
+- minimum release age for new packages
+- disabled install scripts
+- stricter pnpm dependency builds
+- provenance downgrade protections where supported
+- Dependabot or Renovate cooldowns
+- package-manager-specific hardening across npm, pnpm, yarn, bun, and uv
+
+Recommended rollout:
+
+1. Run `depsguard scan` read-only.
+2. Separate repo-level findings from user-level findings.
+3. Apply low-risk repo settings first.
+4. Defer settings that require package-manager upgrades.
+
+Orbit AI scan result on 2026-04-24:
+
+- `depsguard` was not installed globally.
+- A verified temporary `depsguard` v0.1.33 macOS arm64 binary was used.
+- Result: 16 checks total, 4 missing files, 2 unset settings, 10 unsupported, 0 OK.
+- Most pnpm hardening settings are unsupported until pnpm 10+ because Orbit AI currently uses pnpm 9.12.3.
+- The most actionable repo-level finding was missing Dependabot cooldowns.
+
+## Dependabot
+
+Dependabot is useful for known vulnerable dependencies and routine updates, but it should be configured to reduce noise.
+
+Recommended settings:
+
+- group related updates carefully
+- limit open PR count
+- add cooldowns where appropriate
+- avoid auto-merging major updates
+- separate runtime dependencies from dev-toolchain migrations
+
+When closing a Dependabot PR, leave a comment explaining why.
+
+## CodeQL
+
+CodeQL should be enabled for code scanning. It is a good baseline for public repositories.
+
+Recommended rollout:
+
+1. Enable default setup.
+2. Let it run on a few PRs.
+3. Triage initial alerts.
+4. Consider making it required only after tuning and alert cleanup.
+
+## CodeRabbit And Copilot Review
+
+Use these as advisory tools, not as primary security gates.
+
+Good uses:
+
+- code quality feedback
+- maintainability suggestions
+- catching obvious mistakes
+- review assistance for public PRs
+
+Do not automatically block merges on every comment. Decide whether each finding is:
+
+- real issue to fix
+- false positive to dismiss with reason
+- follow-up issue
+- non-blocking suggestion
+
+## CI Security Defaults
+
+Recommended CI patterns:
+
+- use `pnpm install --frozen-lockfile`
+- use `--ignore-scripts` where practical
+- run required build/typecheck/lint/test on every PR
+- scope E2E tests by changed paths
+- run full E2E on `main`
+- use minimal workflow permissions
+- pin GitHub Actions to commit SHAs where practical
+- keep publish credentials out of build steps
+
+## Cross-Project Adoption Plan
+
+For any new project:
+
+1. Add `SECURITY.md`, license, and contribution guidance.
+2. Protect the default branch.
+3. Require CI.
+4. Enable GitHub secret scanning, push protection, Dependabot, and CodeQL.
+5. Install Socket in non-blocking mode.
+6. Run DepsGuard read-only.
+7. Add cooldowns and safe package-manager hardening.
+8. Document dependency triage rules.
+9. Track major toolchain upgrades in public issues.
+10. Review the setup quarterly.
+
+For private projects, keep the same model. The artifacts can live in internal docs instead of public issues, but the discipline is the same.
+


### PR DESCRIPTION
## Summary

Adds reusable security docs that can be copied into other open source or private projects:

- Security resources index
- Open source AI security blog brief
- Open source security manifesto
- Security tools playbook covering GitHub security, Socket, DepsGuard, Dependabot, CodeQL, CI, and release safety

## Validation

- Checked local Markdown relative links with a Ruby script

## Notes

This is documentation-only and does not change CI, runtime code, package manifests, or security settings.