### PR TITLE
docs: schema migration hardening semantics (closes #103)

### DIFF
--- a/.changeset/schema-migration-hardening-docs.md
+++ b/.changeset/schema-migration-hardening-docs.md
@@ -1,0 +1,8 @@
+---
+"@orbit-ai/api": patch
+"@orbit-ai/cli": patch
+"@orbit-ai/core": patch
+"@orbit-ai/sdk": patch
+---
+
+Document schema migration hardening semantics in package READMEs: time-bound destructive confirmations, supported custom-field migration targets, SQL field redaction, and Postgres connection pool requirements for migration applies.

--- a/docs/security/database-hardening-checklist.md
+++ b/docs/security/database-hardening-checklist.md
@@ -86,6 +86,14 @@ Use this checklist before exposing a new table, route, connector, or environment
 - [ ] runtime app credentials cannot run schema migrations
 - [ ] destructive migrations cannot run silently in production
 
+### 4.4 Schema Migration Hardening Requirements
+
+- [x] Custom-field migration operations may target only entities with custom field value storage. Public-but-non-extensible objects such as pipelines, stages, tags, and users must be rejected before migration authority executes.
+- [x] Metadata-changing migration DML must fail closed when the expected custom field metadata row is not affected. Entity value cleanup may affect zero rows; metadata delete/rename must affect exactly one row.
+- [x] Destructive migration confirmations are checksum-bound and time-bound. A confirmation is valid for 15 minutes from `confirmedAt`, with at most 60 seconds of future clock skew.
+- [x] Public schema migration outputs must not expose raw generated SQL fields, including `sqlStatements`, `rollbackStatements`, `sql_statements`, or `rollback_statements`.
+- [x] Idempotency-keyed applies are serialized by a dedicated migration lock keyed on a SHA-256 digest of the idempotency key; lock conflict details never expose raw key material.
+
 ## 5. API Key Storage and Access
 
 ### 5.1 Required

--- a/docs/testing/security-e2e-matrix.md
+++ b/docs/testing/security-e2e-matrix.md
@@ -25,7 +25,7 @@ journeys cannot cross tenant, scope, credential, or transport boundaries.
 | Webhook SSRF | API route rejects private targets | Prove webhook create rejects localhost, loopback, link-local metadata, private IPs, and IPv4-mapped loopback | `e2e/src/security/webhook-ssrf.test.ts` |
 | SQLite tenant warning | Docs warn SQLite has no RLS | Business docs must not present SQLite as multi-tenant production-safe | Docs review checklist |
 | Postgres RLS | Current e2e does not prove restricted-role RLS | Deferred unless a restricted-role Postgres harness exists | Follow-up plan |
-| Migration safety | Journey 8 is stub passthrough only | Deferred to Plan C.5; do not claim destructive migration safety until real engine lands | Existing Plan C.5 |
+| Migration safety | Journey 8 covers destructive custom-field delete preview/apply and MCP exclusion; Journey 16 covers custom-field rename apply | Add restricted-role Postgres/RLS proof when harness exists | `e2e/src/journeys/08-migration-preview-apply.test.ts`, `e2e/src/journeys/16-custom-field-rename.test.ts`, `packages/core/src/schema-engine/engine.test.ts`, `packages/api/src/__tests__/routes-wave2.test.ts`, `packages/sdk/src/__tests__/direct-transport.test.ts`, `packages/cli/src/__tests__/destructive-actions.test.ts`, `packages/mcp/src/__tests__/schema-tools.test.ts` |
 
 ## High-Risk Abuse Stories
 
@@ -130,6 +130,17 @@ MCP stdio wire coverage remains deferred because `packages/mcp/package.json` has
 no `bin` entry and `packages/cli/src/commands/mcp.ts` still throws
 `DEPENDENCY_NOT_AVAILABLE` for `orbit mcp serve`. Restricted-role Postgres/RLS
 proof remains outside this SQLite-only gate.
+
+## Schema Migration Hardening Update
+
+**2026-06-10 update:** Schema migration safety coverage now includes invalid
+custom-field migration target rejection, metadata row-count failure handling,
+time-bound destructive confirmations, SQL field redaction across
+API/SDK/CLI/MCP output boundaries (including CLI global API-error envelopes),
+migration apply idempotency rechecks inside the lock, and cross-target
+idempotency-key lock serialization. Journey 16 rollback execution proof and
+restricted-role Postgres/RLS proof remain deferred (rollback proof tracked in
+#105).
 
 ## MCP Agent Q&A Update
 

--- a/llms.txt
+++ b/llms.txt
@@ -45,9 +45,12 @@ Schema migration surfaces: API POST /v1/schema/migrations/preview, POST
 client.schema.previewMigration/applyMigration/rollbackMigration; CLI orbit
 migrate --preview|--apply --operations <json>, orbit migrate --rollback --id
 <migration-id> --checksum <checksum> --yes. Destructive confirmations are
-checksum-bound. Apply returns rollbackable and rollbackDecision. custom_field.delete
-is executable but non-rollbackable unless future value snapshots exist;
-custom_field.rename is rollbackable.
+checksum-bound and time-bound: confirmations expire 15 minutes after confirmedAt
+and are rejected if confirmedAt is more than 60 seconds in the future. Apply
+returns rollbackable and rollbackDecision. custom_field.delete is executable but
+non-rollbackable unless future value snapshots exist; custom_field.rename is
+rollbackable. Custom-field migration operations are limited to entities with
+custom field value storage.
 
 ## API Error Codes
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -147,6 +147,10 @@ environments. When `destructiveMigrationEnvironment` is `staging` or
 `confirmation.safeguards`: environment acknowledgement, backup or snapshot
 evidence, ledger evidence, and a rollback or non-rollbackable decision.
 
+Destructive schema migration operations require `schema:apply` and a confirmation object whose checksum matches the current migration checksum. Confirmations expire 15 minutes after `confirmedAt` and are rejected if they are more than 60 seconds in the future. Public migration responses do not include raw SQL statement fields.
+
+Custom-field migration operations are limited to entities that store custom field values. Public objects without custom field value storage, including pipelines, stages, tags, and users, reject custom-field add, update, rename, delete, and promote operations before migration authority executes.
+
 Errors follow:
 
 ```json

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -90,6 +90,16 @@ environments (`ORBIT_DESTRUCTIVE_MIGRATION_ENVIRONMENT=staging` or
 environment acknowledgement, backup or snapshot evidence, ledger evidence, and a
 rollback or non-rollbackable decision.
 
+CLI JSON output redacts raw SQL statement fields from migration previews,
+applies, rollbacks, and destructive-confirmation errors — including API error
+envelopes.
+
+Custom-field migration commands are limited to entities with custom field value
+storage. Pipelines, stages, tags, and users do not support custom-field
+migration operations.
+
+On Postgres, a migration apply through DirectTransport can hold up to three concurrent connections (tenant-context transaction, advisory-lock transaction, ledger write) — four when an idempotency key is supplied, since idempotency-keyed applies take an additional advisory-lock transaction. Configure the connection pool with `max: 4` or higher when running migrations.
+
 ### CRM Entities
 
 All entity commands follow the same pattern: `orbit <entity> <verb> [args]`

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -100,6 +100,11 @@ evidence in `confirmation.safeguards` before elevated execution.
 `custom_field.delete` apply is executable but non-rollbackable unless future
 value snapshots exist; `custom_field.rename` is rollbackable.
 
+Destructive confirmations are checksum-bound and time-bound: confirmations expire
+15 minutes after `confirmedAt` and are rejected if `confirmedAt` is more than 60
+seconds in the future. Custom-field migration operations are limited to entities
+with custom field value storage.
+
 Migration execution requires an explicit `SchemaMigrationAuthority` when services
 are created. Request/runtime adapters expose normal data access; elevated DDL
 access is only entered through that authority and only for apply/rollback paths.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -164,6 +164,12 @@ or `production`, core also requires `confirmation.safeguards` with environment
 acknowledgement, backup or snapshot evidence, ledger evidence, and a rollback or
 non-rollbackable decision before elevated execution.
 
+`schema.rollbackMigration()` validates the checksum for the stored reverse operations, not the original apply checksum. Compute or read the rollback checksum before sending confirmation. DirectTransport applies the same schema migration redaction as the HTTP API and does not expose raw SQL statement fields.
+
+Custom-field migration helpers follow the core migration target contract: only entities with custom field value storage can be migrated. Public objects without value storage, such as pipelines, stages, tags, and users, reject custom-field migration operations.
+
+On Postgres, a migration apply through DirectTransport can hold up to three concurrent connections (tenant-context transaction, advisory-lock transaction, ledger write) — four when an idempotency key is supplied, since idempotency-keyed applies take an additional advisory-lock transaction. Configure the connection pool with `max: 4` or higher when running migrations.
+
 ## Direct-core transport (server-side / tests)
 
 > **@security** DirectTransport bypasses HTTP, auth middleware, rate limiting,


### PR DESCRIPTION
## Summary

Docs-only PR documenting schema migration hardening behavior that is already merged on main (PR #84 + PR #111). Every statement was verified against the code in this branch (`destructive-confirmation.ts` TTL constants, `EXTENSIBLE_ENTITY_TABLES`, `schema-engine/redaction.ts`, `idempotencyLockTarget`, `assertMetadataRowAffected`).

- **docs/security/database-hardening-checklist.md** — new section 4.4 "Schema Migration Hardening Requirements": extensible-entity-only migration targets, fail-closed metadata row-count DML, checksum- and time-bound destructive confirmations (15-minute TTL, 60s future skew), SQL statement field redaction, SHA-256-digest idempotency-key lock.
- **llms.txt** — schema migration paragraph now states confirmations are checksum-bound and time-bound (15-minute expiry, 60s future skew) and that custom-field migration operations are limited to entities with custom field value storage.
- **packages/core/README.md** — confirmation expiry/skew and supported custom-field migration targets.
- **packages/api/README.md** — destructive apply requirements (scope, checksum echo, expiry/skew, no raw SQL in responses) and rejection of custom-field operations on non-extensible objects (pipelines, stages, tags, users).
- **packages/sdk/README.md** — rollback checksum semantics, DirectTransport redaction parity, supported migration targets, and the Postgres connection pool requirement (`max: 4` or higher; idempotency-keyed applies take an additional advisory-lock connection). Closes #103.
- **packages/cli/README.md** — CLI JSON SQL-field redaction (including API error envelopes), supported migration targets, and the same Postgres pool note.
- **docs/testing/security-e2e-matrix.md** — Migration safety row updated to reflect Journey 8 + Journey 16 coverage, plus a "Schema Migration Hardening Update" section.
- **.changeset/schema-migration-hardening-docs.md** — patch changeset for api/cli/core/sdk README updates.

## Deliberately deferred (not documented)

- **CLI skip-preview behavior**: the planned claim that `orbit fields update` skips migration preview for safe metadata (label/description) updates is unimplemented — today the CLI always previews first. Deferred to hardening PR 2b.
- **Journey 16 rollback execution proof**: Journey 16 currently covers rename apply and asserts rollbackability metadata only; rollback execution proof is tracked in #105.

Closes #103

## Test plan

- `corepack pnpm test:doc-hygiene` — passes
- `corepack pnpm -r lint` — passes (exit 0)
- `git diff --check` — clean
- Verified every referenced test file path in the matrix row exists on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)