### PR TITLE
chore: resolve moderate dependency advisories

### DIFF
--- a/.changeset/moderate-dependency-advisories.md
+++ b/.changeset/moderate-dependency-advisories.md
@@ -1,0 +1,16 @@
+---
+"@orbit-ai/api": patch
+"@orbit-ai/cli": patch
+"@orbit-ai/core": patch
+"@orbit-ai/create-orbit-app": patch
+"@orbit-ai/demo-seed": patch
+"@orbit-ai/integrations": patch
+"@orbit-ai/mcp": patch
+"@orbit-ai/sdk": patch
+---
+
+Resolve moderate dependency advisories by pinning patched transitive versions.
+
+- Override `uuid` to `^11.1.1` for GHSA-w5hq-g745-h8pq.
+- Override `qs` to `^6.15.2` for GHSA-q8mj-m7cp-5q26.
+- Override `ws` to `^8.20.1` and upgrade `turbo` to `^2.9.14` so `pnpm audit --audit-level moderate` is clean.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.31.0",
     "@types/node": "^24.6.0",
-    "turbo": "^2.5.6",
+    "turbo": "^2.9.14",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   },
@@ -30,8 +30,11 @@
       "fast-uri": "^3.1.2",
       "hono": "^4.12.18",
       "ip-address": "^10.1.1",
+      "qs": "^6.15.2",
+      "uuid": "^11.1.1",
       "vite": "^7.3.2",
-      "postcss": "^8.5.10"
+      "postcss": "^8.5.10",
+      "ws": "^8.20.1"
     }
   }
 }

--- a/packages/integrations/src/encryption.test.ts
+++ b/packages/integrations/src/encryption.test.ts
@@ -96,8 +96,9 @@ describe('AesGcmEncryptionProvider', () => {
     const provider = new AesGcmEncryptionProvider(VALID_KEY)
     const ciphertext = await provider.encrypt('sensitive-data')
     const parts = ciphertext.split(':')
-    // Flip first byte of data
-    const tamperedData = 'ff' + parts[1]!.slice(2)
+    const firstByte = Number.parseInt(parts[1]!.slice(0, 2), 16)
+    const tamperedFirstByte = (firstByte ^ 0xff).toString(16).padStart(2, '0')
+    const tamperedData = tamperedFirstByte + parts[1]!.slice(2)
     const tampered = [parts[0], tamperedData, parts[2]].join(':')
     await expect(provider.decrypt(tampered)).rejects.toThrow()
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,11 @@ overrides:
   fast-uri: ^3.1.2
   hono: ^4.12.18
   ip-address: ^10.1.1
+  qs: ^6.15.2
+  uuid: ^11.1.1
   vite: ^7.3.2
   postcss: ^8.5.10
+  ws: ^8.20.1
 
 importers:
 
@@ -25,8 +28,8 @@ importers:
         specifier: ^24.6.0
         version: 24.12.0
       turbo:
-        specifier: ^2.5.6
-        version: 2.9.1
+        specifier: ^2.9.14
+        version: 2.9.14
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -690,33 +693,33 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@turbo/darwin-64@2.9.1':
-    resolution: {integrity: sha512-d1zTcIf6VWT7cdfjhi0X36C2PRsUi2HdEwYzVgkLHmuuYtL+1Y1Zu3JdlouoB/NjG2vX3q4NnKLMNhDOEweoIg==}
+  '@turbo/darwin-64@2.9.14':
+    resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.1':
-    resolution: {integrity: sha512-AwJ4mA++Kpem33Lcov093hS1LrgqbKxqq5FCReoqsA8ayEG6eAJAo8ItDd9qQTdBiXxZH8GHCspLAMIe1t3Xyw==}
+  '@turbo/darwin-arm64@2.9.14':
+    resolution: {integrity: sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.1':
-    resolution: {integrity: sha512-HT9SjKkjEw9uvlgly/qwCGEm4wOXOwQPSPS+wkg+/O1Qan3F1uU/0PFYzxl3m4lfuV3CP9wr2Dq5dPrUX+B9Ag==}
+  '@turbo/linux-64@2.9.14':
+    resolution: {integrity: sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.1':
-    resolution: {integrity: sha512-+4s5GZs3kjxc1KMhLBhoQy4UBkXjOhgidA9ipNllkA4JLivSqUCuOgU1Xbyp6vzYrsqHJ9vvwo/2mXgEtD6ZHg==}
+  '@turbo/linux-arm64@2.9.14':
+    resolution: {integrity: sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.1':
-    resolution: {integrity: sha512-ZO7GCyQd5HV564XWHc9KysjanFfM3DmnWquyEByu+hQMq42g9OMU/fYOCfHS6Xj2aXkIg2FHJeRV+iAck2YrbQ==}
+  '@turbo/windows-64@2.9.14':
+    resolution: {integrity: sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.1':
-    resolution: {integrity: sha512-BjX2fdz38mBb/H94JXrD5cJ+mEq8NmsCbYdC42JzQebJ0X8EdNgyFoEhOydPGViOmaRmhhdZnPZKKn6wahSpcA==}
+  '@turbo/windows-arm64@2.9.14':
+    resolution: {integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==}
     cpu: [arm64]
     os: [win32]
 
@@ -1905,8 +1908,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -2170,8 +2173,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo@2.9.1:
-    resolution: {integrity: sha512-TO9du8MwLTAKoXcGezekh9cPJabJUb0+8KxtpMR6kXdRASrmJ8qXf2GkVbCREgzbMQakzfNcux9cZtxheDY4RQ==}
+  turbo@2.9.14:
+    resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
 
   type-fest@4.41.0:
@@ -2209,8 +2212,8 @@ packages:
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vary@1.1.2:
@@ -2321,8 +2324,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2756,22 +2759,22 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@turbo/darwin-64@2.9.1':
+  '@turbo/darwin-64@2.9.14':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.1':
+  '@turbo/darwin-arm64@2.9.14':
     optional: true
 
-  '@turbo/linux-64@2.9.1':
+  '@turbo/linux-64@2.9.14':
     optional: true
 
-  '@turbo/linux-arm64@2.9.1':
+  '@turbo/linux-arm64@2.9.14':
     optional: true
 
-  '@turbo/windows-64@2.9.1':
+  '@turbo/windows-64@2.9.14':
     optional: true
 
-  '@turbo/windows-arm64@2.9.1':
+  '@turbo/windows-arm64@2.9.14':
     optional: true
 
   '@types/chai@5.2.3':
@@ -2904,7 +2907,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -3168,7 +3171,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -3265,7 +3268,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -3369,9 +3372,9 @@ snapshots:
       extend: 3.0.2
       gaxios: 6.7.1
       google-auth-library: 9.15.1
-      qs: 6.15.1
+      qs: 6.15.2
       url-template: 2.0.8
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -3464,7 +3467,7 @@ snapshots:
       type-fest: 4.41.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
-      ws: 8.20.0
+      ws: 8.21.0
       yoga-layout: 3.2.1
     optionalDependencies:
       '@types/react': 18.3.28
@@ -3838,7 +3841,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -4131,14 +4134,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo@2.9.1:
+  turbo@2.9.14:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.1
-      '@turbo/darwin-arm64': 2.9.1
-      '@turbo/linux-64': 2.9.1
-      '@turbo/linux-arm64': 2.9.1
-      '@turbo/windows-64': 2.9.1
-      '@turbo/windows-arm64': 2.9.1
+      '@turbo/darwin-64': 2.9.14
+      '@turbo/darwin-arm64': 2.9.14
+      '@turbo/linux-64': 2.9.14
+      '@turbo/linux-arm64': 2.9.14
+      '@turbo/windows-64': 2.9.14
+      '@turbo/windows-arm64': 2.9.14
 
   type-fest@4.41.0: {}
 
@@ -4162,7 +4165,7 @@ snapshots:
 
   url-template@2.0.8: {}
 
-  uuid@9.0.1: {}
+  uuid@11.1.1: {}
 
   vary@1.1.2: {}
 
@@ -4272,7 +4275,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- Adds root pnpm overrides for patched transitive versions of `qs`, `uuid`, and `ws`.
- Updates root `turbo` to the patched `2.9.14` release.
- Regenerates `pnpm-lock.yaml` so Dependabot's current moderate `uuid`/`qs` alerts are resolved and `pnpm audit --audit-level moderate` is clean.

## Security Notes
- GitHub Dependabot open alerts checked before this PR:
  - `uuid` GHSA-w5hq-g745-h8pq, patched at 11.1.1
  - `qs` GHSA-q8mj-m7cp-5q26, patched at 6.15.2
- Local pnpm audit also flagged moderate advisories for `ws` and `turbo`; both are patched in this PR.

## Test Plan
- pnpm audit --audit-level moderate
- pnpm -r build
- pnpm -F @orbit-ai/cli test
- pnpm -F @orbit-ai/integrations test
- pnpm -F @orbit-ai/e2e test -- src/journeys/12-integrations-gmail.test.ts src/journeys/13-integrations-calendar.test.ts src/journeys/14-integrations-stripe.test.ts src/journeys/11-mcp-core-tools.test.ts

Note: the first parallel package test attempt ran before build completed and failed on missing local dist resolution. After `pnpm -r build` completed, the same package/E2E checks passed.