### PR TITLE
docs: update test baseline to 1871 after PRs #91/#92

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,14 @@
 
 ## Project
 
-Orbit AI — CRM infrastructure for AI agents and developers. TypeScript monorepo (Turborepo + pnpm). All 8 public packages implemented: `@orbit-ai/core`, `@orbit-ai/api`, `@orbit-ai/sdk`, `@orbit-ai/cli`, `@orbit-ai/mcp`, `@orbit-ai/integrations`, `@orbit-ai/demo-seed`, `@orbit-ai/create-orbit-app`; `@orbit-ai/e2e` is a private launch-gate test package. 1,796 package tests passing. Not yet published to npm.
+Orbit AI — CRM infrastructure for AI agents and developers. TypeScript monorepo (Turborepo + pnpm). All 8 public packages implemented: `@orbit-ai/core`, `@orbit-ai/api`, `@orbit-ai/sdk`, `@orbit-ai/cli`, `@orbit-ai/mcp`, `@orbit-ai/integrations`, `@orbit-ai/demo-seed`, `@orbit-ai/create-orbit-app`; `@orbit-ai/e2e` is a private launch-gate test package. 1,871 package tests passing. Not yet published to npm.
 
 ## Commands
 
 ```bash
 pnpm install              # Install all workspace dependencies
 pnpm -r build             # Build all packages (core must build first)
-pnpm -r test              # Run all package tests (vitest) — expect 1796 passing
+pnpm -r test              # Run all package tests (vitest) — expect 1871 passing
 pnpm -r typecheck         # TypeScript type checking
 pnpm -r lint              # Lint all packages
 
@@ -175,7 +175,7 @@ pnpm -r test        # must be ≥ current baseline (update baseline below after 
 pnpm -r lint
 ```
 
-**Test baseline**: 1796 package tests (update this number after each merge to main)
+**Test baseline**: 1871 package tests (update this number after each merge to main)
 
 **Before any npm-publish branch**: verify `CHANGELOG.md` is updated and `files` field in each `package.json` is correct (`dist/`, `README.md`, `LICENSE` only).
 


### PR DESCRIPTION
## Summary
Refreshes the CLAUDE.md test baseline from 1796 to 1871 after the security-fix PRs merged.

- PR #91 added 2 integration tests (email-parsing helper, outbound-empty-to edge case).
- The rest of the +73 drift is from intermediate PRs landed since 1796 was last set; running \`pnpm -r test\` on \`main\` now reports 1871 passing across the 8 published packages (plus 23 e2e tests, counted separately).

## Test plan
- [x] \`pnpm -r test\` reports 1871 passing across packages
- [x] All three CLAUDE.md references (intro paragraph, Commands section, Pre-PR checklist) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)